### PR TITLE
Add blockr.session to the reverse-dependency check set

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,5 +26,6 @@ jobs:
         BristolMyersSquibb/blockr.dock
         BristolMyersSquibb/blockr.dag
         BristolMyersSquibb/blockr.assistant
+        BristolMyersSquibb/blockr.session
     secrets:
       BLOCKR_PAT: ${{ secrets.BLOCKR_PAT }}


### PR DESCRIPTION
## Summary

- core's merge-queue revdep gate (`revdep-packages` in `.github/workflows/ci.yaml`) checked only `blockr.dock`, `blockr.dag` and `blockr.assistant` — all reactive board-server consumers.
- None of them exercise core's serialization / save-restore API (`serialize_board`, `restore_board`, `restore_result`, `preserve_board`); `blockr.session` is the only package in the stack that does, so changes to that surface (e.g. the board-loader rework in #214) passed the gate while breaking session silently.
- Add `BristolMyersSquibb/blockr.session` to the revdep set. It is unit-test only (no shinytest2 e2e), so it adds coverage without contributing merge-queue flakiness.

Fixes #234