### PR TITLE
Fix deadlock in board reload

### DIFF
--- a/R/board-server.R
+++ b/R/board-server.R
@@ -293,37 +293,54 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
       )
 
       if (not_null(board_refresh)) {
-        observeEvent(
-          board_refresh(),
-          {
-            while (is_reloading("reload")) {
-              notify(
-                "Reload in progress.",
-                duration = NULL,
-                id = session$token
-              )
-              Sys.sleep(5)
+
+        reload_pending <- reactiveVal(NULL)
+
+        observeEvent(board_refresh(), reload_pending(Sys.time()))
+
+        observe({
+
+          pending <- reload_pending()
+          req(pending)
+
+          if (is_reloading("reload")) {
+
+            if (difftime(Sys.time(), pending, units = "secs") >= 60) {
+              log_warn("stale reload state, clearing")
+              finalize_reload("reload")
+              reload_pending(NULL)
+              session$close()
+              return()
             }
 
-            removeNotification(session$token)
-
-            val <- board_refresh()
-
-            if (is_board(val)) {
-              board <- val
-              meta <- NULL
-            } else {
-              board <- val$board
-              meta <- val$meta
-            }
-
-            log_debug("refreshing board")
-            update_serve_obj("reload", board, meta = meta)
-
-            log_debug("reloading session")
-            session$reload()
+            notify(
+              "Reload in progress.",
+              duration = NULL,
+              id = session$token
+            )
+            invalidateLater(1000)
+            return()
           }
-        )
+
+          removeNotification(session$token)
+          reload_pending(NULL)
+
+          val <- isolate(board_refresh())
+
+          if (is_board(val)) {
+            board <- val
+            meta <- NULL
+          } else {
+            board <- val$board
+            meta <- val$meta
+          }
+
+          log_debug("refreshing board")
+          update_serve_obj("reload", board, meta = meta)
+
+          log_debug("reloading session")
+          session$reload()
+        })
       }
 
       call_plugin_server(


### PR DESCRIPTION
## Summary

- Replace blocking `while`/`Sys.sleep` loop in the board refresh observer with cooperative waiting via `invalidateLater`, fixing the deadlock described in #147
- Serialize concurrent reloads across sessions using `is_reloading()` as a process-level gate, with R's single-threaded flush ordering providing mutual exclusion
- Add 60-second timeout to detect stale reload state (e.g. user closed browser mid-reload), clearing the stale entry and aborting the waiting session to prevent wrong-content leakage across sessions

Closes #147