### PR TITLE
Point CI workflows at BristolMyersSquibb/blockr.ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ name: ci
 
 jobs:
   ci:
-    uses: cynkra/blockr.ci/.github/workflows/ci.yaml@main
+    uses: BristolMyersSquibb/blockr.ci/.github/workflows/ci.yaml@main
     with:
       lintr-exclusions: |
         vignettes/create-block.qmd
@@ -20,7 +20,7 @@ jobs:
       BLOCKR_PAT: ${{ secrets.BLOCKR_PAT }}
 
   revdep:
-    uses: cynkra/blockr.ci/.github/workflows/revdep.yaml@main
+    uses: BristolMyersSquibb/blockr.ci/.github/workflows/revdep.yaml@main
     with:
       revdep-packages: |
         BristolMyersSquibb/blockr.dock

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -6,7 +6,7 @@ name: pkgdown
 
 jobs:
   pkgdown:
-    uses: cynkra/blockr.ci/.github/workflows/pkgdown.yaml@main
+    uses: BristolMyersSquibb/blockr.ci/.github/workflows/pkgdown.yaml@main
     secrets:
       BLOCKR_PAT: ${{ secrets.BLOCKR_PAT }}
     permissions:


### PR DESCRIPTION
## Summary

- `blockr.ci` moved from the `cynkra` org to `BristolMyersSquibb`. CI only kept working via GitHub's owner redirect, which reads less clearly and silently breaks if the `cynkra` name is ever reclaimed.
- Repoint every reusable-workflow `uses:` reference to `BristolMyersSquibb/blockr.ci`, keeping the path and `@main` ref unchanged: `ci.yaml` (both the `ci` and `revdep` jobs) and `pkgdown.yaml`.
- Reusable-workflow and job names are unchanged, so no required-status-check or ruleset updates are needed.

Fixes #224
