### PR TITLE
Record board-update outcome on board$last_update

### DIFF
--- a/R/board-server.R
+++ b/R/board-server.R
@@ -62,7 +62,8 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
         board_id = id,
         links = list(),
         stacks = list(),
-        reload_meta = reload_meta
+        reload_meta = reload_meta,
+        last_update = NULL
       )
 
       rv_ro <- list(board = make_read_only(rv))
@@ -140,6 +141,20 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
         plugins = plugins
       )
 
+      update_seq <- 0L
+
+      record_update_outcome <- function(ok, phase, message = NA_character_) {
+
+        update_seq <<- update_seq + 1L
+
+        rv$last_update <- list(
+          seq = update_seq,
+          ok = ok,
+          phase = phase,
+          message = message
+        )
+      }
+
       observeEvent(
         board_update(),
         {
@@ -160,6 +175,7 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
             error = function(e) {
               log_warn("board update rejected: {conditionMessage(e)}")
               notify(conditionMessage(e), type = "error", session = session)
+              record_update_outcome(FALSE, "validate", conditionMessage(e))
               board_update(NULL)
             }
           )
@@ -195,10 +211,13 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
 
               stopifnot(is_board(new_board))
               rv$board <- new_board
+
+              record_update_outcome(TRUE, "apply")
             },
             error = function(e) {
               log_warn("apply_board_update failed: {conditionMessage(e)}")
               notify(conditionMessage(e), type = "error", session = session)
+              record_update_outcome(FALSE, "apply", conditionMessage(e))
             }
           )
 
@@ -674,6 +693,18 @@ add_blocks_to_stacks <- function(rv, add, session) {
 #' Errors thrown from either augment or apply are caught by the
 #' observer, reported via [notify()], and the reactive is reset so the
 #' app keeps running.
+#'
+#' @section Outcome:
+#' Alongside the human-facing [notify()] toast, every update cycle
+#' records a machine-readable result into `board$last_update` (the
+#' read-only board handed to plugins and callbacks). It is a list with
+#' a monotonically increasing `seq`, a logical `ok`, the `phase` it
+#' ended in (`"validate"` or `"apply"`), and a `message`
+#' (`conditionMessage()` on failure, `NA` on success); it is `NULL`
+#' before the first update. The `seq` advances on every write so that
+#' two consecutive identical outcomes still invalidate a downstream
+#' observer. A programmatic caller can watch this field to learn
+#' whether a dispatched update was rejected, failed to apply, or landed.
 #'
 #' @param payload,upd A board update payload — see Validation above
 #' for the accepted shape.

--- a/man/board_update.Rd
+++ b/man/board_update.Rd
@@ -82,6 +82,20 @@ observer, reported via \code{\link[=notify]{notify()}}, and the reactive is rese
 app keeps running.
 }
 
+\section{Outcome}{
+
+Alongside the human-facing \code{\link[=notify]{notify()}} toast, every update cycle
+records a machine-readable result into \code{board$last_update} (the
+read-only board handed to plugins and callbacks). It is a list with
+a monotonically increasing \code{seq}, a logical \code{ok}, the \code{phase} it
+ended in (\code{"validate"} or \code{"apply"}), and a \code{message}
+(\code{conditionMessage()} on failure, \code{NA} on success); it is \code{NULL}
+before the first update. The \code{seq} advances on every write so that
+two consecutive identical outcomes still invalidate a downstream
+observer. A programmatic caller can watch this field to learn
+whether a dispatched update was rejected, failed to apply, or landed.
+}
+
 \examples{
 brd <- new_board(
   blocks = c(a = new_dataset_block("iris"), b = new_subset_block()),

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -1048,3 +1048,111 @@ test_that("apply_board_update runs after core has settled rv state", {
     )
   )
 })
