### PR TITLE
Make board accessors pure reads instead of re-validating

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,12 @@
   `block_meta_keywords()`, and so on. A single argument's fields are read with
   `block_arg_description()`, `block_arg_example()` and `block_arg_type()`.
   `registry_metadata()` is deprecated in favour of these (#121).
+* Board accessors (`board_blocks()`, `board_links()`, `board_stacks()`)
+  are now pure reads. They previously re-validated their entire
+  collection on every call, and because board setup reads links once per
+  block, that cost scaled quadratically and dominated startup of large
+  boards. Validation is unchanged at construction and on mutation, and
+  `validate_board()` still checks each collection in full (#241).
 * Board options contributed by blocks or the registry (e.g. the
   preview-row count) are no longer reset to their defaults on save and
   reload. The settings sidebar manages the wider `blockr_app_options()`

--- a/R/board-class.R
+++ b/R/board-class.R
@@ -182,10 +182,10 @@ validate_board.board <- function(x) {
     )
   }
 
-  blks <- board_blocks(x)
+  blks <- validate_blocks(board_blocks(x))
 
-  validate_board_blocks_links(blks, board_links(x))
-  validate_board_blocks_stacks(blks, board_stacks(x))
+  validate_board_blocks_links(blks, validate_links(board_links(x)))
+  validate_board_blocks_stacks(blks, validate_stacks(board_stacks(x)))
 
   x
 }
@@ -290,7 +290,7 @@ is_acyclic.board <- function(x) {
 #' @export
 board_blocks <- function(x) {
   stopifnot(is_board(x))
-  validate_blocks(x[["blocks"]])
+  x[["blocks"]]
 }
 
 #' @param value Replacement value
@@ -380,7 +380,7 @@ rm_blocks.board <- function(x, rm, ..., session = get_session()) {
 #' @export
 board_links <- function(x) {
   stopifnot(is_board(x))
-  validate_links(x[["links"]])
+  x[["links"]]
 }
 
 #' @rdname board_blocks
@@ -449,7 +449,7 @@ modify_board_links.board <- function(x, add = NULL, rm = NULL, mod = NULL,
 #' @export
 board_stacks <- function(x) {
   stopifnot(is_board(x))
-  validate_stacks(x[["stacks"]])
+  x[["stacks"]]
 }
 
 #' @rdname board_blocks

--- a/tests/testthat/test-board-class.R
+++ b/tests/testthat/test-board-class.R
@@ -182,6 +182,39 @@ test_that("board constructor", {
   )
 })
 
+test_that("validate_board checks each collection, not just cross-relations", {
+
+  board <- new_board(c(a = new_dataset_block(), b = new_subset_block()))
+
+  # Board accessors are pure reads, so validate_board must itself run each
+  # collection's validator. A bare list (e.g. from a botched deserialization)
+  # slips past the cross-relationship checks but not the per-collection ones.
+
+  blocks_corrupt <- board
+  blocks_corrupt[["blocks"]] <- list()
+
+  expect_error(
+    validate_board(blocks_corrupt),
+    class = "blocks_class_invalid"
+  )
+
+  links_corrupt <- board
+  links_corrupt[["links"]] <- list()
+
+  expect_error(
+    validate_board(links_corrupt),
+    class = "links_class_invalid"
+  )
+
+  stacks_corrupt <- board
+  stacks_corrupt[["stacks"]] <- list()
+
+  expect_error(
+    validate_board(stacks_corrupt),
+    class = "stacks_class_invalid"
+  )
+})
+
 test_that("a board has a compact str_value()", {
 
   board <- new_board(


### PR DESCRIPTION
## Summary

- `board_blocks()`, `board_links()` and `board_stacks()` ran full collection validation on every read. Board setup reads links once per block (`setup_block()` → `board_links()`), so the cost was O(blocks × links) and dominated startup of large boards — profiling a 99-block / 108-link board attributed ~23s (~14% of the whole load) to link validation alone.
- These accessors are now pure reads. An already-constructed board holds validated collections, so re-validating on every read bought nothing.
- Validation is unchanged where state actually changes: construction (`new_board()` → `as_blocks()`/`as_links()`/`as_stacks()`) and mutation (`board_*<-()`, `modify_board_*()`, `rm_blocks()`, which all route through `validate_board()`).
- `validate_board()` previously relied on the accessors to validate each collection and only added the cross-relationship checks itself. It now runs `validate_blocks()`/`validate_links()`/`validate_stacks()` directly, so a structurally invalid collection (e.g. a malformed deserialized board) is still rejected. A regression test locks this — it fails if `validate_board()` stops checking the collections.

Fixes #241
