### PR TITLE
Forward ... to per-class methods in blockr_deser.list

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,10 @@
   internal `block_external_ctrl_vars()`, letting dependent packages dispatch
   on it (e.g. for dock extensions) instead of re-reading the raw
   `external_ctrl` attribute (#192).
+* `blockr_deser.list()` now forwards `...` to the dispatched per-class
+  method, so callers can thread additional context (e.g. a producer
+  version) down to nested deserializers. Previously such arguments were
+  silently dropped at the list-dispatch boundary (#186).
 
 # blockr.core 0.1.2
 

--- a/R/utils-serdes.R
+++ b/R/utils-serdes.R
@@ -11,6 +11,10 @@
 #' strings and no objects which are hard/impossible to truthfully re-create in
 #' new sessions (such as environments).
 #'
+#' During deserialization, `blockr_deser()` forwards `...` to the dispatched
+#' per-class method. This lets callers (and outer methods deserializing nested
+#' objects) thread additional context down to inner deserializers.
+#'
 #' @param x Object to (de)serialize
 #' @param ... Generic consistency
 #'
@@ -260,7 +264,8 @@ blockr_deser.list <- function(x, ...) {
 
   res <- blockr_deser(
     structure(list(), class = cls),
-    data = x
+    data = x,
+    ...
   )
 
   if (!identical(class(res), cls)) {

--- a/man/blockr_ser.Rd
+++ b/man/blockr_ser.Rd
@@ -111,6 +111,10 @@ generics and perform most of the heavy lifting for (de-)serialization:
 representing objects as easy-to-serialize (nested) lists containing mostly
 strings and no objects which are hard/impossible to truthfully re-create in
 new sessions (such as environments).
+
+During deserialization, \code{blockr_deser()} forwards \code{...} to the dispatched
+per-class method. This lets callers (and outer methods deserializing nested
+objects) thread additional context down to inner deserializers.
 }
 \examples{
 blk <- new_dataset_block("iris")

--- a/tests/testthat/test-utils-serdes.R
+++ b/tests/testthat/test-utils-serdes.R
@@ -142,3 +142,30 @@ test_that("serialization", {
     class = "option_value_arg_name_mismatch"
   )
 })
+
+test_that("blockr_deser.list forwards `...` to per-class methods", {
+
+  captured <- NULL
+
+  registerS3method(
+    "blockr_deser", "deser_ctx_probe",
+    function(x, data, version = NULL, ...) {
+      captured <<- version
+      structure(list(), class = "deser_ctx_probe")
+    },
+    envir = asNamespace("blockr.core")
+  )
+
+  with_ctx <- blockr_deser(
+    list(object = "deser_ctx_probe"),
+    version = "1.2.3"
+  )
+
+  expect_s3_class(with_ctx, "deser_ctx_probe")
+  expect_identical(captured, "1.2.3")
+
+  no_ctx <- blockr_deser(list(object = "deser_ctx_probe"))
+
+  expect_s3_class(no_ctx, "deser_ctx_probe")
+  expect_null(captured)
+})


### PR DESCRIPTION
## Summary

- `blockr_deser.list()` re-dispatches on the serialized `object` class field but dropped `...` when invoking the per-class method, so any caller-supplied context was silently lost at the list boundary.
- Forward `...` through to the dispatched method, letting an outer deserializer thread context (e.g. a producer version) down to nested per-class deserializers — the immediate need in BristolMyersSquibb/blockr.dock#153, where `blockr_deser.dock_board` wants to route per-view deserialization by the producing blockr.dock version.
- Purely additive: existing callers pass no extra arguments, so behaviour is unchanged, and every `blockr_deser.*` method already declares `...`.
- Audit of the issue's side-note: only `blockr_deser.list` has the re-dispatch-by-`object`-field shape. The other `.list` methods (`as_blocks.list`, `as_links.list`, `as_plugin.list`, …) are plain converters, not re-dispatchers, so nothing else needs the change.

Fixes #186
