### PR TITLE
Detach generate_plugin_args() output from its testServer session

### DIFF
--- a/R/utils-tests.R
+++ b/R/utils-tests.R
@@ -9,7 +9,9 @@
 #' `update` over read plugins such as `preserve_board`.
 #'
 #' @return For testing plugins, `generate_plugin_args()` returns objects that
-#' mimic how plugins are called in the board server, `sink_msg()` is called
+#' mimic how plugins are called in the board server (with reactive components
+#' re-created on a `NULL` reactive domain so they outlive the
+#' [shiny::testServer()] session used to set them up), `sink_msg()` is called
 #' mainly for the side-effect of muting shiny messages (and returns them
 #' invisibly), `with_mock_session()` returns `NULL` (invisibly) and
 #' `with_mock_context()` returns the result of a call to
@@ -34,16 +36,50 @@ generate_plugin_args <- function(board, ..., mode = c("edit", "read")) {
     get_s3_method("board_server", board),
     {
       session$flushReact()
-      res_plugin_args <<- switch(
-        mode,
-        edit = edit_plugin_args,
-        read = read_plugin_args
+      res_plugin_args <<- snapshot_reactives(
+        switch(mode, edit = edit_plugin_args, read = read_plugin_args)
       )
     },
     args = list(x = board, ...)
   )
 
   res_plugin_args
+}
+
+# Re-create the reactive parts of the plugin args on a NULL reactive domain, so
+# they survive the testServer() session that built them (which shiny tears down
+# on close, taking session-scoped reactives with it; see #196). reactiveVal and
+# reactiveExpr both become read-only reactives, since callers only read them.
+snapshot_reactives <- function(x) {
+
+  if (is.reactivevalues(x)) {
+    vals <- lapply(isolate(reactiveValuesToList(x)), snapshot_reactives)
+    return(withReactiveDomain(NULL, do.call(reactiveValues, vals)))
+  }
+
+  if (inherits(x, "reactive")) {
+
+    # Defer evaluation errors (e.g. a block with unset inputs) to read time, as
+    # the live reactive would have, rather than failing the whole snapshot.
+    captured <- tryCatch(
+      list(value = isolate(x())),
+      error = function(e) list(cond = e)
+    )
+
+    if (is.null(captured$cond)) {
+      val <- captured$value
+      return(withReactiveDomain(NULL, reactive(val)))
+    }
+
+    cnd <- captured$cond
+    return(withReactiveDomain(NULL, reactive(stop(cnd))))
+  }
+
+  if (is.list(x) && is.null(attr(x, "class"))) {
+    return(lapply(x, snapshot_reactives))
+  }
+
+  x
 }
 
 #' @param ... Forwarded to [utils::capture.output()]

--- a/man/testing.Rd
+++ b/man/testing.Rd
@@ -51,7 +51,9 @@ of \code{expr}.}
 }
 \value{
 For testing plugins, \code{generate_plugin_args()} returns objects that
-mimic how plugins are called in the board server, \code{sink_msg()} is called
+mimic how plugins are called in the board server (with reactive components
+re-created on a \code{NULL} reactive domain so they outlive the
+\code{\link[shiny:testServer]{shiny::testServer()}} session used to set them up), \code{sink_msg()} is called
 mainly for the side-effect of muting shiny messages (and returns them
 invisibly), \code{with_mock_session()} returns \code{NULL} (invisibly) and
 \code{with_mock_context()} returns the result of a call to

--- a/tests/testthat/test-utils-tests.R
+++ b/tests/testthat/test-utils-tests.R
@@ -1,0 +1,71 @@
+test_that("snapshot_reactives detaches from the source reactives", {
+
+  src <- reactiveValues(
+    val = 1L,
+    block = list(
+      server = list(
+        expr = reactive("E"),
+        cond = reactiveValues(eval = "c")
+      )
+    )
+  )
+
+  snap <- snapshot_reactives(src)
+
+  expect_true(is.reactivevalues(snap))
+
+  isolate({
+
+    expect_identical(snap$val, 1L)
+    expect_identical(snap$block$server$expr(), "E")
+
+    expect_true(is.reactivevalues(snap$block$server$cond))
+    expect_identical(
+      reactiveValuesToList(snap$block$server$cond),
+      list(eval = "c")
+    )
+  })
+
+  isolate(src$val <- 2L)
+  isolate(src$block$server$cond$eval <- "d")
+
+  expect_identical(isolate(snap$val), 1L)
+  expect_identical(isolate(snap$block$server$cond$eval), "c")
+})
+
+test_that("snapshot_reactives defers evaluation errors to read time", {
+
+  snap <- snapshot_reactives(list(thrower = reactive(stop("boom"))))
+
+  expect_error(isolate(snap$thrower()), "boom")
+})
+
+test_that("generate_plugin_args returns session-independent args", {
+
+  board <- new_board(
+    blocks = c(
+      a = new_dataset_block("BOD"),
+      b = new_dataset_block("ChickWeight"),
+      c = new_merge_block(by = "Time")
+    ),
+    links = links(
+      from = c("a", "b"),
+      to = c("c", "c"),
+      input = c("x", "y")
+    )
+  )
+
+  args <- generate_plugin_args(board)
+
+  expect_true(is.reactivevalues(args$board))
+
+  isolate({
+
+    exprs <- lst_xtr_reval(args$board$blocks, "server", "expr")
+    expect_named(exprs, c("a", "b", "c"), ignore.order = TRUE)
+
+    cond <- args$board$blocks[["a"]]$server$cond
+    expect_true(is.reactivevalues(cond))
+    expect_type(reactiveValuesToList(cond), "list")
+  })
+})


### PR DESCRIPTION
## Summary

- shiny's upcoming module-scoped reactive cleanup ([rstudio/shiny#4372](https://github.com/rstudio/shiny/pull/4372)) tears down session-scoped reactives when `testServer()` closes. `generate_plugin_args()` returned the board's live `reactiveValues` (and the nested block reactives), so callers that read them after the helper returns will hit *"its module session has been destroyed."*
- Re-create the returned reactive parts on a `NULL` reactive domain (new internal `snapshot_reactives()`), so they outlive the setup session — the issue's snapshot suggestion combined with its `withReactiveDomain(NULL, …)` mechanism, applied in the helper rather than in the production `board_server()`.
- Keep types intact (`reactiveValues` stays `reactiveValues`, not plain data): `blockr.dock` reads `server$cond` via `reactiveValuesToList()`, which the literal `isolate(reactiveValuesToList(rv))` suggestion would break.
- Defer errors from not-yet-evaluable reactives (e.g. a block with unset inputs) to read time, matching the lazy behaviour of the live reactive — eager evaluation during the snapshot would otherwise fail the whole call.

I also ran the downstream consumers of this helper (`blockr.code`, `blockr.dock`'s `board_args` tests) against the patched core; both stay green.

Fixes #196