### PR TITLE
Freeze block inputs via a per-block frozen channel

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,20 @@
 # blockr.core 0.1.4
 
 * The board callback now gates block construction, evaluation and rendering
-  through two per-block `reactiveValues` it receives as `visibility` --
+  through per-block `reactiveVal` channels it receives as `visibility` --
   `required` (which blocks are needed) and `visible` (which are on screen) --
   in place of the single `visible` write-channel. Breaking for front-ends.
+* The `visibility` bundle carries a third channel, `frozen`, letting a
+  front-end freeze a block's inputs server-side: setting
+  `visibility$frozen[[id]](TRUE)` -- for example for a locked board that shows
+  outputs but hides controls -- holds the block's expression, state readiness
+  and serialized state at their last editable values and drops the input
+  trigger, so a forged `Shiny.setInputValue` (which still fires the block's own
+  observer) reaches neither the expression, the block's status, a
+  re-evaluation, nor a saved board. Externally controllable inputs are held too
+  -- a high-priority observer reverts any write while frozen -- so a frozen
+  block is fully read-only. Upstream-data-driven re-evaluation still runs, and
+  unfreezing resumes normal input handling (#231).
 * `background_construction_delay` now accepts `Inf`, skipping the background
   construction pass so a block is built only once it becomes required. Code
   export ("Show code") then marks every block required, so the exported

--- a/R/block-server.R
+++ b/R/block-server.R
@@ -52,10 +52,11 @@
 #' [block_output()] generic. The [block_ui()] generic can then be used to
 #' control rendering of outputs.
 #'
-#' A front-end (such as blockr.dock) drives two per-block channels that
-#' [board_server()] hands to the board callback as `visibility`: `required`
-#' (which blocks it needs built and evaluated) and `visible` (which blocks it
-#' has arranged on screen). Requirements are a cause the front-end -- and
+#' A front-end (such as blockr.dock) drives per-block channels that
+#' [board_server()] hands to the board callback as `visibility`. Two of them
+#' gate what is built and shown: `required` (which blocks it needs built and
+#' evaluated) and `visible` (which blocks it has arranged on screen).
+#' Requirements are a cause the front-end -- and
 #' core-side features such as code export -- declare; visibility is the effect
 #' the front-end reports back once it has painted a block. Rendering is gated
 #' on `visible`: the render observer is suspended while a block carries no
@@ -85,6 +86,19 @@
 #' `gate_visibility` [blockr_option()] (default `TRUE`) turns gating off
 #' entirely.
 #'
+#' The same bundle carries a third channel, `frozen`, through which a
+#' front-end reports the blocks whose inputs it has hidden (for example a
+#' locked board that shows outputs but not controls). While frozen a block is
+#' read-only: its expression, state readiness and the state it exposes for
+#' serialization are held at the values last seen while editable, and the input
+#' trigger is dropped, so a forged client input (which still fires the block's
+#' own observer) reaches neither the expression, the block's status, a
+#' re-evaluation, nor a save. Externally controllable inputs (see
+#' [external_ctrl_vars()]) are held too -- a high-priority observer reverts any
+#' write while frozen -- so not even the programmatic control channel can drive
+#' a frozen block. Upstream data still flows through, and unfreezing resumes
+#' normal input handling.
+#'
 #' @param id Namespace ID
 #' @param x Object for which to generate a [shiny::moduleServer()]
 #' @param data Input data (list of reactives)
@@ -108,10 +122,11 @@ block_server <- function(id, x, data = list(), ...) {
 #' inputs are all connected to ready upstream blocks (supplied by
 #' [board_server()]; defaults to always-ready when a block server is run
 #' standalone)
-#' @param visibility Visibility channel bundle -- a list with two channels,
-#' `required` and `visible`, each an environment of per-block `reactiveVal`s,
-#' supplied by [board_server()] to gate rendering; `NULL` (the standalone
-#' default) leaves the block ungated
+#' @param visibility Front-end channel bundle -- a list with three channels,
+#' `required`, `visible` and `frozen`, each an environment of per-block
+#' `reactiveVal`s, supplied by [board_server()] to gate rendering and to
+#' freeze block inputs; `NULL` (the standalone default) leaves the block
+#' ungated
 #' @rdname block_server
 #' @export
 block_server.block <- function(id, x, data = list(), block_id = id,
@@ -141,11 +156,23 @@ block_server.block <- function(id, x, data = list(), block_id = id,
         x
       )
 
-      lang <- reactive(
-        exprs_to_lang(exp$expr())
+      frozen <- reactive(
+        not_null(visibility) && block_frozen(block_id, visibility)
+      )
+
+      lang <- freeze_reactive(
+        reactive(exprs_to_lang(exp$expr())),
+        frozen,
+        session
       )
 
       state <- exp$state
+
+      exposed_state <- if (not_null(visibility)) {
+        freeze_exposed_state(state, x, frozen, session)
+      } else {
+        state
+      }
 
       dat <- reactive(
         {
@@ -162,12 +189,20 @@ block_server.block <- function(id, x, data = list(), block_id = id,
       data_valid <- validate_block_reactive(block_id, x, dat, cond, session,
                                             inputs_ready)
 
-      state_ready <- state_ready_reactive(block_id, x, state, session)
+      state_ready <- freeze_reactive(
+        state_ready_reactive(block_id, x, state, session),
+        frozen,
+        session
+      )
 
       dat_eval <- reactive(
         {
           req(isTRUE(data_valid()), isTRUE(state_ready()))
-          lapply(state, reval_if)
+
+          if (!frozen()) {
+            lapply(state, reval_if)
+          }
+
           try(lang(), silent = TRUE)
 
           res <- dat()
@@ -348,7 +383,7 @@ block_server.block <- function(id, x, data = list(), block_id = id,
           state_ready = state_ready,
           failed = failed,
           expr = lang,
-          state = state,
+          state = exposed_state,
           conditions = conditions
         ),
         eb_res
@@ -536,6 +571,94 @@ render_gate_observer <- function(id, visibility, render_obs, sess) {
     },
     domain = sess
   )
+}
+
+freeze_reactive <- function(live, frozen, sess) {
+
+  pin <- reactiveVal(tryCatch(isolate(live()), error = function(e) NULL))
+
+  reactive(
+    {
+      if (frozen()) {
+        return(isolate(pin()))
+      }
+
+      cur <- live()
+      isolate(pin(cur))
+
+      cur
+    },
+    domain = sess
+  )
+}
+
+freeze_exposed_state <- function(state, x, frozen, sess) {
+
+  fn_names <- names(state)[lgl_ply(state, is.function)]
+
+  if (!length(fn_names)) {
+    return(state)
+  }
+
+  ctrl <- intersect(fn_names, external_ctrl_vars(x))
+  views <- setdiff(fn_names, ctrl)
+
+  live <- state[fn_names]
+
+  snapshot <- reactiveVal(NULL)
+
+  observeEvent(
+    frozen(),
+    if (isTRUE(frozen())) {
+      snapshot(lapply(live, reval_if))
+    },
+    domain = sess
+  )
+
+  if (length(ctrl)) {
+    hold_ctrl_state(live[ctrl], frozen, snapshot, sess)
+  }
+
+  for (nm in views) {
+    state[[nm]] <- freeze_state_view(live[[nm]], nm, frozen, snapshot, sess)
+  }
+
+  state
+}
+
+freeze_state_view <- function(live, nm, frozen, snapshot, sess) {
+
+  reactive(
+    if (frozen()) snapshot()[[nm]] else reval_if(live),
+    domain = sess
+  )
+}
+
+hold_ctrl_state <- function(rvs, frozen, snapshot, sess) {
+
+  revert <- observe(
+    {
+      snap <- snapshot()
+
+      if (not_null(snap)) {
+        for (nm in names(rvs)) {
+          if (!identical(rvs[[nm]](), snap[[nm]])) {
+            rvs[[nm]](snap[[nm]])
+          }
+        }
+      }
+    },
+    priority = Inf,
+    suspended = TRUE,
+    domain = sess
+  )
+
+  observe(
+    if (frozen()) revert$resume() else revert$suspend(),
+    domain = sess
+  )
+
+  invisible()
 }
 
 block_cond_observer <- function(blk, cond, sess) {

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -34,13 +34,15 @@ board_server <- function(id, x, ...) {
 #' @param options Board options (`NULL` defaults to the union of board, block
 #' and registry sourced options)
 #' @param callbacks Single (or list of) callback function(s) registering
-#' additional observers. Each receives a `visibility` list with two channels,
-#' `required` and `visible`, each an environment of per-block `reactiveVal`s
-#' (core keeps one per board block as blocks are added and removed). Declare a
-#' block needed with `visibility$required[[id]](TRUE)` (or `FALSE` for built
-#' but dormant) and report the view it is rendered into with
+#' additional observers. Each receives a `visibility` list with three channels,
+#' `required`, `visible` and `frozen`, each an environment of per-block
+#' `reactiveVal`s (core keeps one per board block as blocks are added and
+#' removed). Declare a block needed with `visibility$required[[id]](TRUE)` (or
+#' `FALSE` for built but dormant) and report the view it is rendered into with
 #' `visibility$visible[[id]](view)` (or `NA_character_` for off screen); the
-#' board reads both to gate construction, evaluation and rendering.
+#' board reads both to gate construction, evaluation and rendering. Set
+#' `visibility$frozen[[id]](TRUE)` to freeze a block's inputs (for example when
+#' its controls are hidden), so a forged input can no longer steer it.
 #' @param callback_location Location of callback invocation (before or after
 #' plugins)
 #' @rdname board_server
@@ -87,7 +89,8 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
 
       vis <- list(
         required = new.env(parent = emptyenv()),
-        visible = new.env(parent = emptyenv())
+        visible = new.env(parent = emptyenv()),
+        frozen = new.env(parent = emptyenv())
       )
 
       add_vis_slots(vis, isolate(board_block_ids(rv$board)))
@@ -600,6 +603,7 @@ add_vis_slots <- function(vis, ids) {
   for (id in ids) {
     vis$required[[id]] <- reactiveVal(NA)
     vis$visible[[id]] <- reactiveVal(NA_character_)
+    vis$frozen[[id]] <- reactiveVal(FALSE)
   }
 
   invisible()
@@ -612,6 +616,7 @@ rm_vis_slots <- function(vis, ids) {
   if (length(gone)) {
     rm(list = gone, envir = vis$required)
     rm(list = gone, envir = vis$visible)
+    rm(list = gone, envir = vis$frozen)
   }
 
   invisible()
@@ -651,6 +656,10 @@ block_visible <- function(id, vis) {
   is_visible(vis$visible[[id]]())
 }
 
+block_frozen <- function(id, vis) {
+  isTRUE(vis$frozen[[id]]())
+}
+
 required_fulfilled <- function(vis) {
   all(lgl_ply(required_now(vis$required), block_visible, vis))
 }
@@ -675,6 +684,15 @@ validate_vis <- function(vis) {
     }
   }
 
+  for (id in ls(vis$frozen)) {
+    if (!valid_frozen(vis$frozen[[id]]())) {
+      blockr_abort(
+        "frozen[[{id}]] must be TRUE or FALSE",
+        class = "invalid_frozen"
+      )
+    }
+  }
+
   invisible()
 }
 
@@ -684,6 +702,10 @@ valid_required <- function(x) {
 
 valid_visible <- function(x) {
   is.character(x) && length(x) == 1L && (is.na(x) || nzchar(x))
+}
+
+valid_frozen <- function(x) {
+  is.logical(x) && length(x) == 1L && !is.na(x)
 }
 
 needed_block_ids <- function(rv, required) {

--- a/man/block_server.Rd
+++ b/man/block_server.Rd
@@ -64,10 +64,11 @@ inputs are all connected to ready upstream blocks (supplied by
 \code{\link[=board_server]{board_server()}}; defaults to always-ready when a block server is run
 standalone)}
 
-\item{visibility}{Visibility channel bundle -- a list with two channels,
-\code{required} and \code{visible}, each an environment of per-block \code{reactiveVal}s,
-supplied by \code{\link[=board_server]{board_server()}} to gate rendering; \code{NULL} (the standalone
-default) leaves the block ungated}
+\item{visibility}{Front-end channel bundle -- a list with three channels,
+\code{required}, \code{visible} and \code{frozen}, each an environment of per-block
+\code{reactiveVal}s, supplied by \code{\link[=board_server]{board_server()}} to gate rendering and to
+freeze block inputs; \code{NULL} (the standalone default) leaves the block
+ungated}
 }
 \value{
 Both \code{block_server()} and \code{expr_server()} return shiny server module
@@ -131,10 +132,11 @@ from output, the behavior of which can be customized via the
 \code{\link[=block_output]{block_output()}} generic. The \code{\link[=block_ui]{block_ui()}} generic can then be used to
 control rendering of outputs.
 
-A front-end (such as blockr.dock) drives two per-block channels that
-\code{\link[=board_server]{board_server()}} hands to the board callback as \code{visibility}: \code{required}
-(which blocks it needs built and evaluated) and \code{visible} (which blocks it
-has arranged on screen). Requirements are a cause the front-end -- and
+A front-end (such as blockr.dock) drives per-block channels that
+\code{\link[=board_server]{board_server()}} hands to the board callback as \code{visibility}. Two of them
+gate what is built and shown: \code{required} (which blocks it needs built and
+evaluated) and \code{visible} (which blocks it has arranged on screen).
+Requirements are a cause the front-end -- and
 core-side features such as code export -- declare; visibility is the effect
 the front-end reports back once it has painted a block. Rendering is gated
 on \code{visible}: the render observer is suspended while a block carries no
@@ -163,4 +165,17 @@ the staggering and builds every block up front. With nothing writing
 \code{required} every block is needed and behaviour is unchanged; the
 \code{gate_visibility} \code{\link[=blockr_option]{blockr_option()}} (default \code{TRUE}) turns gating off
 entirely.
+
+The same bundle carries a third channel, \code{frozen}, through which a
+front-end reports the blocks whose inputs it has hidden (for example a
+locked board that shows outputs but not controls). While frozen a block is
+read-only: its expression, state readiness and the state it exposes for
+serialization are held at the values last seen while editable, and the input
+trigger is dropped, so a forged client input (which still fires the block's
+own observer) reaches neither the expression, the block's status, a
+re-evaluation, nor a save. Externally controllable inputs (see
+\code{\link[=external_ctrl_vars]{external_ctrl_vars()}}) are held too -- a high-priority observer reverts any
+write while frozen -- so not even the programmatic control channel can drive
+a frozen block. Upstream data still flows through, and unfreezing resumes
+normal input handling.
 }

--- a/man/board_server.Rd
+++ b/man/board_server.Rd
@@ -30,13 +30,15 @@ board_server(id, x, ...)
 and registry sourced options)}
 
 \item{callbacks}{Single (or list of) callback function(s) registering
-additional observers. Each receives a \code{visibility} list with two channels,
-\code{required} and \code{visible}, each an environment of per-block \code{reactiveVal}s
-(core keeps one per board block as blocks are added and removed). Declare a
-block needed with \code{visibility$required[[id]](TRUE)} (or \code{FALSE} for built
-but dormant) and report the view it is rendered into with
+additional observers. Each receives a \code{visibility} list with three channels,
+\code{required}, \code{visible} and \code{frozen}, each an environment of per-block
+\code{reactiveVal}s (core keeps one per board block as blocks are added and
+removed). Declare a block needed with \code{visibility$required[[id]](TRUE)} (or
+\code{FALSE} for built but dormant) and report the view it is rendered into with
 \code{visibility$visible[[id]](view)} (or \code{NA_character_} for off screen); the
-board reads both to gate construction, evaluation and rendering.}
+board reads both to gate construction, evaluation and rendering. Set
+\code{visibility$frozen[[id]](TRUE)} to freeze a block's inputs (for example when
+its controls are hidden), so a forged input can no longer steer it.}
 
 \item{callback_location}{Location of callback invocation (before or after
 plugins)}

--- a/tests/testthat/test-input-freeze.R
+++ b/tests/testthat/test-input-freeze.R
@@ -1,0 +1,279 @@
+make_vis <- function(ids, frozen = character()) {
+
+  vis <- list(
+    required = new.env(parent = emptyenv()),
+    visible = new.env(parent = emptyenv()),
+    frozen = new.env(parent = emptyenv())
+  )
+
+  add_vis_slots(vis, ids)
+
+  for (id in frozen) {
+    vis$frozen[[id]](TRUE)
+  }
+
+  vis
+}
+
+new_state_probe <- function(v = "published") {
+  new_transform_block(
+    function(id, data) {
+      moduleServer(
+        id,
+        function(input, output, session) {
+          val <- reactiveVal(v)
+          observeEvent(input$v, val(input$v))
+          list(expr = reactive(quote(identity(data))), state = list(v = val))
+        }
+      )
+    },
+    function(id) shiny::tagList(),
+    class = "state_probe",
+    block_metadata = FALSE
+  )
+}
+
+test_that("the board exposes a per-block frozen channel", {
+
+  board <- new_board(blocks = c(a = new_dataset_block("iris")))
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      expect_true("a" %in% ls(vis$frozen))
+      expect_false(block_frozen("a", vis))
+
+      vis$frozen[["a"]](TRUE)
+      session$flushReact()
+
+      expect_true(block_frozen("a", vis))
+    },
+    args = list(x = board, plugins = list())
+  )
+})
+
+test_that("valid_frozen accepts logical scalars only", {
+
+  expect_true(valid_frozen(TRUE))
+  expect_true(valid_frozen(FALSE))
+  expect_false(valid_frozen(NA))
+  expect_false(valid_frozen("yes"))
+  expect_false(valid_frozen(c(TRUE, FALSE)))
+})
+
+test_that("a frozen block ignores a forged input", {
+
+  blk <- new_dataset_block("iris")
+
+  testServer(
+    get_s3_method("block_server", blk),
+    {
+      session$flushReact()
+
+      expect_equal(session$returned$result(), iris)
+
+      session$makeScope("expr")$setInputs(dataset = "mtcars")
+      session$flushReact()
+
+      expect_equal(session$returned$result(), iris)
+    },
+    args = list(
+      x = blk,
+      data = list(),
+      block_id = "data",
+      visibility = make_vis("data", frozen = "data")
+    )
+  )
+})
+
+test_that("freezing and unfreezing toggles a block's input handling", {
+
+  blk <- new_dataset_block("iris")
+
+  vis <- make_vis("data")
+
+  testServer(
+    get_s3_method("block_server", blk),
+    {
+      session$flushReact()
+
+      session$makeScope("expr")$setInputs(dataset = "mtcars")
+      session$flushReact()
+
+      expect_equal(session$returned$result(), mtcars)
+
+      vis$frozen[["data"]](TRUE)
+      session$flushReact()
+
+      session$makeScope("expr")$setInputs(dataset = "iris")
+      session$flushReact()
+
+      expect_equal(session$returned$result(), mtcars)
+
+      vis$frozen[["data"]](FALSE)
+      session$flushReact()
+
+      session$makeScope("expr")$setInputs(dataset = "iris")
+      session$flushReact()
+
+      expect_equal(session$returned$result(), iris)
+    },
+    args = list(
+      x = blk,
+      data = list(),
+      block_id = "data",
+      visibility = vis
+    )
+  )
+})
+
+test_that("a frozen block still re-evaluates on upstream data changes", {
+
+  blk <- new_subset_block("Sepal.Width > 3")
+
+  data <- reactiveVal(iris)
+
+  testServer(
+    get_s3_method("block_server", blk),
+    {
+      session$flushReact()
+
+      expect_equal(
+        session$returned$result(),
+        subset(iris, Sepal.Width > 3)
+      )
+
+      session$makeScope("expr")$setInputs(
+        subset = "Sepal.Width > 99",
+        select = "",
+        eval = 1L
+      )
+      session$flushReact()
+
+      expect_equal(
+        session$returned$result(),
+        subset(iris, Sepal.Width > 3)
+      )
+
+      data(head(iris, 20L))
+      session$flushReact()
+
+      expect_equal(
+        session$returned$result(),
+        subset(head(iris, 20L), Sepal.Width > 3)
+      )
+    },
+    args = list(
+      x = blk,
+      data = list(data = data),
+      block_id = "sub",
+      visibility = make_vis("sub", frozen = "sub")
+    )
+  )
+})
+
+test_that("a frozen block exposes its published state, not a forged one", {
+
+  blk <- new_state_probe("published")
+
+  testServer(
+    get_s3_method("block_server", blk),
+    {
+      session$flushReact()
+
+      expect_equal(reval_if(session$returned$state$v), "published")
+
+      session$makeScope("expr")$setInputs(v = "forged")
+      session$flushReact()
+
+      expect_equal(reval_if(session$returned$state$v), "published")
+    },
+    args = list(
+      x = blk,
+      data = list(data = reactiveVal(datasets::BOD)),
+      block_id = "p",
+      visibility = make_vis("p", frozen = "p")
+    )
+  )
+})
+
+test_that("an unfrozen block exposes its live state", {
+
+  blk <- new_state_probe("published")
+
+  testServer(
+    get_s3_method("block_server", blk),
+    {
+      session$flushReact()
+
+      session$makeScope("expr")$setInputs(v = "forged")
+      session$flushReact()
+
+      expect_equal(reval_if(session$returned$state$v), "forged")
+    },
+    args = list(
+      x = blk,
+      data = list(data = reactiveVal(datasets::BOD)),
+      block_id = "p",
+      visibility = make_vis("p")
+    )
+  )
+})
+
+test_that("a frozen block reverts writes to externally controllable state", {
+
+  blk <- new_subset_block("Sepal.Width > 3")
+
+  testServer(
+    get_s3_method("block_server", blk),
+    {
+      session$flushReact()
+
+      expect_equal(reval_if(session$returned$state$subset), "Sepal.Width > 3")
+
+      session$makeScope("expr")$setInputs(
+        subset = "forged",
+        select = "",
+        eval = 1L
+      )
+      session$flushReact()
+
+      expect_equal(reval_if(session$returned$state$subset), "Sepal.Width > 3")
+    },
+    args = list(
+      x = blk,
+      data = list(data = reactiveVal(iris)),
+      block_id = "sub",
+      visibility = make_vis("sub", frozen = "sub")
+    )
+  )
+})
+
+test_that("an unfrozen block keeps writes to externally controllable state", {
+
+  blk <- new_subset_block("Sepal.Width > 3")
+
+  testServer(
+    get_s3_method("block_server", blk),
+    {
+      session$flushReact()
+
+      session$makeScope("expr")$setInputs(
+        subset = "Sepal.Width > 9",
+        select = "",
+        eval = 1L
+      )
+      session$flushReact()
+
+      expect_equal(reval_if(session$returned$state$subset), "Sepal.Width > 9")
+    },
+    args = list(
+      x = blk,
+      data = list(data = reactiveVal(iris)),
+      block_id = "sub",
+      visibility = make_vis("sub")
+    )
+  )
+})


### PR DESCRIPTION
## Summary

A front-end like blockr.dock shows and hides a block's input controls per block. When it hides them, core has to stop honouring that block's inputs server-side — hiding the UI isn't enough, since a forged `Shiny.setInputValue` from the browser console still fires the block's own input observer (the same lesson as the lock, #229).

The `visibility` bundle the board callback already receives (`required`, `visible`) gains a third per-block channel, **`frozen`**. A front-end sets `visibility$frozen[[id]](TRUE)` for a block whose inputs it has hidden. Core then holds, at the values last seen while editable:

- the block **expression** (`lang`) — so a forged input can't change what it evaluates;
- its **state readiness** — so a forged input can't flip it to `unset`, blank it, or shift its eval status;
- the **state it exposes for serialization** — so a save-while-frozen persists the published values, not a forged one;

and drops the evaluation's input trigger. A frozen block's reactive graph reduces to "upstream data + the `frozen` channel": it still re-evaluates when its upstream data changes, but a forged local input reaches nothing. Unfreezing resumes normal input handling.

## Notes / design decisions

- **No new exported API** — `frozen` is a third env in the existing `visibility` bundle (`add_vis_slots` / `rm_vis_slots` / `validate_vis`), so it rides along wherever `visibility` already goes.
- Core can't literally suspend a block author's input observers (they live in the block's own server), so it stops *consuming* a frozen block's inputs. User-input interpolation happens inside `exp$expr`, so pinning its output (`lang`) freezes eval uniformly, whether the state behind it is a `reactiveVal` or a `reactive()`.
- **Serialized-state freeze** is captured by a freeze-onset snapshot: non-ctrl entries are served frozen through a view, and externally controllable inputs (guaranteed `reactiveVal`s) are held by a `priority = Inf` observer that reverts any write while frozen — suspended otherwise, so it costs nothing for non-frozen blocks. So a frozen block is **fully read-only**: no channel, UI or programmatic, can drive it, and a forged ctrl write is discarded rather than deferred (the revert holds the published value).
- **Unfreeze defers rather than discards.** Discarding a change made while frozen can't be a core guarantee — `exp$expr` reads the author's live state and `reactive()` state has no setter to revert — so unfreeze resumes from the inputs' current values. Safe when unfreezing is a privileged unlock.

Fixes #231
