### PR TITLE
Rework notify_user per-block and extend the notify() API

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,14 @@
   O(N) rather than O(N^2) cost when a condition cascade touches many
   blocks on a large board. `board$conditions()` is unchanged for
   programmatic consumers (#222).
+* `notify()` gains `glue` and `log` arguments (both `TRUE` by default, so
+  existing behaviour is unchanged). `glue = FALSE` surfaces literal text
+  without [cli::pluralize()] interpolation — so caught condition messages
+  containing brace characters no longer error — and `log = FALSE` skips
+  the log entry for already-logged text. The board update, link and stack
+  error toasts now pass condition messages through with `glue = FALSE`,
+  and the default `notify_user()` plugin renders through `notify()`
+  (#222).
 * Active block conditions (errors, warnings and messages captured during
   evaluation) are now emitted as tidy data frames. Each block server
   returns its conditions as a reactive `server$conditions` (one row per

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # blockr.core 0.1.3
 
+* The default `notify_user()` plugin now tracks each block's conditions
+  individually rather than re-deriving the whole board's condition frame
+  on every change. A single block's condition change updates only the
+  notifications it affects, restoring O(block)-per-change work and an
+  O(N) rather than O(N^2) cost when a condition cascade touches many
+  blocks on a large board. `board$conditions()` is unchanged for
+  programmatic consumers (#222).
 * Active block conditions (errors, warnings and messages captured during
   evaluation) are now emitted as tidy data frames. Each block server
   returns its conditions as a reactive `server$conditions` (one row per
@@ -9,7 +16,7 @@
   callbacks. A consumer reads one reactive — a single block's frame for
   fine-grained updates, or the whole board — instead of walking the
   nested per-block condition state, and the default `notify_user()`
-  plugin renders toasts from this single source. The block server no
+  plugin surfaces them to the user as toasts. The block server no
   longer returns its raw `cond` reactive values object — read
   `server$conditions()` instead (#217).
 * `str_value()` now covers every domain class that has a full-tier

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -191,7 +191,8 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
             },
             error = function(e) {
               log_warn("board update rejected: {conditionMessage(e)}")
-              notify(conditionMessage(e), type = "error", session = session)
+              notify(conditionMessage(e), type = "error", glue = FALSE,
+                     session = session)
               record_update_outcome(FALSE, "validate", conditionMessage(e))
               board_update(NULL)
             }
@@ -233,7 +234,8 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
             },
             error = function(e) {
               log_warn("apply_board_update failed: {conditionMessage(e)}")
-              notify(conditionMessage(e), type = "error", session = session)
+              notify(conditionMessage(e), type = "error", glue = FALSE,
+                     session = session)
               record_update_outcome(FALSE, "apply", conditionMessage(e))
             }
           )
@@ -283,7 +285,7 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
             return()
           }
 
-          removeNotification(session$token)
+          notify_remove(session$token)
           reload_pending(NULL)
 
           val <- isolate(board_refresh())

--- a/R/plugin-control.R
+++ b/R/plugin-control.R
@@ -75,7 +75,7 @@ ctrl_block_server <- function(id, x, vars, data, eval) {
             err <- attr(result, "condition")
 
             if (!inherits(err, "shiny.silent.error")) {
-              notify(conditionMessage(err), type = "error")
+              notify(conditionMessage(err), type = "error", glue = FALSE)
             }
 
             gate(FALSE)

--- a/R/plugin-links.R
+++ b/R/plugin-links.R
@@ -504,15 +504,15 @@ modify_link_observer <- function(input, rv, upd, session, proxy, res) {
         modify_board_links(rv$board, upd$add, upd$rm),
         message = function(e) {
           notify(conditionMessage(e), duration = NULL, type = "message",
-                 session = session)
+                 glue = FALSE, session = session)
         },
         warning = function(e) {
           notify(conditionMessage(e), duration = NULL, type = "warning",
-                 session = session)
+                 glue = FALSE, session = session)
         },
         error = function(e) {
           notify(conditionMessage(e), duration = NULL, type = "error",
-                 session = session)
+                 glue = FALSE, session = session)
           NULL
         }
       )

