### PR TITLE
Point CI workflows at BristolMyersSquibb/blockr.ci after org move

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ name: ci
 
 jobs:
   ci:
-    uses: cynkra/blockr.ci/.github/workflows/ci.yaml@main
+    uses: BristolMyersSquibb/blockr.ci/.github/workflows/ci.yaml@main
     with:
       lintr-exclusions: |
         vignettes/create-block.qmd
@@ -20,7 +20,7 @@ jobs:
       BLOCKR_PAT: ${{ secrets.BLOCKR_PAT }}
 
   revdep:
-    uses: cynkra/blockr.ci/.github/workflows/revdep.yaml@main
+    uses: BristolMyersSquibb/blockr.ci/.github/workflows/revdep.yaml@main
     with:
       revdep-packages: |
         BristolMyersSquibb/blockr.dock

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -6,7 +6,7 @@ name: pkgdown
 
 jobs:
   pkgdown:
-    uses: cynkra/blockr.ci/.github/workflows/pkgdown.yaml@main
+    uses: BristolMyersSquibb/blockr.ci/.github/workflows/pkgdown.yaml@main
     secrets:
       BLOCKR_PAT: ${{ secrets.BLOCKR_PAT }}
     permissions:


### PR DESCRIPTION
## Summary

`blockr.ci` was transferred from the `cynkra` org to `BristolMyersSquibb`. GitHub Actions does not follow repo-transfer redirects for reusable-workflow `uses:` references, so core's stale `cynkra/blockr.ci@main` calls fail at workflow *startup* — zero jobs, zero logs, "workflow file may be broken" — which blocks CI on every core PR (the previously-green commits fail identically; blockr.dock/ui already on the new org ref run fine concurrently).

This repoints `ci.yaml` (the `ci` and `revdep` calls) and `pkgdown.yaml` to `BristolMyersSquibb/blockr.ci@main`, matching what blockr.dock and blockr.ui already use. The branch carries the fixed refs, so its own CI exercises the new path.

blockr.assistant and blockr.dag still reference the old `cynkra` org and need the same one-line migration.
