### PR TITLE
Drop the broken NULL fallback claim from board param docs

### DIFF
--- a/R/board-options.R
+++ b/R/board-options.R
@@ -275,8 +275,7 @@ get_board_opt_rv_from_userdata <- function(opt, session = get_session()) {
 
 #' @param val New value
 #' @param board Board the option belongs to, used to resolve the lock
-#' state (see [is_board_locked()]); pass `NULL` to fall back to the
-#' option.
+#' state (see [is_board_locked()]).
 #' @rdname new_board_options
 #' @export
 set_board_option_value <- function(opt, val, board, session = get_session()) {

--- a/man/new_board_options.Rd
+++ b/man/new_board_options.Rd
@@ -198,8 +198,7 @@ combine_board_options(...)
 \item{val}{New value}
 
 \item{board}{Board the option belongs to, used to resolve the lock
-state (see \code{\link[=is_board_locked]{is_board_locked()}}); pass \code{NULL} to fall back to the
-option.}
+state (see \code{\link[=is_board_locked]{is_board_locked()}}).}
 
 \item{opts}{Board options}
 


### PR DESCRIPTION
## Summary

- `set_board_option_value()`'s `@param board` promised that passing `NULL` falls back to the option, but `is_board_locked()` has only a `board` method — no `NULL`/default — so that path errors, and no call site passes `NULL`.
- Drop the misleading sentence and document `board` as the required lock-dispatch argument it is.

This is the core-side resolution of #236. The production crash additionally needs the downstream call sites still on the pre-#230 3-arg form (`set_board_option_value(opt, val, session)`, which lands the session in `board`) threaded through to the 4-arg signature — `blockr.io`, `blockr.theme`, `blockr.topline` — which is separate-repo work tracked in those repos. See the issue comment for the verified call-site status.

Fixes #236
