### PR TITLE
Augment payload before xref validation in validate_board_update

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: blockr.core
 Title: Graphical Web-Framework for Data Manipulation and Visualization
-Version: 0.1.2
+Version: 0.1.3
 Authors@R: 
     c(person(given = "Nicolas",
              family = "Bennett",

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -1052,6 +1052,8 @@ combine_update_blocks <- function(upd, board) {
 
 validate_board_update_xrefs <- function(payload, board) {
 
+  payload <- augment_board_update(payload, board)
+
   if (has_comp("links", payload)) {
     lnk <- payload$links
   } else {
@@ -1153,9 +1155,7 @@ validate_board_update_stacks <- function(upd, board) {
   invisible()
 }
 
-preprocess_board_update <- function(update, board) {
-
-  upd <- update()
+augment_board_update <- function(upd, board) {
 
   if ("blocks" %in% names(upd) && "rm" %in% names(upd$blocks)) {
 
@@ -1228,10 +1228,18 @@ preprocess_board_update <- function(update, board) {
     )
   }
 
-  if (length(mis_lnk) + length(upd_stk) + length(add_lnk)) {
-    update(upd)
-    return(TRUE)
+  upd
+}
+
+preprocess_board_update <- function(update, board) {
+
+  upd <- update()
+  augmented <- augment_board_update(upd, board)
+
+  if (identical(augmented, upd)) {
+    return(FALSE)
   }
 
-  FALSE
+  update(augmented)
+  TRUE
 }

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -754,6 +754,34 @@ test_that("public validate_board_update", {
   )
 })
 
+test_that("validate_board_update handles block-rm orphan cleanup (#177)", {
+
+  brd <- new_board(
+    blocks = c(my_data = new_dataset_block("iris"), preview = new_head_block()),
+    links = c(lnk1 = new_link("my_data", "preview", "data"))
+  )
+
+  payload <- list(
+    blocks = list(add = c(preview_new = new_head_block()), rm = "preview"),
+    links = list(add = c(lnk_new = new_link("my_data", "preview_new", "data")))
+  )
+
+  expect_identical(
+    validate_board_update(payload, brd),
+    payload
+  )
+
+  payload_mod <- list(
+    blocks = list(rm = "preview"),
+    links = list(mod = list(lnk1 = list(input = "data")))
+  )
+
+  expect_error(
+    validate_board_update(payload_mod, brd),
+    class = "board_block_link_name_mismatch"
+  )
+})
+
 test_that("board server utils", {
 
   expect_identical(


### PR DESCRIPTION
## Summary

- `validate_board_update_xrefs()` now runs `augment_board_update()` (the orphan-link / variadic-input / stack-membership cleanup previously inlined in `preprocess_board_update()`) before checking link xrefs, so the public validator agrees with the runtime apply path.
- Extracted `augment_board_update(upd, board)` as a pure function returning the augmented payload; `preprocess_board_update()` now delegates to it and re-sets the reactive only when something actually changed.
- Fixes the trap where "replace a block" (`blocks.rm = X` + `blocks.add = Y` + `links.add = …→Y`) was rejected at validation time even though it would apply cleanly.

Stacked on #176.

Fixes #177