### PR TITLE
Guard manage-links and manage-stacks against no-op board re-emits

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,30 @@
 # blockr.core 0.1.3
 
+* The manage-links and manage-stacks plugins no longer flicker the table's
+  cell selectizes on a board re-emit (#246). The observer that keeps the
+  table in sync re-rendered every row whenever `upd$curr` was invalidated --
+  `observeEvent(names(upd$curr))` fires on each re-emit, not only when the
+  link or stack id set changes -- so `DT::replaceData` ran unconditionally,
+  briefly blanking the cell inputs before the async redraw landed. The
+  redraw is now guarded on the id set, so it runs only when a link or stack
+  is actually added or removed; value edits and no-op re-emits are skipped.
+* The manage-links and manage-stacks plugins no longer clobber staged
+  edits on a board re-emit (#246). The board-sync observers replaced the
+  working copy on every re-emit, dropping a half-finished staged add or
+  edit while its entry lingered in `upd$add` / `upd$mod`. A new
+  `merge_staged_links()` / `merge_staged_stacks()` overlay now merges the
+  refreshed applied state with the staged add / edit / rm deltas instead of
+  replacing it, mirroring the blockr.dock edit-board extension.
+* The manage-links and manage-stacks plugins now dedupe board re-emits
+  (#246). The board-sync observers keyed off `board_links()` /
+  `board_stacks()` fired on each board invalidation -- `observeEvent` does
+  not value-dedupe -- so a fresh board object carrying byte-identical links
+  or stacks still re-ran the handler. A new shared
+  `deduped_board_reactive()` helper wraps each board accessor in a
+  `reactiveVal` + `identical()` guard and keys the re-sync off the deduped
+  value, so a board update that leaves the links or stacks untouched never
+  reaches the plugin.
+
 * Block registry entries gained a structured argument specification, built
   with the new exported `new_block_args()` / `new_block_arg()`, carrying a
   per-argument `description`, a single worked `example`, and an optional

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -355,6 +355,23 @@ bs_theme_colors <- function(session) {
   )
 }
 
+deduped_board_reactive <- function(board, accessor) {
+
+  val <- reactiveVal(isolate(accessor(board$board)))
+
+  observe(
+    {
+      new <- accessor(board$board)
+
+      if (!identical(new, isolate(val()))) {
+        val(new)
+      }
+    }
+  )
+
+  val
+}
+
 setup_board <- function(rv, blk_ed, blk_ct, stk_mod, args, sess) {
 
   stopifnot(

--- a/R/plugin-links.R
+++ b/R/plugin-links.R
@@ -51,10 +51,12 @@ manage_links_server <- function(id, board, update, ...) {
         edit = NULL
       )
 
+      applied_links <- deduped_board_reactive(board, board_links)
+
       observeEvent(
-        board_links(board$board),
+        applied_links(),
         {
-          upd$curr <- board_links(board$board)
+          upd$curr <- merge_staged_links(applied_links(), upd$add, upd$rm)
         }
       )
 
@@ -357,6 +359,10 @@ create_link_obs_observer <- function(input, rv, upd, session, proxy) {
     {
       ids <- names(upd$curr)
 
+      if (setequal(ids, names(upd$obs))) {
+        return()
+      }
+
       DT::replaceData(
         proxy,
         dt_board_link(upd$curr, session$ns, rv$board),
@@ -396,6 +402,20 @@ edit_link_observer <- function(upd, rv) {
       }
     }
   )
+}
+
+merge_staged_links <- function(applied, add, rm) {
+
+  keep <- setdiff(names(applied), setdiff(rm, names(add)))
+  out <- applied[keep]
+
+  edited <- intersect(keep, names(add))
+
+  if (length(edited)) {
+    out[edited] <- add[edited]
+  }
+
+  c(out, add[setdiff(names(add), names(applied))])
 }
 
 add_link_observer <- function(input, rv, upd, sess) {

--- a/R/plugin-stacks.R
+++ b/R/plugin-stacks.R
@@ -54,10 +54,14 @@ manage_stacks_server <- function(id, board, update, ...) {
         edit = NULL
       )
 
+      applied_stacks <- deduped_board_reactive(board, board_stacks)
+
       observeEvent(
-        board_stacks(board$board),
+        applied_stacks(),
         {
-          upd$curr <- board_stacks(board$board)
+          upd$curr <- merge_staged_stacks(
+            applied_stacks(), upd$add, upd$rm, upd$mod
+          )
         }
       )
 
@@ -299,9 +303,13 @@ destroy_dt_stack_obs <- function(ids, update) {
 create_stack_obs_observer <- function(input, rv, upd, sess, proxy) {
 
   observeEvent(
-    upd$curr,
+    names(upd$curr),
     {
       ids <- names(upd$curr)
+
+      if (setequal(ids, names(upd$obs))) {
+        return()
+      }
 
       DT::replaceData(
         proxy,
@@ -349,6 +357,20 @@ edit_stack_observer <- function(upd, rv) {
       }
     }
   )
+}
+
+merge_staged_stacks <- function(applied, add, rm, mod) {
+
+  keep <- setdiff(names(applied), rm)
+  out <- applied[keep]
+
+  modded <- intersect(keep, names(mod))
+
+  if (length(modded)) {
+    out[modded] <- mod[modded]
+  }
+
+  c(out, add[setdiff(names(add), names(applied))])
 }
 
 add_stack_observer <- function(input, rv, upd, sess) {

--- a/tests/testthat/test-plugin-links.R
+++ b/tests/testthat/test-plugin-links.R
@@ -215,6 +215,182 @@ test_that("add/rm links return validation", {
   )
 })
 
+test_that("merge_staged_links overlays staged edits on refreshed links", {
+
+  applied <- links(
+    l1 = new_link(from = "a", to = "c", input = "1"),
+    l2 = new_link(from = "b", to = "c", input = "2")
+  )
+
+  expect_identical(
+    merge_staged_links(applied, links(), character()),
+    applied
+  )
+
+  added <- links(x = new_link(from = "", to = "", input = ""))
+  expect_identical(
+    merge_staged_links(applied, added, character()),
+    c(applied, added)
+  )
+
+  edited <- links(l1 = new_link(from = "a", to = "c", input = "9"))
+  in_place <- applied
+  in_place["l1"] <- edited
+  expect_identical(merge_staged_links(applied, edited, "l1"), in_place)
+
+  expect_named(merge_staged_links(applied, links(), "l2"), "l1")
+
+  expect_named(
+    merge_staged_links(applied["l1"], added, character()),
+    c("l1", "x")
+  )
+})
+
+test_that("manage links keeps staged edits when the board re-emits", {
+
+  board <- new_board(
+    blocks = c(
+      a = new_dataset_block("iris"),
+      b = new_subset_block(),
+      c = new_subset_block()
+    )
+  )
+
+  testServer(
+    manage_links_server,
+    {
+      session$flushReact()
+
+      session$setInputs(add_link = 1)
+      session$flushReact()
+
+      row <- names(upd$add)
+      expect_length(upd$curr, 1L)
+      expect_identical(names(upd$curr), row)
+
+      board$board <- new_board(
+        blocks = c(
+          a = new_dataset_block("iris"),
+          b = new_subset_block(),
+          c = new_subset_block()
+        )
+      )
+      session$flushReact()
+
+      expect_length(upd$curr, 1L)
+      expect_identical(names(upd$curr), row)
+      expect_identical(upd$add, upd$curr[row])
+
+      upd$edit <- list(row = row, col = "from", val = "a")
+      session$flushReact()
+      upd$edit <- list(row = row, col = "to", val = "c")
+      session$flushReact()
+      upd$edit <- list(row = row, col = "input", val = "data")
+      session$flushReact()
+
+      session$setInputs(modify_links = 1)
+
+      res <- update()$links
+
+      expect_s3_class(res$add, "links")
+      expect_length(res$add, 1L)
+    },
+    args = list(board = reactiveValues(board = board), update = reactiveVal())
+  )
+})
+
+test_that("manage links redraws only when the id set changes", {
+
+  redraws <- 0L
+
+  local_mocked_bindings(
+    replaceData = function(...) redraws <<- redraws + 1L,
+    .package = "DT"
+  )
+
+  board <- new_board(
+    blocks = c(
+      a = new_dataset_block("iris"),
+      b = new_subset_block()
+    ),
+    links = links(aa = new_link(from = "a", to = "b"))
+  )
+
+  testServer(
+    manage_links_server,
+    {
+      session$flushReact()
+
+      expect_identical(names(upd$curr), "aa")
+      expect_setequal(names(upd$obs), "aa")
+
+      base <- redraws
+
+      upd$curr <- links(aa = new_link(from = "a", to = ""))
+      session$flushReact()
+
+      expect_identical(names(upd$curr), "aa")
+      expect_identical(redraws, base)
+      expect_setequal(names(upd$obs), "aa")
+
+      upd$curr <- links(
+        aa = new_link(from = "a", to = ""),
+        bb = new_link(from = "b", to = "")
+      )
+      session$flushReact()
+
+      expect_gt(redraws, base)
+      expect_setequal(names(upd$obs), c("aa", "bb"))
+    },
+    args = list(board = reactiveValues(board = board), update = reactiveVal())
+  )
+})
+
+test_that("manage links ignores no-op board re-emits", {
+
+  link_syncs <- 0L
+
+  real_merge_links <- merge_staged_links
+
+  local_mocked_bindings(
+    merge_staged_links = function(...) {
+      link_syncs <<- link_syncs + 1L
+      real_merge_links(...)
+    }
+  )
+
+  board <- new_board(
+    blocks = c(
+      a = new_dataset_block("iris"),
+      b = new_subset_block()
+    ),
+    links = links(aa = new_link(from = "a", to = "b"))
+  )
+
+  testServer(
+    manage_links_server,
+    {
+      session$flushReact()
+
+      expect_gt(link_syncs, 0L)
+
+      link_base <- link_syncs
+
+      board$board <- new_board(
+        blocks = c(
+          a = new_dataset_block("iris"),
+          b = new_subset_block()
+        ),
+        links = links(aa = new_link(from = "a", to = "b"))
+      )
+      session$flushReact()
+
+      expect_identical(link_syncs, link_base)
+    },
+    args = list(board = reactiveValues(board = board), update = reactiveVal())
+  )
+})
+
 test_that("dummy ad/rm link ui test", {
   expect_s3_class(manage_links_ui("link", new_board()), "shiny.tag.list")
   expect_s3_class(links_modal(NS("links")), "shiny.tag")

--- a/tests/testthat/test-plugin-stacks.R
+++ b/tests/testthat/test-plugin-stacks.R
@@ -210,6 +210,178 @@ test_that("add/rm stacks return validation", {
   )
 })
 
+test_that("merge_staged_stacks overlays staged edits on refreshed stacks", {
+
+  applied <- stacks(
+    k1 = new_stack(name = "One"),
+    k2 = new_stack(name = "Two")
+  )
+
+  expect_identical(
+    merge_staged_stacks(applied, stacks(), character(), stacks()),
+    applied
+  )
+
+  added <- stacks(z = new_stack(name = "Zed"))
+  expect_identical(
+    merge_staged_stacks(applied, added, character(), stacks()),
+    c(applied, added)
+  )
+
+  modded <- stacks(k1 = new_stack(name = "Renamed"))
+  in_place <- applied
+  in_place[["k1"]] <- modded[["k1"]]
+  expect_identical(
+    merge_staged_stacks(applied, stacks(), character(), modded),
+    in_place
+  )
+
+  expect_named(
+    merge_staged_stacks(applied, added, "k2", stacks()),
+    c("k1", "z")
+  )
+})
+
+test_that("manage stacks keeps staged edits when the board re-emits", {
+
+  board <- new_board(
+    blocks = c(
+      a = new_dataset_block("iris"),
+      b = new_subset_block()
+    )
+  )
+
+  testServer(
+    manage_stacks_server,
+    {
+      session$flushReact()
+
+      session$setInputs(add_stack = 1)
+      session$flushReact()
+
+      row <- names(upd$add)
+      expect_length(upd$curr, 1L)
+
+      upd$edit <- list(row = row, col = "blocks", val = "a")
+      session$flushReact()
+
+      expect_named(upd$add, row)
+      expect_true(row %in% names(upd$curr))
+
+      board$board <- new_board(
+        blocks = c(
+          a = new_dataset_block("iris"),
+          b = new_subset_block()
+        )
+      )
+      session$flushReact()
+
+      expect_true(row %in% names(upd$curr))
+      expect_named(upd$add, row)
+      expect_identical(upd$curr[[row]], upd$add[[row]])
+
+      session$setInputs(modify_stacks = 1)
+
+      res <- update()$stacks
+
+      expect_named(res$add, row)
+    },
+    args = list(board = reactiveValues(board = board), update = reactiveVal())
+  )
+})
+
+test_that("manage stacks redraws only when the id set changes", {
+
+  redraws <- 0L
+
+  local_mocked_bindings(
+    replaceData = function(...) redraws <<- redraws + 1L,
+    .package = "DT"
+  )
+
+  board <- new_board(
+    blocks = c(
+      a = new_dataset_block("iris"),
+      b = new_subset_block()
+    ),
+    stacks = stacks(ab = c("a", "b"))
+  )
+
+  testServer(
+    manage_stacks_server,
+    {
+      session$flushReact()
+
+      expect_identical(names(upd$curr), "ab")
+      expect_setequal(names(upd$obs), "ab")
+
+      base <- redraws
+
+      upd$curr <- stacks(ab = new_stack(blocks = "a", name = "ab"))
+      session$flushReact()
+
+      expect_identical(names(upd$curr), "ab")
+      expect_identical(redraws, base)
+      expect_setequal(names(upd$obs), "ab")
+
+      upd$curr <- stacks(
+        ab = new_stack(blocks = "a", name = "ab"),
+        cd = new_stack(blocks = "b", name = "cd")
+      )
+      session$flushReact()
+
+      expect_gt(redraws, base)
+      expect_setequal(names(upd$obs), c("ab", "cd"))
+    },
+    args = list(board = reactiveValues(board = board), update = reactiveVal())
+  )
+})
+
+test_that("manage stacks ignores no-op board re-emits", {
+
+  stack_syncs <- 0L
+
+  real_merge_stacks <- merge_staged_stacks
+
+  local_mocked_bindings(
+    merge_staged_stacks = function(...) {
+      stack_syncs <<- stack_syncs + 1L
+      real_merge_stacks(...)
+    }
+  )
+
+  board <- new_board(
+    blocks = c(
+      a = new_dataset_block("iris"),
+      b = new_subset_block()
+    ),
+    stacks = stacks(s1 = new_stack(blocks = "a", name = "One"))
+  )
+
+  testServer(
+    manage_stacks_server,
+    {
+      session$flushReact()
+
+      expect_gt(stack_syncs, 0L)
+
+      stack_base <- stack_syncs
+
+      board$board <- new_board(
+        blocks = c(
+          a = new_dataset_block("iris"),
+          b = new_subset_block()
+        ),
+        stacks = stacks(s1 = new_stack(blocks = "a", name = "One"))
+      )
+      session$flushReact()
+
+      expect_identical(stack_syncs, stack_base)
+    },
+    args = list(board = reactiveValues(board = board), update = reactiveVal())
+  )
+})
+
 test_that("dummy ad/rm stack ui test", {
   expect_s3_class(manage_stacks_ui("stack", new_board()), "shiny.tag.list")
   expect_s3_class(stacks_modal(NS("stacks")), "shiny.tag")


### PR DESCRIPTION
## Summary

- Guard the manage-links and manage-stacks table redraw on the id set so `DT::replaceData` only runs when a link or stack is actually added or removed, not on every `upd$curr` invalidation; value edits and no-op re-emits are skipped, mirroring blockr.dock#279.
- Overlay staged add / edit / rm deltas onto the refreshed applied state via new `merge_staged_links()` / `merge_staged_stacks()` helpers instead of replacing `upd$curr`, so a half-finished staged edit survives a board re-emit, mirroring blockr.dock#277.
- Dedupe the board accessor behind a shared `deduped_board_reactive()` helper (`reactiveVal` + `identical()`) and key each re-sync off the deduped value, so a board update that leaves the links or stacks untouched never reaches the plugin, mirroring blockr.dock#281.

Fixes #246