### PR TITLE
Gate block evaluation and rendering on visibility

### DIFF
--- a/R/block-server.R
+++ b/R/block-server.R
@@ -456,15 +456,15 @@ visibility_gate_observer <- function(id, board, eval_obs, render_obs, sess) {
   observe(
     {
       vis <- board$visible
-      ev <- board$visible_eval
+      ev <- board$eval
 
-      if (is.null(ev) || id %in% ev) {
+      if (isTRUE(ev) || id %in% ev) {
         eval_obs$resume()
       } else {
         eval_obs$suspend()
       }
 
-      if (is.null(vis) || id %in% vis) {
+      if (isTRUE(vis) || id %in% vis) {
         render_obs$resume()
       } else {
         render_obs$suspend()

--- a/R/block-server.R
+++ b/R/block-server.R
@@ -28,6 +28,17 @@
 #' [block_output()] generic. The [block_ui()] generic can then be used to
 #' control rendering of outputs.
 #'
+#' When a front-end (such as blockr.dock) drives the `visible` write-channel
+#' that [board_server()] hands to the board callback, naming the block IDs
+#' currently on screen, block evaluation and rendering are gated on
+#' visibility: a block renders only while on screen and evaluates only while on
+#' screen or upstream of an on-screen block (its closure over [board_links()]).
+#' Gating suspends and resumes the evaluation and render observers, starting
+#' them suspended so off-screen blocks neither evaluate nor render at startup.
+#' With nothing driving `visible` every block is treated as visible and
+#' behaviour is unchanged; the `gate_visibility` [blockr_option()] (default
+#' `TRUE`) turns gating off entirely.
+#'
 #' @param id Namespace ID
 #' @param x Object for which to generate a [shiny::moduleServer()]
 #' @param data Input data (list of reactives)
@@ -191,9 +202,18 @@ block_server.block <- function(id, x, data = list(), block_id = id,
         TRUE
       )
 
-      data_eval_observer(block_id, x, dat_eval, cb_res, res, state, lang, rv,
-                         cond, session)
-      output_render_observer(x, res, cond, session)
+      gated <- is_board(isolate(board$board)) &&
+        isTRUE(blockr_option("gate_visibility", TRUE))
+
+      eval_obs <- data_eval_observer(block_id, x, dat_eval, cb_res, res, state,
+                                     lang, rv, cond, session, suspended = gated)
+
+      render_obs <- output_render_observer(x, res, cond, session,
+                                           suspended = gated)
+
+      if (gated) {
+        visibility_gate_observer(block_id, board, eval_obs, render_obs, session)
+      }
 
       eb_res <- call_plugin_server(
         edit_block,
@@ -363,7 +383,7 @@ state_check_observer <- function(id, x, dat, res, state, rv, cond, sess) {
 }
 
 data_eval_observer <- function(id, x, dat, gate, res, state, lang, rv, cond,
-                               sess) {
+                               sess, suspended = FALSE) {
 
   observeEvent(
     req(reval_if(gate), dat()),
@@ -379,7 +399,8 @@ data_eval_observer <- function(id, x, dat, gate, res, state, lang, rv, cond,
 
       res(out)
     },
-    domain = sess
+    domain = sess,
+    suspended = suspended
   )
 }
 
@@ -410,7 +431,7 @@ block_render_trigger.block <- function(x, session = get_session()) {
   NULL
 }
 
-output_render_observer <- function(x, res, cond, sess) {
+output_render_observer <- function(x, res, cond, sess, suspended = FALSE) {
 
   observeEvent(
     {
@@ -424,6 +445,30 @@ output_render_observer <- function(x, res, cond, sess) {
         "render",
         session = sess
       )
+    },
+    domain = sess,
+    suspended = suspended
+  )
+}
+
+visibility_gate_observer <- function(id, board, eval_obs, render_obs, sess) {
+
+  observe(
+    {
+      vis <- board$visible
+      ev <- board$visible_eval
+
+      if (is.null(ev) || id %in% ev) {
+        eval_obs$resume()
+      } else {
+        eval_obs$suspend()
+      }
+
+      if (is.null(vis) || id %in% vis) {
+        render_obs$resume()
+      } else {
+        render_obs$suspend()
+      }
     },
     domain = sess
   )

--- a/R/block-server.R
+++ b/R/block-server.R
@@ -453,21 +453,31 @@ output_render_observer <- function(x, res, cond, sess, suspended = FALSE) {
 
 visibility_gate_observer <- function(id, board, eval_obs, render_obs, sess) {
 
+  prev_eval <- NA
+  prev_render <- NA
+
   observe(
     {
-      vis <- board$visible
-      ev <- board$eval
+      do_eval <- isTRUE(board$eval) || id %in% board$eval
+      do_render <- isTRUE(board$visible) || id %in% board$visible
 
-      if (isTRUE(ev) || id %in% ev) {
-        eval_obs$resume()
-      } else {
-        eval_obs$suspend()
+      if (do_eval) eval_obs$resume() else eval_obs$suspend()
+      if (do_render) render_obs$resume() else render_obs$suspend()
+
+      if (!identical(do_eval, prev_eval)) {
+        prev_eval <<- do_eval
+        log_debug(
+          "block {id} evaluation ",
+          "{if (do_eval) 'resumed' else 'suspended'}"
+        )
       }
 
-      if (isTRUE(vis) || id %in% vis) {
-        render_obs$resume()
-      } else {
-        render_obs$suspend()
+      if (!identical(do_render, prev_render)) {
+        prev_render <<- do_render
+        log_debug(
+          "block {id} rendering ",
+          "{if (do_render) 'resumed' else 'suspended'}"
+        )
       }
     },
     domain = sess

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -71,7 +71,9 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
         links = list(),
         stacks = list(),
         last_update = NULL,
-        conditions = NULL
+        conditions = NULL,
+        visible = NULL,
+        visible_eval = NULL
       )
 
       rv_ro <- list(board = make_read_only(rv))
@@ -93,6 +95,19 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
       )
 
       board_update <- reactiveVal()
+      board_visible <- reactiveVal()
+
+      observe(
+        {
+          vis <- board_visible()
+          rv$visible <- vis
+          rv$visible_eval <- if (is.null(vis)) {
+            NULL
+          } else {
+            upstream_blocks(vis, rv$board)
+          }
+        }
+      )
 
       cb_res <- set_names(
         vector("list", length(callbacks)),
@@ -101,7 +116,7 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
 
       cb_args <- c(
         rv_ro,
-        list(update = board_update),
+        list(update = board_update, visible = board_visible),
         dot_args,
         list(session = session)
       )

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -107,6 +107,12 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
           } else {
             rv$visible <- vis
             rv$eval <- upstream_blocks(vis, rv$board)
+
+            log_debug(
+              "visibility update: {length(vis)}/",
+              "{length(board_block_ids(rv$board))} on screen, ",
+              "{length(rv$eval)} evaluating"
+            )
           }
         }
       )

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -72,8 +72,8 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
         stacks = list(),
         last_update = NULL,
         conditions = NULL,
-        visible = NULL,
-        visible_eval = NULL
+        visible = TRUE,
+        eval = TRUE
       )
 
       rv_ro <- list(board = make_read_only(rv))
@@ -100,11 +100,13 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
       observe(
         {
           vis <- board_visible()
-          rv$visible <- vis
-          rv$visible_eval <- if (is.null(vis)) {
-            NULL
+
+          if (is.null(vis)) {
+            rv$visible <- TRUE
+            rv$eval <- TRUE
           } else {
-            upstream_blocks(vis, rv$board)
+            rv$visible <- vis
+            rv$eval <- upstream_blocks(vis, rv$board)
           }
         }
       )

--- a/R/utils-graph.R
+++ b/R/utils-graph.R
@@ -99,6 +99,21 @@ as_adjacency_matrix <- function(from, to, nodes = union(from, to)) {
   res
 }
 
+upstream_blocks <- function(ids, board) {
+
+  links <- board_links(board)
+
+  res <- ids
+  new <- ids
+
+  while (length(new)) {
+    new <- setdiff(links$from[links$to %in% new], res)
+    res <- c(res, new)
+  }
+
+  res
+}
+
 #' @param x Object
 #' @rdname topo_sort
 #' @export

--- a/man/block_server.Rd
+++ b/man/block_server.Rd
@@ -92,4 +92,15 @@ Block-level user inputs (provided by the expression module) are separated
 from output, the behavior of which can be customized via the
 \code{\link[=block_output]{block_output()}} generic. The \code{\link[=block_ui]{block_ui()}} generic can then be used to
 control rendering of outputs.
+
+When a front-end (such as blockr.dock) drives the \code{visible} write-channel
+that \code{\link[=board_server]{board_server()}} hands to the board callback, naming the block IDs
+currently on screen, block evaluation and rendering are gated on
+visibility: a block renders only while on screen and evaluates only while on
+screen or upstream of an on-screen block (its closure over \code{\link[=board_links]{board_links()}}).
+Gating suspends and resumes the evaluation and render observers, starting
+them suspended so off-screen blocks neither evaluate nor render at startup.
+With nothing driving \code{visible} every block is treated as visible and
+behaviour is unchanged; the \code{gate_visibility} \code{\link[=blockr_option]{blockr_option()}} (default
+\code{TRUE}) turns gating off entirely.
 }

--- a/tests/testthat/test-utils-graph.R
+++ b/tests/testthat/test-utils-graph.R
@@ -39,3 +39,23 @@ test_that("topo sort", {
     character()
   )
 })
+
+test_that("upstream blocks", {
+
+  board <- new_board(
+    c(a = new_dataset_block("iris"), b = new_dataset_block("mtcars"),
+      c = new_scatter_block(), d = new_subset_block()),
+    list(from = c("a", "d"), to = c("d", "c"))
+  )
+
+  expect_setequal(upstream_blocks("c", board), c("a", "c", "d"))
+  expect_setequal(upstream_blocks("d", board), c("a", "d"))
+  expect_setequal(upstream_blocks("a", board), "a")
+  expect_setequal(upstream_blocks("b", board), "b")
+  expect_setequal(upstream_blocks(c("b", "c"), board), c("a", "b", "c", "d"))
+
+  empty <- new_board(c(a = new_dataset_block("iris")))
+
+  expect_setequal(upstream_blocks("a", empty), "a")
+  expect_identical(upstream_blocks(character(), empty), character())
+})

--- a/tests/testthat/test-visibility-gating.R
+++ b/tests/testthat/test-visibility-gating.R
@@ -1,0 +1,181 @@
+probe_render <- new.env()
+probe_render$ids <- character()
+
+registerS3method(
+  "block_output", "probe_block",
+  function(x, result, session) {
+    probe_render$ids <- c(probe_render$ids, session$ns(NULL))
+    NULL
+  }
+)
+
+registerS3method(
+  "block_ui", "probe_block",
+  function(id, x, ...) shiny::tagList()
+)
+
+probe_source <- function() {
+  new_data_block(
+    function(id) {
+      moduleServer(
+        id,
+        function(input, output, session) {
+          list(expr = reactive(quote(datasets::BOD)), state = list())
+        }
+      )
+    },
+    function(id) shiny::tagList(),
+    class = "probe_block",
+    block_metadata = FALSE
+  )
+}
+
+probe_passthrough <- function() {
+  new_transform_block(
+    function(id, data) {
+      moduleServer(
+        id,
+        function(input, output, session) {
+          list(expr = reactive(quote(identity(data))), state = list())
+        }
+      )
+    },
+    function(id) shiny::tagList(),
+    class = "probe_block",
+    block_metadata = FALSE
+  )
+}
+
+reset_render_log <- function() {
+  probe_render$ids <- character()
+}
+
+rendered <- function(id) {
+  any(endsWith(probe_render$ids, paste0("block_", id)))
+}
+
+evaluated <- function(rv, id) {
+  !is.null(rv$blocks[[id]]$server$result())
+}
+
+test_that("with no producer every block is visible", {
+
+  reset_render_log()
+
+  board <- new_board(
+    blocks = c(a = probe_source(), b = probe_passthrough()),
+    links = links(new_link(from = "a", to = "b"))
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      expect_null(rv$visible)
+      expect_null(rv$visible_eval)
+
+      expect_true(evaluated(rv, "a"))
+      expect_true(evaluated(rv, "b"))
+
+      expect_true(rendered("a"))
+      expect_true(rendered("b"))
+    },
+    args = list(x = board)
+  )
+})
+
+test_that("a producer gates evaluation and rendering on visibility", {
+
+  reset_render_log()
+
+  board <- new_board(
+    blocks = c(
+      a = probe_source(),
+      b = probe_passthrough(),
+      c = probe_passthrough(),
+      d = probe_passthrough()
+    ),
+    links = links(
+      new_link(from = "a", to = "b"),
+      new_link(from = "b", to = "c"),
+      new_link(from = "a", to = "d")
+    )
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      expect_setequal(rv$visible, "b")
+      expect_setequal(rv$visible_eval, c("a", "b"))
+
+      expect_true(evaluated(rv, "b"))
+      expect_true(rendered("b"))
+
+      expect_true(evaluated(rv, "a"))
+      expect_false(rendered("a"))
+
+      expect_false(evaluated(rv, "c"))
+      expect_false(rendered("c"))
+
+      expect_false(evaluated(rv, "d"))
+      expect_false(rendered("d"))
+
+      board_visible(c("b", "c", "d"))
+      session$flushReact()
+
+      expect_true(evaluated(rv, "c"))
+      expect_true(rendered("c"))
+
+      expect_true(evaluated(rv, "d"))
+      expect_true(rendered("d"))
+    },
+    args = list(
+      x = board,
+      callbacks = function(visible, ...) {
+        visible("b")
+        NULL
+      }
+    )
+  )
+})
+
+test_that("the gate_visibility option disables gating", {
+
+  reset_render_log()
+
+  withr::local_options(blockr.gate_visibility = FALSE)
+
+  board <- new_board(
+    blocks = c(
+      a = probe_source(),
+      b = probe_passthrough(),
+      c = probe_passthrough()
+    ),
+    links = links(
+      new_link(from = "a", to = "b"),
+      new_link(from = "b", to = "c")
+    )
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      for (id in c("a", "b", "c")) {
+        expect_true(evaluated(rv, id))
+        expect_true(rendered(id))
+      }
+    },
+    args = list(
+      x = board,
+      callbacks = function(visible, ...) {
+        visible("b")
+        NULL
+      }
+    )
+  )
+})

--- a/tests/testthat/test-visibility-gating.R
+++ b/tests/testthat/test-visibility-gating.R
@@ -72,8 +72,8 @@ test_that("with no producer every block is visible", {
     {
       session$flushReact()
 
-      expect_null(rv$visible)
-      expect_null(rv$visible_eval)
+      expect_true(rv$visible)
+      expect_true(rv$eval)
 
       expect_true(evaluated(rv, "a"))
       expect_true(evaluated(rv, "b"))
@@ -109,7 +109,7 @@ test_that("a producer gates evaluation and rendering on visibility", {
       session$flushReact()
 
       expect_setequal(rv$visible, "b")
-      expect_setequal(rv$visible_eval, c("a", "b"))
+      expect_setequal(rv$eval, c("a", "b"))
 
       expect_true(evaluated(rv, "b"))
       expect_true(rendered("b"))


### PR DESCRIPTION
## Summary

- `board_server()` hands the board callback a writable `visible` channel (same shape as `update`), naming the on-screen block IDs. With nothing driving it, every block is treated as visible and behaviour is unchanged.
- Core owns the dependency reasoning: it stores the on-screen set in `rv$visible` and derives `rv$eval` — the visible set plus its upstream closure over `board_links()` — which blocks read through the read-only `board` they already hold. No new block-server argument; the only writable surface is the callback channel, because `board` is read-only to third-party code (as with `update`).
- Each block renders only while visible and evaluates while visible or upstream of a visible block (an off-screen intermediate still feeds its visible descendants but does no rendering). Gating is suspend/resume of the existing eval and render observers, constructed suspended so off-screen blocks do no work on first load and catch up on reveal.
- The `gate_visibility` `blockr_option` (default `TRUE`) is the master switch.

Producer side: BristolMyersSquibb/blockr.dock#195. Follow-up (demand-driven lazy pull so off-screen subtrees go fully quiescent): #204.

Fixes #203.
