### PR TITLE
Add copy code button

### DIFF
--- a/R/block-class.R
+++ b/R/block-class.R
@@ -49,7 +49,7 @@ new_block <- function(server, ui, class, ctor, ctor_pkg, dat_valid = NULL,
     } else {
 
       if (missing(ctor_pkg)) {
-        ctor_pkg <- utils::packageName(environment(fun))
+        ctor_pkg <- pkg_name(environment(fun))
       }
 
       if (not_null(ctor_pkg)) {
@@ -330,7 +330,7 @@ as.list.block <- function(x, state = NULL, ...) {
     payload = state,
     constructor = attr(x, "ctor"),
     package = pkg,
-    version = as.character(utils::packageVersion(pkg))
+    version = as.character(pkg_version(pkg))
   )
 }
 

--- a/R/json.R
+++ b/R/json.R
@@ -49,7 +49,7 @@ blockr_ser.board <- function(x, blocks = NULL, ...) {
     object = class(x),
     blocks = blockr_ser(board_blocks(x), blocks),
     links = lapply(board_links(x), blockr_ser),
-    version = as.character(utils::packageVersion(utils::packageName()))
+    version = as.character(pkg_version())
   )
 }
 

--- a/R/pkg.R
+++ b/R/pkg.R
@@ -5,3 +5,15 @@
 #' @importFrom rlang abort warn inform
 #' @import shiny
 NULL
+
+pkg_name <- function(env = parent.frame()) {
+  utils::packageName(env)
+}
+
+pkg_version <- function(pkg = pkg_name()) {
+  utils::packageVersion(pkg)
+}
+
+pkg_file <- function(...) {
+  system.file(..., package = pkg_name())
+}

--- a/R/plugin-code.R
+++ b/R/plugin-code.R
@@ -24,28 +24,20 @@ gen_code_server <- function(id, rv, ...) {
         {
           output$code_out <- renderPrint(HTML(code()))
 
+          id <- "code_out"
+
           showModal(
             modalDialog(
               title = "Generated code",
               div(
                 class = "text-decoration-none position-relative",
-                copy_to_clipboard(session),
-                verbatimTextOutput(session$ns("code_out"))
+                copy_to_clipboard(session, id),
+                verbatimTextOutput(session$ns(id))
               ),
               easyClose = TRUE,
               footer = NULL,
               size = "l"
             )
-          )
-        }
-      )
-
-      observeEvent(
-        input$copy_code,
-        {
-          session$sendCustomMessage(
-            "blockr-copy-code",
-            list(code = code())
           )
         }
       )
@@ -68,7 +60,7 @@ gen_code_ui <- function(id, board) {
   )
 }
 