--- a/R/plugin-notification.R
+++ b/R/plugin-notification.R
@@ -85,7 +85,7 @@ block_notif_observer <- function(block_id, board, session) {
       frame <- notif_frame(conditions(), session)
 
       for (key in setdiff(shown, frame$key)) {
-        removeNotification(key, session)
+        notify_remove(key, session)
       }
 
       for (key in setdiff(frame$key, shown)) {
@@ -103,7 +103,7 @@ block_notif_observer <- function(block_id, board, session) {
       obs$destroy()
 
       for (key in shown) {
-        removeNotification(key, session)
+        notify_remove(key, session)
       }
     }
   )
@@ -129,10 +129,10 @@ notif_frame <- function(conditions, session = get_session()) {
 }
 
 notif_show <- function(key, row, session) {
-  showNotification(
-    HTML(
-      paste0("Block ", row$block, ": ", cli::ansi_html(row$message))
-    ),
+  notify(
+    "Block ", row$block, ": ", row$message,
+    glue = FALSE,
+    log = FALSE,
     duration = NULL,
     id = key,
     type = row$severity,

--- a/R/plugin-notification.R
+++ b/R/plugin-notification.R
@@ -4,10 +4,9 @@
 #' messages) may be raised. The default `notify_user` plugin surfaces these to
 #' the user as [shiny::showNotification()] toasts, displaying newly active
 #' conditions and clearing ones that are no longer active via
-#' [shiny::removeNotification()]. It renders from `board$conditions()` (see
-#' [board_server()]), the board-level reactive frame of active conditions, so
-#' that toast display and any programmatic consumer share a single processed
-#' view rather than each walking per-block condition state.
+#' [shiny::removeNotification()]. Each block's conditions (see [board_server()])
+#' are tracked individually, so that a single block's change touches only its
+#' own notifications rather than re-processing the whole board.
 #'
 #' @param server,ui Server/UI for the plugin module
 #'
@@ -33,15 +32,16 @@ notify_user_server <- function(id, board, ...) {
     id,
     function(input, output, session) {
 
-      shown <- reactiveVal(character())
+      tracked <- new.env(parent = emptyenv())
 
-      observeEvent(
-        board$conditions(),
-        shown(
-          update_condition_notif(board$conditions(), shown(), session)
-        ),
-        ignoreNULL = FALSE
-      )
+      observe({
+
+        ids <- names(board$blocks)
+
+        isolate(
+          sync_block_notifs(ids, tracked, board, session)
+        )
+      })
 
       invisible()
     }
@@ -58,8 +58,58 @@ notify_user_ui <- function(id, board) {
   )
 }
 
-update_condition_notif <- function(conditions, shown,
-                                   session = get_session()) {
+sync_block_notifs <- function(ids, tracked, board, session) {
+
+  for (id in setdiff(ids, ls(tracked))) {
+    tracked[[id]] <- block_notif_observer(id, board, session)
+  }
+
+  for (id in setdiff(ls(tracked), ids)) {
+
+    tracked[[id]]$destroy()
+    rm(list = id, envir = tracked)
+  }
+
+  invisible()
+}
+
+block_notif_observer <- function(block_id, board, session) {
+
+  conditions <- isolate(board$blocks[[block_id]]$server$conditions)
+
+  shown <- character()
+
+  obs <- observeEvent(
+    conditions(),
+    {
+      frame <- notif_frame(conditions(), session)
+
+      for (key in setdiff(shown, frame$key)) {
+        removeNotification(key, session)
+      }
+
+      for (key in setdiff(frame$key, shown)) {
+        notif_show(key, frame[frame$key == key, , drop = FALSE], session)
+      }
+
+      shown <<- frame$key
+    },
+    ignoreNULL = FALSE
+  )
+
+  list(
+    destroy = function() {
+
+      obs$destroy()
+
+      for (key in shown) {
+        removeNotification(key, session)
+      }
+    }
+  )
+}
+
+notif_frame <- function(conditions, session = get_session()) {
 
   cnds <- coal(
     isolate(
@@ -70,36 +120,22 @@ update_condition_notif <- function(conditions, shown,
 
   conditions <- conditions[conditions$severity %in% cnds, , drop = FALSE]
 
-  ids <- paste(conditions$severity, conditions$id, sep = "-")
-  keep <- which(!duplicated(ids))
+  conditions$key <- paste(
+    conditions$block, conditions$severity, conditions$id,
+    sep = "-"
+  )
 
-  cur <- character()
+  conditions[!duplicated(conditions$key), , drop = FALSE]
+}
 
-  for (i in keep) {
-
-    id <- ids[i]
-
-    if (!id %in% shown) {
-      showNotification(
-        HTML(
-          paste0(
-            "Block ", conditions$block[i], ": ",
-            cli::ansi_html(conditions$message[i])
-          )
-        ),
-        duration = NULL,
-        id = id,
-        type = conditions$severity[i],
-        session = session
-      )
-    }
-
-    cur <- c(cur, id)
-  }
-
-  for (id in setdiff(shown, cur)) {
-    removeNotification(id, session)
-  }
-
-  cur
+notif_show <- function(key, row, session) {
+  showNotification(
+    HTML(
+      paste0("Block ", row$block, ": ", cli::ansi_html(row$message))
+    ),
+    duration = NULL,
+    id = key,
+    type = row$severity,
+    session = session
+  )
 }

--- a/R/plugin-stacks.R
+++ b/R/plugin-stacks.R
@@ -469,15 +469,15 @@ modify_stack_observer <- function(input, rv, upd, sess, proxy, res) {
         modify_board_stacks(rv$board, upd$add, upd$rm, upd$mod),
         message = function(e) {
           notify(conditionMessage(e), duration = NULL, type = "message",
-                 session = sess)
+                 glue = FALSE, session = sess)
         },
         warning = function(e) {
           notify(conditionMessage(e), duration = NULL, type = "warning",
-                 session = sess)
+                 glue = FALSE, session = sess)
         },
         error = function(e) {
           notify(conditionMessage(e), duration = NULL, type = "error",
-                 session = sess)
+                 glue = FALSE, session = sess)
           NULL
         }
       )

--- a/R/utils-shiny.R
+++ b/R/utils-shiny.R
@@ -256,6 +256,10 @@ get_session <- function() {
 }
 
 #' @param close_button Passed as `closeButton` to [shiny::showNotification()]
+#' @param glue,log Whether to [glue::glue()]-interpolate `...` and whether to
+#' emit a log message. Set both to `FALSE` to surface pre-formatted,
+#' already-logged text (e.g. a captured condition message, which may contain
+#' braces that would otherwise fail interpolation).
 #'
 #' @inheritParams write_log
 #' @inheritParams shiny::showNotification
@@ -265,11 +269,11 @@ get_session <- function() {
 notify <- function(..., envir = parent.frame(), action = NULL, duration = 5,
                    close_button = TRUE, id = NULL,
                    type = c("message", "warning", "error"),
-                   session = get_session()) {
+                   glue = TRUE, log = TRUE, session = get_session()) {
 
   type <- match.arg(type)
 
-  msg <- glue_plur(..., envir = envir)
+  msg <- if (glue) glue_plur(..., envir = envir) else paste0(...)
   msg <- HTML(cli::ansi_html(msg))
 
   showNotification(
@@ -282,12 +286,18 @@ notify <- function(..., envir = parent.frame(), action = NULL, duration = 5,
     session = session
   )
 
-  switch(
-    type,
-    message = log_info(msg, envir = envir, use_glue = FALSE),
-    warning = log_warn(msg, envir = envir, use_glue = FALSE),
-    error = log_error(msg, envir = envir, use_glue = FALSE)
-  )
+  if (log) {
+    switch(
+      type,
+      message = log_info(msg, envir = envir, use_glue = FALSE),
+      warning = log_warn(msg, envir = envir, use_glue = FALSE),
+      error = log_error(msg, envir = envir, use_glue = FALSE)
+    )
+  }
 
   invisible(NULL)
+}
+
+notify_remove <- function(id, session = get_session()) {
+  removeNotification(id, session = session)
 }

--- a/man/get_session.Rd
+++ b/man/get_session.Rd
@@ -15,6 +15,8 @@ notify(
   close_button = TRUE,
   id = NULL,
   type = c("message", "warning", "error"),
+  glue = TRUE,
+  log = TRUE,
   session = get_session()
 )
 }
@@ -44,6 +46,11 @@ notification if it exists, otherwise it will create a new one.
 
 \item{type}{A string which controls the color of the notification. One of
 "default" (gray), "message" (blue), "warning" (yellow), or "error" (red).}
+
+\item{glue, log}{Whether to \code{\link[glue:glue]{glue::glue()}}-interpolate \code{...} and whether to
+emit a log message. Set both to \code{FALSE} to surface pre-formatted,
+already-logged text (e.g. a captured condition message, which may contain
+braces that would otherwise fail interpolation).}
 
 \item{session}{Session object to send notification to.}
 }

--- a/man/notify_user.Rd
+++ b/man/notify_user.Rd
@@ -33,8 +33,7 @@ During the evaluation cycle of each block, conditions (errors, warnings and
 messages) may be raised. The default \code{notify_user} plugin surfaces these to
 the user as \code{\link[shiny:showNotification]{shiny::showNotification()}} toasts, displaying newly active
 conditions and clearing ones that are no longer active via
-\code{\link[shiny:showNotification]{shiny::removeNotification()}}. It renders from \code{board$conditions()} (see
-\code{\link[=board_server]{board_server()}}), the board-level reactive frame of active conditions, so
-that toast display and any programmatic consumer share a single processed
-view rather than each walking per-block condition state.
+\code{\link[shiny:showNotification]{shiny::removeNotification()}}. Each block's conditions (see \code{\link[=board_server]{board_server()}})
+are tracked individually, so that a single block's change touches only its
+own notifications rather than re-processing the whole board.
 }

--- a/tests/testthat/test-plugin-notification.R
+++ b/tests/testthat/test-plugin-notification.R
@@ -1,89 +1,249 @@
-test_that("notify_user tracks board$conditions()", {
+cnd_row <- function(block, severity, id, message = "m", phase = "eval") {
+  data.frame(
+    block = block,
+    phase = phase,
+    severity = severity,
+    message = message,
+    id = id
+  )
+}
+
+record_notifications <- function() {
+  rec <- new.env(parent = emptyenv())
+  rec$events <- character()
+  rec
+}
+
+test_that("notify_user shows and clears conditions per block", {
+
+  rec <- record_notifications()
+
+  local_mocked_bindings(
+    showNotification = function(ui, ..., id = NULL, session = NULL) {
+      rec$events <- c(rec$events, paste0("show:", id))
+      id
+    },
+    removeNotification = function(id, session = NULL) {
+      rec$events <- c(rec$events, paste0("remove:", id))
+      invisible()
+    }
+  )
+
+  cond_a <- reactiveVal(empty_conditions_frame())
+
+  board <- reactiveValues(
+    blocks = list(a = list(server = list(conditions = cond_a)))
+  )
 
   testServer(
     notify_user_server,
     {
-      expect_null(session$returned)
-
       session$flushReact()
-      expect_identical(shown(), character())
+      expect_identical(rec$events, character())
 
-      board$conditions(
-        data.frame(
-          block = "a",
-          phase = "eval",
-          severity = "error",
-          message = "some error",
-          id = "id1"
-        )
-      )
-
+      cond_a(cnd_row("a", "error", "e1", "boom"))
       session$flushReact()
+      expect_identical(rec$events, "show:a-error-e1")
 
-      expect_identical(shown(), "error-id1")
-
-      board$conditions(empty_conditions_frame())
-
+      cond_a(empty_conditions_frame())
       session$flushReact()
+      expect_identical(rec$events, c("show:a-error-e1", "remove:a-error-e1"))
 
-      expect_identical(shown(), character())
       expect_null(session$returned)
     },
-    args = list(
-      board = reactiveValues(
-        conditions = reactiveVal(empty_conditions_frame())
-      )
-    )
+    args = list(board = board)
   )
 })
 
-test_that("update_condition_notif gates and de-duplicates", {
+test_that("notify_user shows a separate toast per block for a shared message", {
+
+  rec <- record_notifications()
+
+  local_mocked_bindings(
+    showNotification = function(ui, ..., id = NULL, session = NULL) {
+      rec$events <- c(rec$events, paste0("show:", id))
+      id
+    },
+    removeNotification = function(id, session = NULL) {
+      rec$events <- c(rec$events, paste0("remove:", id))
+      invisible()
+    }
+  )
+
+  cond_a <- reactiveVal(empty_conditions_frame())
+  cond_b <- reactiveVal(empty_conditions_frame())
+
+  board <- reactiveValues(
+    blocks = list(
+      a = list(server = list(conditions = cond_a)),
+      b = list(server = list(conditions = cond_b))
+    )
+  )
+
+  testServer(
+    notify_user_server,
+    {
+      session$flushReact()
+
+      cond_a(cnd_row("a", "error", "e1", "boom"))
+      session$flushReact()
+
+      cond_b(cnd_row("b", "error", "e1", "boom"))
+      session$flushReact()
+
+      expect_identical(rec$events, c("show:a-error-e1", "show:b-error-e1"))
+
+      cond_a(empty_conditions_frame())
+      session$flushReact()
+
+      expect_identical(
+        rec$events,
+        c("show:a-error-e1", "show:b-error-e1", "remove:a-error-e1")
+      )
+    },
+    args = list(board = board)
+  )
+})
+
+test_that("notify_user clears notifications of a removed block", {
+
+  rec <- record_notifications()
+
+  local_mocked_bindings(
+    showNotification = function(ui, ..., id = NULL, session = NULL) {
+      rec$events <- c(rec$events, paste0("show:", id))
+      id
+    },
+    removeNotification = function(id, session = NULL) {
+      rec$events <- c(rec$events, paste0("remove:", id))
+      invisible()
+    }
+  )
+
+  cond_a <- reactiveVal(cnd_row("a", "error", "ea", "boom"))
+  cond_b <- reactiveVal(cnd_row("b", "warning", "wb", "careful"))
+
+  board <- reactiveValues(
+    blocks = list(
+      a = list(server = list(conditions = cond_a)),
+      b = list(server = list(conditions = cond_b))
+    )
+  )
+
+  testServer(
+    notify_user_server,
+    {
+      session$flushReact()
+      expect_setequal(rec$events, c("show:a-error-ea", "show:b-warning-wb"))
+
+      rec$events <- character()
+
+      board$blocks <- board$blocks["a"]
+      session$flushReact()
+
+      expect_identical(rec$events, "remove:b-warning-wb")
+    },
+    args = list(board = board)
+  )
+})
+
+test_that("notify_user reads only the changed block's conditions", {
+
+  local_mocked_bindings(
+    showNotification = function(ui, ..., id = NULL, session = NULL) id,
+    removeNotification = function(id, session = NULL) invisible()
+  )
+
+  reads <- new.env(parent = emptyenv())
+  reads$a <- 0L
+  reads$b <- 0L
+
+  val_a <- reactiveVal(empty_conditions_frame())
+  val_b <- reactiveVal(cnd_row("b", "error", "eb", "B"))
+
+  cond_a <- function() {
+    reads$a <- reads$a + 1L
+    val_a()
+  }
+
+  cond_b <- function() {
+    reads$b <- reads$b + 1L
+    val_b()
+  }
+
+  board <- reactiveValues(
+    blocks = list(
+      a = list(server = list(conditions = cond_a)),
+      b = list(server = list(conditions = cond_b))
+    )
+  )
+
+  testServer(
+    notify_user_server,
+    {
+      session$flushReact()
+
+      reads_a <- reads$a
+      reads_b <- reads$b
+
+      for (i in seq_len(5L)) {
+        val_a(cnd_row("a", "error", paste0("ea", i), "A"))
+        session$flushReact()
+      }
+
+      expect_gt(reads$a, reads_a)
+      expect_identical(reads$b, reads_b)
+    },
+    args = list(board = board)
+  )
+})
+
+test_that("notif_frame gates by show_conditions", {
+
+  frame <- rbind(
+    cnd_row("a", "error", "e1", "boom"),
+    cnd_row("b", "warning", "w1", "careful"),
+    cnd_row("c", "message", "m1", "fyi")
+  )
 
   with_mock_session(
     {
-      df <- data.frame(
-        block = c("a", "b", "c"),
-        phase = c("eval", "render", "data"),
-        severity = c("error", "warning", "message"),
-        message = c("boom", "careful", "fyi"),
-        id = c("e1", "w1", "m1")
-      )
-
-      shown <- withr::with_options(
+      gated <- withr::with_options(
         list(blockr.show_conditions = c("warning", "error")),
-        update_condition_notif(df, character(), session)
+        notif_frame(frame, session)
       )
 
-      expect_setequal(shown, c("error-e1", "warning-w1"))
+      expect_setequal(gated$key, c("a-error-e1", "b-warning-w1"))
 
-      shown <- withr::with_options(
+      full <- withr::with_options(
         list(blockr.show_conditions = c("message", "warning", "error")),
-        update_condition_notif(df, shown, session)
+        notif_frame(frame, session)
       )
 
-      expect_setequal(shown, c("error-e1", "warning-w1", "message-m1"))
-
-      dup <- data.frame(
-        block = c("a", "b"),
-        phase = c("eval", "render"),
-        severity = c("error", "error"),
-        message = c("boom", "boom"),
-        id = c("e1", "e1")
+      expect_setequal(
+        full$key,
+        c("a-error-e1", "b-warning-w1", "c-message-m1")
       )
+    }
+  )
+})
 
-      shown <- withr::with_options(
+test_that("notif_frame collapses a block's duplicate keys to one row", {
+
+  dup <- rbind(
+    cnd_row("a", "error", "e1", "boom"),
+    cnd_row("a", "error", "e1", "boom", phase = "render")
+  )
+
+  with_mock_session(
+    {
+      res <- withr::with_options(
         list(blockr.show_conditions = c("warning", "error")),
-        update_condition_notif(dup, character(), session)
+        notif_frame(dup, session)
       )
 
-      expect_identical(shown, "error-e1")
-
-      shown <- withr::with_options(
-        list(blockr.show_conditions = c("warning", "error")),
-        update_condition_notif(empty_conditions_frame(), shown, session)
-      )
-
-      expect_identical(shown, character())
+      expect_identical(nrow(res), 1L)
+      expect_identical(res$key, "a-error-e1")
     }
   )
 })

--- a/tests/testthat/test-utils-shiny.R
+++ b/tests/testthat/test-utils-shiny.R
@@ -48,3 +48,79 @@ test_that("shiny utils", {
   expect_false(trace_observe())
   expect_true(untrace_observe())
 })
+
+test_that("notify(glue = FALSE) surfaces literal text with braces", {
+
+  shown <- NULL
+
+  local_mocked_bindings(
+    showNotification = function(ui, ...) {
+      shown <<- as.character(ui)
+      invisible()
+    }
+  )
+
+  with_mock_session(
+    notify(
+      "object {x} not found",
+      type = "error",
+      glue = FALSE,
+      log = FALSE,
+      session = session
+    )
+  )
+
+  expect_match(shown, "object {x} not found", fixed = TRUE)
+})
+
+test_that("notify() interpolates by default and errors on bad braces", {
+
+  local_mocked_bindings(showNotification = function(ui, ...) invisible())
+
+  with_mock_session(
+    expect_error(
+      notify("object {x} not found", type = "error", session = session)
+    )
+  )
+})
+
+test_that("notify(log = FALSE) skips the log entry", {
+
+  logged <- new.env(parent = emptyenv())
+  logged$n <- 0L
+
+  local_mocked_bindings(
+    showNotification = function(ui, ...) invisible(),
+    log_error = function(...) {
+      logged$n <- logged$n + 1L
+      invisible()
+    }
+  )
+
+  with_mock_session(
+    {
+      notify("boom", type = "error", glue = FALSE, log = FALSE,
+             session = session)
+      expect_identical(logged$n, 0L)
+
+      notify("boom", type = "error", glue = FALSE, session = session)
+      expect_identical(logged$n, 1L)
+    }
+  )
+})
+
+test_that("notify_remove removes a notification by id", {
+
+  removed <- NULL
+
+  local_mocked_bindings(
+    removeNotification = function(id, ...) {
+      removed <<- id
+      invisible()
+    }
+  )
+
+  with_mock_session(notify_remove("toast-1", session))
+
+  expect_identical(removed, "toast-1")
+})


### PR DESCRIPTION
## notify_user: per-block notifications

- `notify_user` re-derived the whole board's combined condition frame (`board$conditions()`) on every condition change — O(N) per flush, O(N^2) under a cascade across N blocks on large boards. It now attaches an observer to each block's `conditions()` reactive (added/removed as `board$blocks` changes) and does work proportional to the block that changed. Per-block condition state is already gated on the id-set (`capture_conditions` / `block_cond_observer`), so each observer fires only on a real change.
- Toasts are scoped per block: each block's conditions surface as their own notifications, cleared when resolved or when the block is removed. This intentionally drops the previous cross-block de-duplication — two blocks raising the same message now show one toast each, labelled by block.
- `board$conditions()` is unchanged — the board-level surface from #218 stays for (debounced) programmatic consumers like blockr.assistant.

A read-counting test guards the core property: changing one block never reads another block's conditions (it fails on the old combine-the-frame design — 5 extra reads of the untouched block vs 0).

## notify(): glue/log toggles + a removal counterpart

- `notify()` gains `glue` and `log` arguments (both `TRUE` by default, so existing behaviour is unchanged). `glue = FALSE` surfaces literal text without `cli::pluralize()` interpolation; `log = FALSE` skips the log entry for already-logged text.
- This also fixes a latent crash: ~9 sites already pass `conditionMessage(e)` straight into `notify()` (board update ×2, plugin-control, and link/stack edits ×3 each), so any non-blockr error message containing `{…}` errored inside glue. Those now pass `glue = FALSE`.
- New internal `notify_remove(id)` pairs with `notify()` for clearing persistent toasts; the reload toast and `notify_user` now use it. Kept unexported — nothing downstream removes notifications yet.

The `glue = FALSE` toggle resolves the long-standing glue-crash-on-braces bug (#135) for `notify()` (`write_log()` already had `use_glue = FALSE`); all of core's raw-condition-message toasts now use it. The downstream cleanup — replacing blockr.session's `cnd_to_notif()` brace-escaping with `notify(glue = FALSE)` — is tracked in BristolMyersSquibb/blockr.session#57.

Fixes #222
Fixes #135
