### PR TITLE
Return empty data.frame from block_metadata() on empty input

### DIFF
--- a/R/block-class.R
+++ b/R/block-class.R
@@ -716,8 +716,11 @@ block_metadata <- function(x) {
     list2DF(res)
   }
 
-  do.call(
-    rbind,
-    lapply(lapply(as_blocks(x), get_one), coal, list())
-  )
+  rows <- lapply(as_blocks(x), get_one)
+
+  if (!length(rows)) {
+    return(get_one(structure(list(), class = "block"))[0L, , drop = FALSE])
+  }
+
+  do.call(rbind, lapply(rows, coal, list()))
 }

--- a/R/block-class.R
+++ b/R/block-class.R
@@ -716,11 +716,9 @@ block_metadata <- function(x) {
     list2DF(res)
   }
 
-  rows <- lapply(as_blocks(x), get_one)
-
-  if (!length(rows)) {
-    return(get_one(structure(list(), class = "block"))[0L, , drop = FALSE])
+  if (length(x)) {
+    do.call(rbind, lapply(as_blocks(x), get_one))
+  } else {
+    get_one(structure(list(), class = "block"))[0L, , drop = FALSE]
   }
-
-  do.call(rbind, lapply(rows, coal, list()))
 }

--- a/tests/testthat/test-block-class.R
+++ b/tests/testthat/test-block-class.R
@@ -232,4 +232,14 @@ test_that("block metadata", {
     c("id", "name", "description", "category", "icon", "arguments", "package")
   )
   expect_identical(rownames(meta3), c("a", "b"))
+
+  meta4 <- block_metadata(blocks())
+
+  expect_s3_class(meta4, "data.frame")
+  expect_identical(nrow(meta4), 0L)
+  expect_identical(ncol(meta4), 7L)
+  expect_named(
+    meta4,
+    c("id", "name", "description", "category", "icon", "arguments", "package")
+  )
 })


### PR DESCRIPTION
`block_metadata(blocks())` currently runs `do.call(rbind, list())` and returns `NULL`. Callers that pass the result through `cbind()` (e.g. blockr.dock's `blks_metadata()`, which appends a `color` column) end up with an atomic matrix, and the next `$`-access blows up — that's the source of [blockr.dock#102](https://github.com/BristolMyersSquibb/blockr.dock/issues/102), where opening the create-stack modal on a fresh board crashed.

Fixed by returning an empty data.frame with the right schema. The empty rows are derived from `get_one()` applied to a stub block, so the column set stays in sync automatically if `get_one()` is changed.

Includes a test for the empty case.