+
+test_that("successful board update records ok outcome with monotonic seq", {
+
+  empty <- new_board()
+
+  testServer(
+    get_s3_method("board_server", empty),
+    {
+      session$flushReact()
+
+      expect_null(rv$last_update)
+
+      board_update(
+        list(blocks = list(add = as_blocks(c(a = new_dataset_block()))))
+      )
+
+      session$flushReact()
+
+      expect_length(board_blocks(rv$board), 1L)
+      expect_true(rv$last_update$ok)
+      expect_identical(rv$last_update$phase, "apply")
+      expect_identical(rv$last_update$seq, 1L)
+      expect_identical(rv$last_update$message, NA_character_)
+
+      expect_identical(make_read_only(rv)$last_update, rv$last_update)
+
+      board_update(
+        list(blocks = list(add = as_blocks(c(b = new_subset_block()))))
+      )
+
+      session$flushReact()
+
+      expect_length(board_blocks(rv$board), 2L)
+      expect_true(rv$last_update$ok)
+      expect_identical(rv$last_update$seq, 2L)
+    },
+    args = list(
+      x = empty,
+      plugins = list(manage_blocks())
+    )
+  )
+})
+
+test_that("rejected board update records validate-phase failure each time", {
+
+  empty <- new_board()
+
+  testServer(
+    get_s3_method("board_server", empty),
+    {
+      session$flushReact()
+
+      board_update(list(blocks = list(rm = "missing")))
+
+      session$flushReact()
+
+      expect_false(rv$last_update$ok)
+      expect_identical(rv$last_update$phase, "validate")
+      expect_true(nzchar(rv$last_update$message))
+      expect_null(board_update())
+      expect_length(board_blocks(rv$board), 0L)
+
+      first_seq <- rv$last_update$seq
+
+      board_update(list(blocks = list(rm = "missing")))
+
+      session$flushReact()
+
+      expect_false(rv$last_update$ok)
+      expect_identical(rv$last_update$phase, "validate")
+      expect_identical(rv$last_update$seq, first_seq + 1L)
+    },
+    args = list(
+      x = empty,
+      plugins = list(manage_blocks())
+    )
+  )
+})
+
+test_that("apply-phase failure records apply outcome", {
+
+  local_mocked_bindings(
+    apply_board_update = function(board, upd, ...) {
+      stop("apply boom")
+    }
+  )
+
+  empty <- new_board()
+
+  testServer(
+    get_s3_method("board_server", empty),
+    {
+      session$flushReact()
+
+      board_update(list())
+
+      session$flushReact()
+
+      expect_false(rv$last_update$ok)
+      expect_identical(rv$last_update$phase, "apply")
+      expect_match(rv$last_update$message, "apply boom")
+    },
+    args = list(
+      x = empty,
+      plugins = list(manage_blocks())
+    )
+  )
+})


### PR DESCRIPTION
## Summary

- A plugin or extension dispatching a board update had no machine-readable signal of whether it landed — validate and apply run in two async observers on the board server, and failures surfaced only through `notify()` (a human-facing toast). Pre-validating before dispatch doesn't close the gap: the applier executes the mutation and can throw on a payload that validated clean, and some checks (dock's `validate_views_delta`) run async-only inside augment.
- Each update cycle now records a flat `list(seq, ok, phase, message)` into a new `rv$last_update` — at the validator's error handler (`phase = "validate"`), the applier's error handler (`phase = "apply"`), and the applier's success path (`ok = TRUE`, `message = NA`). The board is already handed to plugins and callbacks as `make_read_only(rv)`, so this surfaces as `board$last_update` with no change to any callback signature.
- `seq` advances on every write because `reactiveValues` skips invalidation on an `identical()` write — without it, two consecutive identical failures would be invisible to a downstream observer.
- `notify()` is untouched (a parallel channel, not a replacement); the record means "this phase raised", not "nothing changed" — apply stays non-transactional per the issue's non-goals. Immediate consumer: BristolMyersSquibb/blockr.assistant#29.

Fixes #200
