### PR TITLE
Migrate CI to blockr.ci pr-gates structure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,4 @@
 on:
-  push:
-    branches: main
   pull_request:
     branches: main
   merge_group:
@@ -9,7 +7,7 @@ name: ci
 
 jobs:
   ci:
-    uses: cynkra/blockr.ci/.github/workflows/ci.yaml@main
+    uses: cynkra/blockr.ci/.github/workflows/ci.yaml@17-pr-gates
     with:
       lintr-exclusions: |
         vignettes/create-block.qmd
@@ -20,12 +18,9 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       BLOCKR_PAT: ${{ secrets.BLOCKR_PAT }}
-    permissions:
-      contents: write
 
   revdep:
-    if: github.event_name == 'merge_group'
-    uses: cynkra/blockr.ci/.github/workflows/revdep.yaml@main
+    uses: cynkra/blockr.ci/.github/workflows/revdep.yaml@17-pr-gates
     with:
       revdep-packages: |
         BristolMyersSquibb/blockr.dock

--- a/.github/workflows/deps-rerun.yaml
+++ b/.github/workflows/deps-rerun.yaml
@@ -7,6 +7,6 @@ name: deps-rerun
 
 jobs:
   rerun:
-    uses: cynkra/blockr.ci/.github/workflows/deps-rerun.yaml@main
+    uses: cynkra/blockr.ci/.github/workflows/deps-rerun.yaml@17-pr-gates
     secrets:
       BLOCKR_PAT: ${{ secrets.BLOCKR_PAT }}

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,13 @@
+on:
+  push:
+    branches: main
+
+name: pkgdown
+
+jobs:
+  pkgdown:
+    uses: cynkra/blockr.ci/.github/workflows/pkgdown.yaml@17-pr-gates
+    secrets:
+      BLOCKR_PAT: ${{ secrets.BLOCKR_PAT }}
+    permissions:
+      contents: write


### PR DESCRIPTION
## Summary

- Point the `ci`, `revdep` and `deps-rerun` workflows at `cynkra/blockr.ci@17-pr-gates` (the restructured pipeline in cynkra/blockr.ci#19), mirroring blockr.dock.
- Add a standalone `pkgdown.yaml` deploy workflow — the site deploy moved out of the shared `ci.yaml`, so `contents: write` and the `push` trigger are dropped from `ci.yaml`.
- Drop the consumer-side `if: merge_group` on `revdep`; the new `revdep.yaml` self-gates its heavy matrix to the merge queue.
- Keep `lintr-exclusions` (still a supported input) and the `revdep-packages` list.

Branch protection is updated out-of-band to match the new gates: `ci / lint`, `ci / smoke`, `ci / pkgdown-dev`, `ci / coverage`, `ci / check-all`, `revdep / revdep-all`.

Fixes #190