### PR TITLE
Migrate revdep to standalone revdep.yaml workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,9 +11,6 @@ jobs:
   ci:
     uses: cynkra/blockr.ci/.github/workflows/ci.yaml@main
     with:
-      revdep-packages: |
-        BristolMyersSquibb/blockr.dock
-        BristolMyersSquibb/blockr.dag
       lintr-exclusions: |
         vignettes/create-block.qmd
         vignettes/extend-blockr.qmd
@@ -25,3 +22,13 @@ jobs:
       BLOCKR_PAT: ${{ secrets.BLOCKR_PAT }}
     permissions:
       contents: write
+
+  revdep:
+    if: github.event_name == 'merge_group'
+    uses: cynkra/blockr.ci/.github/workflows/revdep.yaml@main
+    with:
+      revdep-packages: |
+        BristolMyersSquibb/blockr.dock
+        BristolMyersSquibb/blockr.dag
+    secrets:
+      BLOCKR_PAT: ${{ secrets.BLOCKR_PAT }}


### PR DESCRIPTION
## Summary

- Drop `revdep-packages` from the `ci:` `with:` block — the input was deprecated in cynkra/blockr.ci#15 and is now a no-op on `ci.yaml`.
- Call the new `revdep.yaml` reusable workflow from a separate `revdep:` job entry, gated with `if: github.event_name == 'merge_group'` so reverse-dependency checks run before merge instead of on every PR push.

Until this lands, revdep checks for `blockr.dock` / `blockr.dag` have stopped running (a yellow CI warning fires on each ci.yaml run).

Fixes #182