### PR TITLE
Add validate_board_update to pkgdown reference index

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -49,6 +49,7 @@ reference:
     - board_server
     - board_ui
     - new_board_options
+    - validate_board_update
 - title: Board plugins
 - subtitle: Utilities
   desc: Tools for creating and working with board plugins.


### PR DESCRIPTION
## Summary

- Add `validate_board_update` to the Board subtitle under `reference:` in `_pkgdown.yml`.
- Function was exported in #174 but the index entry was missed, breaking the pkgdown CI job on `main`.

Fixes #180