### PR TITLE
Augment a resolved board with the managed option set

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # blockr.core 0.1.3
 
+* Board options contributed by blocks or the registry (e.g. the
+  preview-row count) are no longer reset to their defaults on save and
+  reload. The settings sidebar manages the wider `blockr_app_options()`
+  set, but a board carried only its own `board_options()`, and that
+  narrow set is what `serialize_board()` persisted — so a user's change
+  to a block-backed option was dropped. `resolve_board()` now augments
+  the board it returns with the managed option set, so the UI, the
+  server and serialization all operate on the same options (#238).
+
 * The board to build for an incoming request is now resolved by an
   app-level **board loader**, passed to `serve()` as its new `loader`
   argument (default: `local_loader()`, an in-process save/restore handoff).

--- a/R/board-loader.R
+++ b/R/board-loader.R
@@ -167,20 +167,28 @@ local_loader <- function() {
   board_loader(resolve, stage)
 }
 
-resolve_board <- function(default, loader, request, session) {
+resolve_board <- function(default, loader, request, session,
+                          options = blockr_app_options) {
 
   board <- loader$resolve(request, session, default)
 
   if (is.null(board)) {
-    return(default)
-  }
-
-  if (!is_board(board)) {
+    board <- default
+  } else if (!is_board(board)) {
     blockr_abort(
       "A board loader's `resolve` must return `NULL` or a `board`.",
       class = "invalid_board_loader"
     )
+  } else {
+    board <- validate_board(board)
   }
 
-  validate_board(board)
+  # A board declares only its own options, but the settings UI manages the
+  # wider `options(board)` set (board options plus those contributed by blocks
+  # and the registry). Bake it onto the resolved board so the UI, the server
+  # and serialization all see the same set -- otherwise a user-changed,
+  # block-contributed option is lost on save.
+  board_options(board) <- options(board)
+
+  board
 }

--- a/R/utils-serve.R
+++ b/R/utils-serve.R
@@ -209,7 +209,7 @@ serve_board_ui <- function(id, default, loader, plugins, options, ...) {
 
   function(request) {
 
-    x <- resolve_board(default, loader, request, NULL)
+    x <- resolve_board(default, loader, request, NULL, options)
     id <- coal(attr(x, "id"), id)
 
     log_debug("building ui for board {id}")
@@ -229,7 +229,7 @@ serve_board_srv <- function(id, default, loader, plugins, options, ...) {
 
     onStop(revert(trace_observe()), session)
 
-    x <- resolve_board(default, loader, session$request, session)
+    x <- resolve_board(default, loader, session$request, session, options)
     id <- coal(attr(x, "id"), id)
 
     res <- do.call(

--- a/tests/testthat/test-plugin-serdes.R
+++ b/tests/testthat/test-plugin-serdes.R
@@ -213,16 +213,88 @@ test_that("resolve_board prefers the loader board, validates, falls back", {
   default <- new_board()
   staged <- new_board(blocks = c(a = new_dataset_block("iris")))
 
+  # resolve_board augments the returned board's options (covered below), so the
+  # picked board is no longer identical to the input -- compare by blocks.
   pref <- board_loader(function(request, session, default) staged)
-  expect_identical(resolve_board(default, pref, list(), NULL), staged)
+  expect_identical(
+    board_blocks(resolve_board(default, pref, list(), NULL)),
+    board_blocks(staged)
+  )
 
   none <- board_loader(function(request, session, default) NULL)
-  expect_identical(resolve_board(default, none, list(), NULL), default)
+  expect_identical(
+    board_blocks(resolve_board(default, none, list(), NULL)),
+    board_blocks(default)
+  )
 
   bad <- board_loader(function(request, session, default) "nope")
   expect_error(
     resolve_board(default, bad, list(), NULL),
     class = "invalid_board_loader"
+  )
+})
+
+test_that("resolve_board augments the board with the managed option set", {
+
+  # A board declares only its own options, but the settings UI manages the
+  # wider blockr_app_options() set -- options contributed by registered blocks
+  # (e.g. the preview-row count `n_rows`). resolve_board() bakes that set onto
+  # the board it returns so the server and serialization see the full set.
+  brd <- new_board()
+
+  expect_false("n_rows" %in% names(board_options(brd)))
+  expect_true("n_rows" %in% names(blockr_app_options(brd)))
+
+  null_loader <- board_loader(function(request, session, default) NULL)
+  via_default <- resolve_board(
+    brd, null_loader, request = list(), session = NULL
+  )
+  expect_true("n_rows" %in% names(board_options(via_default)))
+
+  load_loader <- board_loader(function(request, session, default) new_board())
+  via_loaded <- resolve_board(
+    brd, load_loader, request = list(), session = NULL
+  )
+  expect_true("n_rows" %in% names(board_options(via_loaded)))
+})
+
+test_that("a user-changed block-backed board option survives save/restore", {
+
+  # End to end of the augmentation: `n_rows` is contributed by blocks, not the
+  # board itself, so before resolve_board() widened the board it was dropped on
+  # save and reverted to its registry default on reload.
+  x <- resolve_board(
+    new_board(),
+    board_loader(function(request, session, default) NULL),
+    request = list(),
+    session = NULL
+  )
+
+  ser <- NULL
+
+  testServer(
+    get_s3_method("board_server", x),
+    {
+      session$flushReact()
+
+      session$setInputs(n_rows = 100L)
+      session$flushReact()
+
+      ser <<- serialize_board(rv$board, rv$blocks, id = "b", session = session)
+    },
+    args = list(
+      x = x,
+      plugins = list(manage_blocks()),
+      options = blockr_app_options(x)
+    )
+  )
+
+  loaded <- blockr_deser(ser)
+
+  expect_true("n_rows" %in% names(board_options(loaded)))
+  expect_identical(
+    board_option_value(blockr_app_options(loaded)[["n_rows"]]),
+    100L
   )
 })
 


### PR DESCRIPTION
## Summary

The settings sidebar manages `blockr_app_options(x)` — board options plus those contributed by the board's blocks and by every registered block type (`available_blocks()`, e.g. the preview-row count `n_rows`). But a board carried only its own narrow `board_options(x)`, and `serialize_board()` persisted that narrow set, so a user's change to a block-contributed option was dropped on save and reverted to the registry default on reload.

- `resolve_board()` now augments the board it returns with the managed option set (`board_options(board) <- options(board)`), threading the serve `options` function in (defaulted to `blockr_app_options`). The resolved board is complete for the UI, the server and serialization alike — no per-serializer widening.
- Both `serve_board_ui` and `serve_board_srv` pass `options` through, so the augmentation lands in the single `resolve_board` choke point and covers the loaded and the default-fallback paths.
- Regression tests: `resolve_board` augments on both paths, and a changed `n_rows` survives a serialize → restore round-trip (proven to fail on the prior code).

Fixes #238