### PR TITLE
Key the board reload handoff per tab, not a global slot

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # blockr.core 0.1.3
 
+* The board reload handoff (the `session$reload()` board restore) is keyed per
+  reload rather than via a single process-global slot: the board is staged
+  under a one-time token that rides across the reload in the URL and is
+  resolved per request. Under one shared process (e.g. Posit Connect) a session
+  no longer renders or strands a board staged for another — the root cause of
+  the cross-session board contamination and the associated reload loop. Stale
+  handoff slots are evicted on a TTL (#208).
 * New exported generic `external_ctrl_vars()` (with a `block` method) and
   predicate `has_external_ctrl()` provide a public, polymorphic API for
   resolving a board component's `external_ctrl` declaration into the set of

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -35,7 +35,7 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
                                callback_location = c("end", "start"),
                                ...) {
 
-  reload_meta <- finalize_reload("reload")
+  reload_meta <- finalize_reload(staged_board_key(session_url_query()))
 
   plugins <- as_plugins(plugins)
 
@@ -238,53 +238,22 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
 
       if (not_null(board_refresh)) {
 
-        reload_pending <- reactiveVal(NULL)
+        observeEvent(
+          board_refresh(),
+          {
+            val <- board_refresh()
 
-        observeEvent(board_refresh(), reload_pending(Sys.time()))
-
-        observe({
-
-          pending <- reload_pending()
-          req(pending)
-
-          if (is_reloading("reload")) {
-
-            if (difftime(Sys.time(), pending, units = "secs") >= 60) {
-              log_warn("stale reload state, clearing")
-              finalize_reload("reload")
-              reload_pending(NULL)
-              session$close()
-              return()
+            if (is_board(val)) {
+              board <- val
+              meta <- NULL
+            } else {
+              board <- val$board
+              meta <- val$meta
             }
 
-            notify(
-              "Reload in progress.",
-              duration = NULL,
-              id = session$token
-            )
-            invalidateLater(1000)
-            return()
+            stage_reload_handoff(board, meta, session)
           }
-
-          removeNotification(session$token)
-          reload_pending(NULL)
-
-          val <- isolate(board_refresh())
-
-          if (is_board(val)) {
-            board <- val
-            meta <- NULL
-          } else {
-            board <- val$board
-            meta <- val$meta
-          }
-
-          log_debug("refreshing board")
-          update_serve_obj("reload", board, meta = meta)
-
-          log_debug("reloading session")
-          session$reload()
-        })
+        )
       }
 
       call_plugin_server(

--- a/R/utils-serve.R
+++ b/R/utils-serve.R
@@ -206,13 +206,14 @@ serve_board_ui <- function(id, plugins, options, ...) {
 
   function(req) {
 
-    if (!is_reloading("reload")) {
+    query <- parseQueryString(coal(req$QUERY_STRING, ""))
+    key <- staged_board_key(query)
+
+    if (!is_reloading(key)) {
 
       preload <- get0("preload_fn", envir = serve_obj, inherits = FALSE)
 
       if (not_null(preload)) {
-
-        query <- parseQueryString(coal(req$QUERY_STRING, ""))
 
         result <- validate_preload_result(
           tryCatch(
@@ -225,12 +226,12 @@ serve_board_ui <- function(id, plugins, options, ...) {
         )
 
         if (not_null(result)) {
-          update_serve_obj("reload", result$board, meta = result$meta)
+          update_serve_obj(key, result$board, meta = result$meta)
         }
       }
     }
 
-    x <- get_serve_obj("reload")
+    x <- get_serve_obj(key)
     id <- coal(attr(x, "id"), id)
 
     log_debug("building ui for board {id}")
@@ -250,13 +251,28 @@ serve_board_srv <- function(id, plugins, options, ...) {
 
     onStop(revert(trace_observe()), session)
 
-    x <- get_serve_obj("reload")
+    query <- session_url_query(session)
+    x <- get_serve_obj(staged_board_key(query))
     id <- coal(attr(x, "id"), id)
 
     res <- do.call(
       blockr_app_server,
       c(list(id, x, plugins = plugins(x), options = options(x)), args)
     )
+
+    # `board_server()` consumes the staged slot synchronously above (its
+    # `finalize_reload()` runs during the call). Strip the one-time handoff
+    # token from the address bar only afterwards, so the consume provably
+    # reads the live token rather than racing the (asynchronous, client-side)
+    # `updateQueryString()`.
+    if (not_null(reload_token(query))) {
+      query[[reload_query_param]] <- NULL
+      updateQueryString(
+        query_to_string(query),
+        mode = "replace",
+        session = session
+      )
+    }
 
     blockr_test_exports(x, res)
 
@@ -266,16 +282,28 @@ serve_board_srv <- function(id, plugins, options, ...) {
 
 serve_obj <- new.env()
 
+reload_query_param <- "__blockr_reload__"
+
+reload_handoff_ttl <- 600
+
 update_serve_obj <- function(id, x, meta = NULL) {
-  assign(id, list(board = x, meta = meta), envir = serve_obj)
+
+  assign(
+    id,
+    list(board = x, meta = meta, stamp = Sys.time()),
+    envir = serve_obj
+  )
+
+  sweep_serve_obj()
+
   invisible(x)
 }
 
-is_reloading <- function(id = "reload") {
+is_reloading <- function(id) {
   exists(id, envir = serve_obj, inherits = FALSE)
 }
 
-finalize_reload <- function(id = "reload") {
+finalize_reload <- function(id) {
 
   obj <- get0(id, envir = serve_obj, inherits = FALSE)
 
@@ -285,6 +313,111 @@ finalize_reload <- function(id = "reload") {
 
   rm(list = id, envir = serve_obj, inherits = FALSE)
   invisible(obj$meta)
+}
+
+# Per-load staging slots (`reload-<token>` handoffs and `preload-<query>`
+# request-phase boards) accumulate in the process-global `serve_obj` whenever a
+# session never returns to consume them (cross-process reloads, double
+# restores, tabs closed mid-reload). Evict ones older than the TTL whenever a
+# new slot is staged.
+sweep_serve_obj <- function(ttl = reload_handoff_ttl, now = Sys.time()) {
+
+  for (key in grep("^(reload|preload)-", ls(serve_obj), value = TRUE)) {
+
+    obj <- get0(key, envir = serve_obj, inherits = FALSE)
+
+    expired <- is.list(obj) && not_null(obj$stamp) &&
+      difftime(now, obj$stamp, units = "secs") > ttl
+
+    if (expired) {
+      rm(list = key, envir = serve_obj, inherits = FALSE)
+    }
+  }
+
+  invisible()
+}
+
+reload_token <- function(query) {
+  tok <- query[[reload_query_param]]
+  if (is_string(tok) && nzchar(tok)) tok else NULL
+}
+
+preload_key <- function(query) {
+
+  rest <- query[setdiff(names(query), reload_query_param)]
+
+  if (!length(rest)) {
+    return("preload-")
+  }
+
+  rest <- rest[order(names(rest))]
+
+  paste0(
+    "preload-",
+    paste(names(rest), unlist(rest), sep = "=", collapse = "&")
+  )
+}
+
+staged_board_key <- function(query) {
+
+  tok <- reload_token(query)
+
+  if (not_null(tok)) {
+    key <- paste0("reload-", tok)
+    if (is_reloading(key)) {
+      return(key)
+    }
+  }
+
+  preload_key(query)
+}
+
+session_url_query <- function(session = get_session()) {
+
+  if (is.null(session)) {
+    return(list())
+  }
+
+  parseQueryString(coal(isolate(session$clientData$url_search), ""))
+}
+
+query_to_string <- function(query) {
+
+  if (!length(query)) {
+    return("?")
+  }
+
+  nms <- chr_ply(names(query), utils::URLencode, reserved = TRUE)
+
+  vals <- chr_ply(
+    unlist(query, use.names = FALSE),
+    utils::URLencode,
+    reserved = TRUE
+  )
+
+  paste0("?", paste(nms, vals, sep = "=", collapse = "&"))
+}
+
+stage_reload_handoff <- function(board, meta, session) {
+
+  token <- rand_names()
+
+  update_serve_obj(paste0("reload-", token), board, meta = meta)
+
+  query <- session_url_query(session)
+  query[[reload_query_param]] <- token
+
+  log_debug("staging board for reload handoff {token}")
+
+  updateQueryString(
+    query_to_string(query),
+    mode = "replace",
+    session = session
+  )
+
+  session$reload()
+
+  invisible(token)
 }
 
 validate_preload_result <- function(x) {

--- a/tests/testthat/apps/reload-handoff/app.R
+++ b/tests/testthat/apps/reload-handoff/app.R
@@ -1,0 +1,42 @@
+library(blockr.core)
+
+# Fixture for the positive per-tab handoff (see test-reload-isolation.R).
+#
+# Just before reloading, the board server stages the next board under a
+# per-tab token (`reload-<token>`) and stamps that token into the URL. Here we
+# stage such a slot on demand: when REPRO_PLANT names an existing file, its
+# contents are the token, and we stage a "restored" board under
+# `reload-<token>` exactly as the producer does. The harness then connects the
+# returning session with the token in its URL (it must land on the staged
+# board) and a fresh session without it (it must not).
+
+plant_file <- Sys.getenv("REPRO_PLANT", "")
+core_ns <- asNamespace("blockr.core")
+
+stage_token_board <- function() {
+
+  if (!nzchar(plant_file) || !file.exists(plant_file)) {
+    return(invisible())
+  }
+
+  token <- tryCatch(readLines(plant_file, warn = FALSE)[1L],
+                    error = function(e) "")
+  unlink(plant_file)
+
+  if (length(token) && nzchar(token)) {
+    board <- new_board(blocks = c(restored = new_dataset_block("BOD")))
+    get("update_serve_obj", core_ns)(paste0("reload-", token), board)
+  }
+
+  invisible()
+}
+
+poll <- function() {
+
+  stage_token_board()
+  later::later(poll, 0.2)
+}
+
+poll()
+
+serve(new_board(blocks = c(initmark = new_dataset_block("iris"))), id = "brd")

--- a/tests/testthat/apps/reload-repro/app.R
+++ b/tests/testthat/apps/reload-repro/app.R
@@ -1,0 +1,45 @@
+library(blockr.core)
+
+# Fixture for the legacy-slot guard (see test-reload-isolation.R).
+#
+# The old design staged the next board in a single process-global "reload"
+# slot that the next session to boot board_server() consumed unconditionally,
+# so under one shared process an unrelated session could read a board staged
+# for someone else.
+#
+# Here we plant a board in that legacy shared "reload" slot on behalf of a
+# session that never returns: when REPRO_PLANT names an existing file, its
+# contents pick a dataset and we stage a board built from it. The harness then
+# connects an unrelated session, which must resolve its own board — the
+# per-tab handoff never reads the legacy shared slot.
+
+plant_file <- Sys.getenv("REPRO_PLANT", "")
+core_ns <- asNamespace("blockr.core")
+
+stage_pending_board <- function() {
+
+  if (!nzchar(plant_file) || !file.exists(plant_file)) {
+    return(invisible())
+  }
+
+  dataset <- tryCatch(readLines(plant_file, warn = FALSE)[1L],
+                      error = function(e) "")
+  unlink(plant_file)
+
+  if (length(dataset) && nzchar(dataset)) {
+    board <- new_board(blocks = c(stolen = new_dataset_block(dataset)))
+    get("update_serve_obj", core_ns)("reload", board)
+  }
+
+  invisible()
+}
+
+poll <- function() {
+
+  stage_pending_board()
+  later::later(poll, 0.2)
+}
+
+poll()
+
+serve(new_board(blocks = c(initmark = new_dataset_block("iris"))), id = "brd")

--- a/tests/testthat/test-reload-isolation.R
+++ b/tests/testthat/test-reload-isolation.R
@@ -1,0 +1,236 @@
+# Guards the cross-session reload handoff.
+#
+# A board restore stages the next board in `serve_obj`, then calls
+# session$reload(). The returning session picks the staged board back up. The
+# staged board is keyed per reload handoff (`reload-<token>`, where the token
+# rides across the boundary in the URL) rather than in a single shared "reload"
+# slot, so under one shared process (Posit Connect) an unrelated session can no
+# longer read or consume a board staged for someone else.
+#
+# `staged_board_key()` is the resolution both the request-phase UI and the
+# server use: a query carrying a live reload token resolves that token's slot,
+# anything else resolves a request-phase preload slot (falling back to the
+# initial board).
+
+test_that("a reload board is keyed per token, hidden from other tabs", {
+
+  update_serve_obj(
+    "initial",
+    new_board(blocks = c(initmark = new_dataset_block("iris")))
+  )
+
+  update_serve_obj(
+    "reload-owner",
+    new_board(blocks = c(restored_a = new_dataset_block("BOD")))
+  )
+
+  withr::defer(
+    if (is_reloading("reload-owner")) finalize_reload("reload-owner")
+  )
+
+  owner     <- list(`__blockr_reload__` = "owner")
+  bystander <- list()
+  intruder  <- list(`__blockr_reload__` = "intruder")
+
+  resolved <- function(q) board_block_ids(get_serve_obj(staged_board_key(q)))
+
+  expect_identical(staged_board_key(owner), "reload-owner")
+  expect_identical(resolved(owner), "restored_a")
+
+  expect_false("restored_a" %in% resolved(bystander))
+  expect_false("restored_a" %in% resolved(intruder))
+})
+
+test_that("a bystander session does not strand the owner's staged board", {
+
+  update_serve_obj(
+    "initial",
+    new_board(blocks = c(initmark = new_dataset_block("iris")))
+  )
+
+  update_serve_obj(
+    "reload-owner",
+    new_board(blocks = c(restored_a = new_dataset_block("BOD")))
+  )
+
+  withr::defer(
+    if (is_reloading("reload-owner")) finalize_reload("reload-owner")
+  )
+
+  finalize_reload(staged_board_key(list()))
+
+  expect_true(is_reloading("reload-owner"))
+  expect_identical(board_block_ids(get_serve_obj("reload-owner")), "restored_a")
+})
+
+test_that("a stale reload token falls through to the request-phase preload", {
+
+  expect_identical(staged_board_key(list()), "preload-")
+  expect_identical(
+    staged_board_key(list(board_name = "Foo")),
+    "preload-board_name=Foo"
+  )
+
+  # a token whose slot was already consumed resolves the preload key, not a
+  # dead reload slot
+  expect_false(is_reloading("reload-gone"))
+  expect_identical(
+    staged_board_key(list(board_name = "Foo", `__blockr_reload__` = "gone")),
+    "preload-board_name=Foo"
+  )
+})
+
+test_that("the reload token round-trips through the URL and strips cleanly", {
+
+  expect_null(reload_token(list()))
+  expect_null(reload_token(list(board_name = "Foo")))
+  expect_identical(reload_token(list(`__blockr_reload__` = "tok")), "tok")
+
+  query <- list(board_name = "My Board", `__blockr_reload__` = "tok")
+  parsed <- parseQueryString(query_to_string(query))
+
+  expect_identical(parsed$board_name, "My Board")
+  expect_identical(reload_token(parsed), "tok")
+
+  query[[reload_query_param]] <- NULL
+  expect_false(grepl("__blockr_reload__", query_to_string(query), fixed = TRUE))
+  expect_match(query_to_string(query), "board_name=My%20Board", fixed = TRUE)
+})
+
+test_that("staging a handoff slot sweeps stale ones, keeps fresh and initial", {
+
+  update_serve_obj(
+    "initial",
+    new_board(blocks = c(initmark = new_dataset_block("iris")))
+  )
+
+  serve_obj[["reload-stale"]] <- list(
+    board = new_board(blocks = c(b = new_dataset_block("BOD"))),
+    meta = NULL,
+    stamp = Sys.time() - 10 * reload_handoff_ttl
+  )
+  withr::defer(
+    if (is_reloading("reload-stale")) finalize_reload("reload-stale")
+  )
+
+  # staging a fresh slot triggers the TTL sweep of expired ones
+  update_serve_obj(
+    "reload-fresh",
+    new_board(blocks = c(a = new_dataset_block("BOD")))
+  )
+  withr::defer(
+    if (is_reloading("reload-fresh")) finalize_reload("reload-fresh")
+  )
+
+  expect_false(is_reloading("reload-stale"))
+  expect_true(is_reloading("reload-fresh"))
+  expect_true(is_reloading("initial"))
+})
+
+test_that("stage_reload_handoff stages a token slot carrying board and meta", {
+
+  session <- new_mock_session()
+  withr::defer(if (!session$isClosed()) session$close())
+
+  board <- new_board(blocks = c(restored = new_dataset_block("BOD")))
+  token <- stage_reload_handoff(board, list(url = "?board_name=Foo"), session)
+
+  slot <- paste0("reload-", token)
+  withr::defer(if (is_reloading(slot)) finalize_reload(slot))
+
+  expect_true(is_reloading(slot))
+  expect_identical(board_block_ids(get_serve_obj(slot)), "restored")
+  expect_identical(finalize_reload(slot)$url, "?board_name=Foo")
+})
+
+rendered_block_ids <- function(app, ns = "brd") {
+
+  html <- xml2::read_html(app$get_html("body"))
+  ids <- xml2::xml_attr(xml2::xml_find_all(html, "//*[@id]"), "id")
+
+  hits <- grep(paste0("^", ns, "-block_[^-]+-"), ids, value = TRUE)
+
+  unique(sub(paste0("^", ns, "-block_([^-]+)-.*$"), "\\1", hits))
+}
+
+test_that("a legacy shared 'reload' slot is never read by a fresh session", {
+
+  skip_on_cran()
+  skip_if_not_installed("shinytest2")
+  skip_if_not_installed("xml2")
+
+  plant <- withr::local_tempfile(fileext = ".cmd")
+  withr::local_envvar(REPRO_PLANT = plant)
+
+  owner <- try(
+    shinytest2::AppDriver$new(
+      test_path("apps", "reload-repro"),
+      name = "reload-legacy-owner",
+      load_timeout = 30 * 1000
+    )
+  )
+
+  skip_if(inherits(owner, "try-error"), "Cannot start reload-repro app.")
+  withr::defer(owner$stop())
+
+  expect_setequal(rendered_block_ids(owner), "initmark")
+
+  writeLines("BOD", plant)
+  Sys.sleep(1)
+
+  bystander <- shinytest2::AppDriver$new(
+    owner$get_url(),
+    name = "reload-legacy-bystander",
+    load_timeout = 30 * 1000
+  )
+
+  withr::defer(bystander$stop())
+
+  expect_false("stolen" %in% rendered_block_ids(bystander))
+})
+
+test_that("a returning session lands on its own board, a fresh one does not", {
+
+  skip_on_cran()
+  skip_if_not_installed("shinytest2")
+  skip_if_not_installed("xml2")
+
+  plant <- withr::local_tempfile(fileext = ".cmd")
+  withr::local_envvar(REPRO_PLANT = plant)
+
+  app <- try(
+    shinytest2::AppDriver$new(
+      test_path("apps", "reload-handoff"),
+      name = "reload-handoff-app",
+      load_timeout = 30 * 1000
+    )
+  )
+
+  skip_if(inherits(app, "try-error"), "Cannot start reload-handoff app.")
+  withr::defer(app$stop())
+
+  expect_setequal(rendered_block_ids(app), "initmark")
+  base <- app$get_url()
+
+  # the producer stages a board under this tab's token just before reloading
+  writeLines("ownsess", plant)
+  Sys.sleep(1)
+
+  # a concurrent fresh session (no token) ignores the staged slot
+  fresh <- shinytest2::AppDriver$new(
+    base,
+    name = "reload-handoff-fresh",
+    load_timeout = 30 * 1000
+  )
+  withr::defer(fresh$stop())
+  expect_setequal(rendered_block_ids(fresh), "initmark")
+
+  # the returning session (its token in the URL) lands on its own board
+  returning <- shinytest2::AppDriver$new(
+    paste0(base, "?__blockr_reload__=ownsess"),
+    name = "reload-handoff-return",
+    load_timeout = 30 * 1000
+  )
+  withr::defer(returning$stop())
+  expect_setequal(rendered_block_ids(returning), "restored")
+})


### PR DESCRIPTION
## Summary

- A `session$reload()` board restore staged the next board in a single process-global slot (`serve_obj$reload`), consumed unconditionally by whichever session booted `board_server()` next. With no stable id across the reload boundary, under one shared process (e.g. Posit Connect) an unrelated session could render or strand a board staged for someone else — the cross-session contamination, and the chained-reload loop when the stranded slot's `meta` misfired blockr.session's anti-loop guard.
- The board is now staged under a one-time, per-reload token. `stage_reload_handoff()` mints a token, stages it under `reload-<token>`, stamps `?__blockr_reload__=<token>` into the URL (additive `updateQueryString(..., "replace")`) and reloads. Both the request-phase UI (from `req$QUERY_STRING`) and the server (from `session$clientData$url_search`, available synchronously) resolve it via a shared `staged_board_key()`, so each returning session picks up exactly its own board; the token is stripped from the address bar after the consume. The request-phase preload from #153 moves to a per-query key in the same step, so no path reads a shared slot.
- Stale handoff / preload slots (cross-process reloads, double restores, tabs closed mid-reload) are swept on a TTL when a new slot is staged — this replaces the global `is_reloading` gate and 60s stale-close the PR removes.

This is approach 1 from the issue (the one-time URL handoff token). I did not add the sessionStorage tab id: `sessionStorage` is unreadable at the GET that builds the UI, so the URL token carries the handoff regardless, and a server-minted per-reload token already gives each returning session its own slot. The server reads `session$clientData$url_search` synchronously at the top of the server function, so the board resolves at request time with no bounce page or deferred render (approaches 2/3). Glad to layer a stable per-tab id on top if you want one for something beyond this handoff.

### URL-param contract with blockr.session

The token write here is additive — a read-modify-write that preserves other params, with the token namespaced as `__blockr_reload__`. blockr.session, by contrast, writes the URL destructively: `board_query_string()` rebuilds the query from `board_name`/`user`/`version` only, and `manage_project_server`'s `new_btn` handler clears it to `"?"` (`server.R:149`), so it would drop `__blockr_reload__`. This is safe today only by ordering — blockr.session sets `board_name` and fires the restore, then this producer appends the token and reloads with no blockr.session write in between — and by the token being ephemeral (consumed and stripped on the next load). Tracked as a follow-up to make the contract robust (additive writes, or a reserved `__blockr_*` namespace every writer preserves): BristolMyersSquibb/blockr.session#53.

The loop fix here is the *root cause* — correct per-tab `meta` delivery. It is verified by reading `manage_project_server`'s token-insensitive guard (it rebuilds the canonical URL from `board_name`/`user`/`version` and compares that to `prev_query`, so `__blockr_reload__` cannot trigger a spurious restore); end-to-end loop validation belongs downstream in blockr.session and is noted in the follow-up.

Stacked on #153 (base `153-double-load`); it extends that PR's request-phase resolution and they land together. CI gates on a `main` base, so checks stay idle until the base retargets to `main` after #153 merges — validated locally meanwhile (full suite green; the repro file is proven red on the unfixed base and green with the fix).

Fixes #208