-copy_to_clipboard <- function(session) {
+copy_to_clipboard <- function(session, id) {
 
   deps <- htmltools::htmlDependency(
     "copy-to-clipboard",
@@ -80,11 +72,13 @@ copy_to_clipboard <- function(session) {
   tagList(
     actionButton(
       session$ns("copy_code"),
+      "",
       class = paste(
         "btn", "btn-outline-secondary", "btn-sm", "position-absolute",
         "top-0", "end-0", "m-2"
       ),
-      icon("clipboard", c("fa-solid", "fa-2x"))
+      icon = icon("copy", c("fa-solid", "fa-2x")),
+      onclick = paste0("copyCode(\"", session$ns(id), "\");")
     ),
     deps
   )

--- a/R/plugin-code.R
+++ b/R/plugin-code.R
@@ -15,22 +15,41 @@ gen_code_server <- function(id, rv, ...) {
     id,
     function(input, output, session) {
 
+      code <- reactive(
+        generate_code(rv)
+      )
+
       observeEvent(
-        input$code,
+        input$code_mod,
         {
-          output$code <- renderPrint(HTML(generate_code(rv)))
+          output$code_out <- renderPrint(HTML(code()))
 
           showModal(
             modalDialog(
               title = "Generated code",
               div(
                 class = "text-decoration-none",
-                verbatimTextOutput(session$ns("code"))
+                actionButton(
+                  session$ns("copy_code"),
+                  class = "btn-sm btn-info position-absolute top-0 end-0",
+                  icon("clipboard")
+                ),
+                verbatimTextOutput(session$ns("code_out"))
               ),
               easyClose = TRUE,
               footer = NULL,
               size = "l"
             )
+          )
+        }
+      )
+
+      observeEvent(
+        input$copy_code,
+        {
+          session$sendCustomMessage(
+            "blockr-copy-code",
+            list(code = code())
           )
         }
       )
@@ -46,10 +65,29 @@ gen_code_server <- function(id, rv, ...) {
 gen_code_ui <- function(id, board) {
   tagList(
     actionButton(
-      NS(id, "code"),
+      NS(id, "code_mod"),
       "Show code",
       icon = icon("code")
     )
+  )
+}
+
+copy_to_clipboard <- function() {
+
+  deps <- htmltools::htmlDependency(
+    "copy-to-clipboard",
+    pkg_version(),
+    src = pkg_file("assets", "js"),
+    script = "copyToClipboard.js"
+  )
+
+  tagList(
+    actionButton(
+      session$ns("copy_code"),
+      class = "btn-sm btn-info position-absolute top-0 end-0",
+      icon("code")
+    ),
+    deps
   )
 }
 

--- a/R/plugin-code.R
+++ b/R/plugin-code.R
@@ -29,11 +29,7 @@ gen_code_server <- function(id, rv, ...) {
               title = "Generated code",
               div(
                 class = "text-decoration-none",
-                actionButton(
-                  session$ns("copy_code"),
-                  class = "btn-sm btn-info position-absolute top-0 end-0",
-                  icon("clipboard")
-                ),
+                copy_to_clipboard(session),
                 verbatimTextOutput(session$ns("code_out"))
               ),
               easyClose = TRUE,
@@ -72,7 +68,7 @@ gen_code_ui <- function(id, board) {
   )
 }
 
-copy_to_clipboard <- function() {
+copy_to_clipboard <- function(session) {
 
   deps <- htmltools::htmlDependency(
     "copy-to-clipboard",

--- a/R/plugin-code.R
+++ b/R/plugin-code.R
@@ -28,7 +28,7 @@ gen_code_server <- function(id, rv, ...) {
             modalDialog(
               title = "Generated code",
               div(
-                class = "text-decoration-none",
+                class = "text-decoration-none position-relative",
                 copy_to_clipboard(session),
                 verbatimTextOutput(session$ns("code_out"))
               ),
@@ -80,8 +80,11 @@ copy_to_clipboard <- function(session) {
   tagList(
     actionButton(
       session$ns("copy_code"),
-      class = "btn-sm btn-info position-absolute top-0 end-0",
-      icon("code")
+      class = paste(
+        "btn", "btn-outline-secondary", "btn-sm", "position-absolute",
+        "top-0", "end-0", "m-2"
+      ),
+      icon("clipboard", c("fa-solid", "fa-2x"))
     ),
     deps
   )

--- a/R/registry.R
+++ b/R/registry.R
@@ -19,7 +19,7 @@ register_block <- function(ctor, name, description, classes = NULL, uid = NULL,
                            overwrite = FALSE) {
 
   if (is.function(ctor)) {
-    package <- utils::packageName(environment(ctor))
+    package <- pkg_name(environment(ctor))
   }
 
   ctor_name <- NULL
@@ -179,7 +179,7 @@ register_core_blocks <- function(which = get_option("blocks", "all")) {
       "data",
       "transform"
     )[blocks],
-    package = utils::packageName(),
+    package = pkg_name(),
     overwrite = TRUE
   )
 }

--- a/R/utils-shiny.R
+++ b/R/utils-shiny.R
@@ -28,8 +28,8 @@ slow_text_input <- function(..., debounce = 1000) {
 
   binding <- htmltools::htmlDependency(
     "slow-text-binding",
-    utils::packageVersion(utils::packageName()),
-    src = system.file("assets/js", package = "blockr.core"),
+    pkg_version(),
+    src = pkg_file("assets", "js"),
     script = "slowTextInputBinding.js"
   )
 

--- a/inst/assets/js/copyToClipboard.js
+++ b/inst/assets/js/copyToClipboard.js
@@ -1,36 +1,24 @@
-function copyText(text) {
-  if (typeof ClipboardItem && navigator.clipboard.write) {
-    const data = new ClipboardItem({
-      "text/plain": new Promise(async (resolve) => {
-        resolve(new Blob([text], { type: "text/plain" }))
-      })
-    })
-    navigator.clipboard.write([data]);
-  } else {
-    navigator.clipboard.writeText(text);
-  }
-}
+function copyCode(id) {
 
-window.Shiny.addCustomMessageHandler("blockr-copy-code", (msg) => {
+  var range = document.createRange();
+  range.selectNode(document.getElementById(id));
 
-  if (!msg.code) {
-    window.Shiny.notifications.show({
-      html: "<span>No code found to copy.</span>",
-      type: "error",
-    });
-    return;
-  }
+  window.getSelection().removeAllRanges();
+  window.getSelection().addRange(range);
 
   try {
-    copyText(msg.code.trim());
+    var successful = document.execCommand("copy");
+    var msg = successful ? "successful" : "unsuccessful";
     window.Shiny.notifications.show({
-      html: "<span>Code successfully copied to clipboard.</span>",
-      type: "message",
+      html: "<span>Copying code command was " + msg + ".</span>",
+      type: successful ? "message" : "error"
     });
   } catch (error) {
     window.Shiny.notifications.show({
       html: "<span>" + error.message + "</span>",
       type: "error"
     });
+  } finally {
+    window.getSelection().removeAllRanges();
   }
-});
+}

--- a/inst/assets/js/copyToClipboard.js
+++ b/inst/assets/js/copyToClipboard.js
@@ -1,0 +1,19 @@
+const copyText = (txt) => {
+  navigator.clipboard.writeText(txt);
+};
+
+window.Shiny.addCustomMessageHandler("blockr-copy-code", (msg) => {
+  // todo notify user
+  if (!msg.code) {
+    window.Shiny.notifications.show({
+      html: "<span>Failed to copy code to clipboard</span>",
+      type: "error",
+    });
+    return;
+  }
+  copyText(msg.code.map((code) => code.trim()).join("\n\t"));
+  window.Shiny.notifications.show({
+    html: "<span>Code copied to clipboard</span>",
+    type: "message",
+  });
+});

--- a/inst/assets/js/copyToClipboard.js
+++ b/inst/assets/js/copyToClipboard.js
@@ -22,7 +22,7 @@ window.Shiny.addCustomMessageHandler("blockr-copy-code", (msg) => {
 
   if (!msg.code) {
     window.Shiny.notifications.show({
-      html: "<span>Failed to copy code to clipboard</span>",
+      html: "<span>No code found to copy.</span>",
       type: "error",
     });
     return;
@@ -31,12 +31,12 @@ window.Shiny.addCustomMessageHandler("blockr-copy-code", (msg) => {
   try {
     await copyText(msg.code.trim());
     window.Shiny.notifications.show({
-      html: "<span>Code copied to clipboard</span>",
+      html: "<span>Code successfully copied to clipboard.</span>",
       type: "message",
     });
   } catch (error) {
     window.Shiny.notifications.show({
-      html: error.message,
+      html: "<span>" + error.message + "</span>",
       type: "error"
     });
   }

--- a/inst/assets/js/copyToClipboard.js
+++ b/inst/assets/js/copyToClipboard.js
@@ -11,7 +11,7 @@ window.Shiny.addCustomMessageHandler("blockr-copy-code", (msg) => {
     });
     return;
   }
-  copyText(msg.code.map((code) => code.trim()).join("\n\t"));
+  copyText(msg.code.trim());
   window.Shiny.notifications.show({
     html: "<span>Code copied to clipboard</span>",
     type: "message",

--- a/tests/testthat/test-block-class.R
+++ b/tests/testthat/test-block-class.R
@@ -159,10 +159,7 @@ test_that("block app", {
 
   skip_on_cran()
 
-  app_path <- system.file(
-    "examples", "block", "app.R",
-    package = "blockr.core"
-  )
+  app_path <- pkg_file("examples", "block", "app.R")
 
   app <- shinytest2::AppDriver$new(
     app_path,

--- a/tests/testthat/test-board-class.R
+++ b/tests/testthat/test-board-class.R
@@ -48,10 +48,7 @@ test_that("board app", {
 
   skip_on_cran()
 
-  app_path <- system.file(
-    "examples", "board", "app.R",
-    package = "blockr.core"
-  )
+  app_path <- pkg_file("examples", "board", "app.R")
 
   app <- shinytest2::AppDriver$new(
     app_path,

--- a/tests/testthat/test-plugin-code.R
+++ b/tests/testthat/test-plugin-code.R
@@ -17,11 +17,11 @@ test_that("generate code", {
     get_s3_method("board_server", board),
     {
       code_gen <- session$makeScope("generate_code")
-      code_gen$setInputs(code = 1)
+      code_gen$setInputs(code_mod = 1)
 
       session$flushReact()
 
-      res <- code_gen$output$code
+      res <- code_gen$output$code_out
 
       expect_type(res, "character")
       expect_length(res, 1L)


### PR DESCRIPTION
@DivadNojnarg I tried copying some things from our previous repo and combining this with how you integrated the JS stuff for the debounced text input. Not much luck in terms of getting it to work though.

Would you mind checking it out and giving me some pointers? I thought if we could get away without pulling in an R dep only for this button, that'd be nice (and from the looks of things we managed to do just that with previous blockr).

Happy to pivot to [rclipboard](https://cran.r-project.org/package=rclipboard) though if you feel this is too much of a hassle.