### PR TITLE
Omit memory log marker when suggested memuse is unavailable

### DIFF
--- a/R/utils-logging.R
+++ b/R/utils-logging.R
@@ -70,6 +70,10 @@ write_log <- function(..., level = "info", envir = parent.frame(),
 
 get_mem_use <- function(prefix = "", suffix = "") {
 
+  if (!has_memuse()) {
+    return("")
+  }
+
   mem <- memuse::Sys.procmem()
 
   if (is.null(mem$peak)) {
@@ -79,6 +83,10 @@ get_mem_use <- function(prefix = "", suffix = "") {
   }
 
   paste0(prefix, mem$size, peak, suffix)
+}
+
+has_memuse <- function() {
+  requireNamespace("memuse", quietly = TRUE)
 }
 
 get_timmestamp <- function(prefix = "", suffix = "") {

--- a/tests/testthat/test-utils-logging.R
+++ b/tests/testthat/test-utils-logging.R
@@ -26,8 +26,16 @@ test_that("logging", {
     {
       expect_true(blockr_option("log_time", FALSE))
       expect_true(blockr_option("log_mem", FALSE))
-      expect_output(log_info("abc"), "\\]\\[.+B\\]\\[blockr\\.core\\] ")
-      expect_output(log_info("abc"), "\\]\\[.+\\]\\[")
+
+      with_mocked_bindings(
+        {
+          expect_output(log_info("abc"), "\\]\\[42B\\]\\[blockr\\.core\\] ")
+          expect_output(log_info("abc"), "\\]\\[.+\\]\\[")
+        },
+        get_mem_use = function(prefix = "", suffix = "") {
+          paste0(prefix, "42B", suffix)
+        }
+      )
     }
   )
 
@@ -42,5 +50,16 @@ test_that("logging", {
       expect_warning(log_error("abc"))
       expect_error(log_fatal("abc"))
     }
+  )
+})
+
+test_that("memory marker is omitted when memuse is unavailable", {
+
+  expect_identical(
+    with_mocked_bindings(
+      get_mem_use("[", "]"),
+      has_memuse = function() FALSE
+    ),
+    ""
   )
 })


### PR DESCRIPTION
## Summary

- `get_mem_use()` called `memuse::Sys.procmem()` unconditionally, so `write_log()` and every `log_*()` wrapper errored with `there is no package called 'memuse'` whenever `log_mem = TRUE` and the suggested `memuse` package was not installed.
- Guard with bare `requireNamespace("memuse")`, degrading to no marker (mirrors the existing `cli` check in `plugin-notification.R`). Bare `requireNamespace` rather than `pkg_avail()` is deliberate: `pkg_avail()` emits a `log_trace()`, which at `log_level = "trace"` would recurse `write_log -> get_mem_use -> pkg_avail -> log_trace -> write_log` forever.
- Stabilize the env-dependent marker assertion in `test-utils-logging.R` by mocking `get_mem_use` to a fixed value, and add a focused test that hides `memuse` from the library paths and asserts the marker is omitted.

Fixes #194