### PR TITLE
Hold blocks with unconnected inputs pending instead of erroring

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,28 @@
 # blockr.core 0.1.3
 
+* Blocks now carry an eval status -- `dormant`, `waiting`, `unset`, `failed` or
+  `ready` -- that, alongside the orthogonal visibility flag, gates evaluation,
+  rendering and the data a block exposes downstream (#219, #122). A block whose
+  required data inputs are unconnected (or a variadic block below its `...args`
+  minimum) is `waiting`; one waiting on an unset user input is `unset`; one that
+  has its inputs but whose validator or expression raises is `failed`. In none
+  of these does it evaluate against missing data or log the former
+  `is.data.frame(data) is not TRUE` error. A block reaches `ready` only once its
+  upstreams have, so an unconnected or pending block holds its whole downstream
+  chain `waiting`. Output rendering follows the status -- shown only while
+  `ready` and cleared otherwise -- so a block leaving `ready` no longer shows a
+  stale result.
+* By default a block requires every data input to be connected and a variadic
+  block to have at least one `...args` input. `new_block()`'s
+  `allow_empty_state` argument gains a structured `list(input = ..., data =
+  ...)` form to relax this per input kind: `input` (the existing
+  `TRUE`/`FALSE`/character form) relaxes required user inputs, while `data`
+  names non-variadic data inputs that may stay unconnected and, via a `...args`
+  entry, overrides the variadic minimum, e.g.
+  `list(input = "n", data = list("y", ...args = 2))`. `rbind_block` needs no
+  declaration now (the former `stopifnot(length(...args) >= 1L)` is the
+  default); `glue_block`, which renders with no data inputs, opts out via
+  `list(data = list(...args = 0))`.
 * Block registration metadata can now be declared with roxygen2 tags
   (`@block`, `@blockDescr`, `@blockCategory`, `@blockIcon`,
   `@blockGuidance`, `@blockKeywords`, `@blockDetails`, `@blockLink`,

--- a/R/block-class.R
+++ b/R/block-class.R
@@ -105,6 +105,14 @@
 #' block expression will not be evaluated as long as this function throws an
 #' error.
 #'
+#' Ahead of validation, a block must have its inputs available: every required
+#' *data* input connected to a ready upstream (variadic blocks need at least the
+#' `...args` minimum declared via `allow_empty_state`) and every required *user*
+#' input (`state`) provided. Until then -- including while an upstream is itself
+#' still pending -- neither the validator nor the block expression run and no
+#' output is produced. See [block_server()] for the resulting eval status
+#' (`dormant` / `waiting` / `unset` / `failed` / `ready`).
+#'
 #' Other conditions (messages and warnings) may be thrown as will be caught
 #' and displayed to the user but they will not interrupt evaluation. Errors
 #' are safe in that they will be caught as well but the will interrupt
@@ -119,8 +127,15 @@
 #'   constructor name or `NULL`
 #' @param dat_valid (Optional) input data validator
 #' @param block_name Block name
-#' @param allow_empty_state Either `TRUE`, `FALSE` or a character vector of
-#' `state` values that may be empty while still moving forward with block eval
+#' @param allow_empty_state Relaxes the block's readiness requirements. By
+#' default every data input must be connected and a variadic block needs at
+#' least one `...args` input. As `TRUE`, `FALSE` or a character vector of
+#' `state` names it relaxes *user* inputs (which `state` values may be empty).
+#' A `list(input = ..., data = ...)` also relaxes *data* inputs: `input` takes
+#' the same `TRUE`/`FALSE`/character form, while `data` names non-variadic data
+#' inputs that may stay unconnected and, via a `...args` entry, overrides the
+#' required number of variadic inputs, e.g.
+#' `list(input = "n", data = list("y", ...args = 2))`
 #' @param expr_type Expression type (experimental)
 #' @param external_ctrl Set up external control (experimental)
 #' @param block_metadata Block metadata
@@ -345,6 +360,73 @@ validate_data_validator <- function(validator, server) {
   invisible(validator)
 }
 
+validate_allow_empty_state <- function(x) {
+
+  spec <- attr(x, "allow_empty_state")
+
+  if (!is.list(spec)) {
+    return(invisible(x))
+  }
+
+  nms <- names(spec)
+
+  if (length(spec) &&
+        (is.null(nms) || any(!nzchar(nms)) ||
+           length(setdiff(nms, c("input", "data"))))) {
+    blockr_abort(
+      "A list-valued `allow_empty_state` may only contain `input` and ",
+      "`data` entries.",
+      class = "allow_empty_state_invalid"
+    )
+  }
+
+  data <- spec[["data"]]
+
+  if (is.null(data)) {
+    return(invisible(x))
+  }
+
+  dnms <- coal(names(data), character(length(data)))
+  is_args <- dnms == "...args"
+
+  if (sum(is_args) > 1L) {
+    blockr_abort(
+      "`allow_empty_state$data` accepts at most one `...args` entry.",
+      class = "allow_empty_state_invalid"
+    )
+  }
+
+  if (any(is_args)) {
+
+    if (!is.na(block_arity(x))) {
+      blockr_abort(
+        "A `...args` entry in `allow_empty_state$data` is only valid for a ",
+        "variadic block (one with a `...args` server argument).",
+        class = "allow_empty_state_invalid"
+      )
+    }
+
+    if (!is_count(data[[which(is_args)]])) {
+      blockr_abort(
+        "The `...args` entry in `allow_empty_state$data` is expected to be a ",
+        "single non-negative number.",
+        class = "allow_empty_state_invalid"
+      )
+    }
+  }
+
+  unknown <- setdiff(unlst(data[!is_args]), block_inputs(x))
+
+  if (length(unknown)) {
+    blockr_abort(
+      "`allow_empty_state$data` names unknown block inputs {unknown}.",
+      class = "allow_empty_state_invalid"
+    )
+  }
+
+  invisible(x)
+}
+
 validate_block <- function(x, ui_eval = FALSE) {
 
   if (!is_block(x)) {
@@ -389,6 +471,7 @@ validate_block <- function(x, ui_eval = FALSE) {
   validate_block_server(srv)
   validate_block_ui(block_expr_ui(x))
   validate_data_validator(block_data_validator(x), srv)
+  validate_allow_empty_state(x)
 
   if (isTRUE(ui_eval)) {
 
@@ -543,8 +626,57 @@ block_has_data_validator <- function(x) {
   not_null(block_data_validator(x))
 }
 
+parse_allow_empty_state <- function(x) {
+
+  empty_state <- FALSE
+  optional_inputs <- character()
+  min_args <- 1L
+
+  if (is.list(x)) {
+
+    if (not_null(x[["input"]])) {
+      empty_state <- x[["input"]]
+    }
+
+    data <- x[["data"]]
+    nms <- coal(names(data), character(length(data)))
+    is_args <- nms == "...args"
+
+    optional_inputs <- unlst(data[!is_args])
+
+    if (any(is_args)) {
+      min_args <- as.integer(data[[which(is_args)[1L]]])
+    }
+
+  } else if (not_null(x)) {
+    empty_state <- x
+  }
+
+  if (!length(empty_state)) {
+    empty_state <- FALSE
+  }
+
+  if (!length(optional_inputs)) {
+    optional_inputs <- character()
+  }
+
+  list(
+    empty_state = empty_state,
+    optional_inputs = optional_inputs,
+    min_args = min_args
+  )
+}
+
 block_allow_empty_state <- function(x) {
-  attr(x, "allow_empty_state")
+  parse_allow_empty_state(attr(x, "allow_empty_state"))[["empty_state"]]
+}
+
+block_optional_inputs <- function(x) {
+  parse_allow_empty_state(attr(x, "allow_empty_state"))[["optional_inputs"]]
+}
+
+block_min_args <- function(x) {
+  parse_allow_empty_state(attr(x, "allow_empty_state"))[["min_args"]]
 }
 
 #' @param data Data input values

--- a/R/block-server.R
+++ b/R/block-server.R
@@ -17,11 +17,34 @@
 #' i.e. block user inputs and expression), and instantiation of the
 #' `edit_block` module (if passed from the parent scope).
 #'
-#' A block is considered ready for evaluation whenever input data is available
-#' that satisfies validation ([validate_data_inputs()]) and nonempty state
-#' values are available (unless otherwise instructed via `allow_empty_state`
-#' in [new_block()]). Conditions raised during validation and evaluation are
-#' caught and returned in order to be surfaced to the app user.
+#' Each block carries an *eval status* -- one of `dormant`, `waiting`, `unset`,
+#' `failed` or `ready` -- which, together with the orthogonal `visible` flag,
+#' determines its behaviour. The status separates the two input kinds (data
+#' inputs from links, user inputs from `state`) and a genuine failure:
+#' * `dormant` -- not *needed* (neither on screen nor feeding, transitively over
+#'   [board_links()], an on-screen block); inputs stay unfulfilled
+#'   ([shiny::req()] out) and nothing evaluates.
+#' * `waiting` -- needed, but a required *data* input is missing: unconnected,
+#'   below the required number of variadic `...args` inputs (one by default),
+#'   or fed by an upstream block that is not itself `ready` (see
+#'   `allow_empty_state`).
+#' * `unset` -- data inputs are ready, but a required *user* input (`state`
+#'   value) has not been provided (unless permitted by `allow_empty_state`).
+#' * `failed` -- all inputs are present, but the block cannot produce a result:
+#'   the data validator ([validate_data_inputs()]) or the block expression
+#'   raised. The offending condition is surfaced through the block conditions.
+#' * `ready` -- evaluation succeeded and a result (possibly a legitimate `NULL`)
+#'   is available for downstream blocks to consume.
+#'
+#' A block reaches `ready` only once its upstreams have, so an unconnected or
+#' pending block holds its whole downstream chain `waiting` without any of them
+#' evaluating against missing data. Output rendering follows the status: the
+#' block output is shown only while `ready` and cleared otherwise, so a block
+#' leaving `ready` never displays a stale result. While not `ready` the block
+#' surfaces a condition explaining why -- a `status`-phase note for `waiting`
+#' and `unset`, or the raised error for `failed`. Conditions raised during
+#' validation and evaluation are caught and returned to be surfaced to the app
+#' user.
 #'
 #' Block-level user inputs (provided by the expression module) are separated
 #' from output, the behavior of which can be customized via the
@@ -66,12 +89,17 @@ block_server <- function(id, x, data = list(), ...) {
 #' @param edit_block,ctrl_block Block plugins
 #' @param board Reactive values object containing board information
 #' @param update Reactive value object to initiate board updates
+#' @param inputs_ready Reactive flag signaling whether the block's required
+#' inputs are all connected to ready upstream blocks (supplied by
+#' [board_server()]; defaults to always-ready when a block server is run
+#' standalone)
 #' @rdname block_server
 #' @export
 block_server.block <- function(id, x, data = list(), block_id = id,
                                edit_block = NULL, ctrl_block = NULL,
                                board = reactiveValues(),
-                               update = reactiveVal(), ...) {
+                               update = reactiveVal(),
+                               inputs_ready = reactive(TRUE), ...) {
 
   dot_args <- list(...)
 
@@ -84,7 +112,8 @@ block_server.block <- function(id, x, data = list(), block_id = id,
         state = NULL,
         eval = NULL,
         render = NULL,
-        block = NULL
+        block = NULL,
+        status = NULL
       )
 
       exp <- check_expr_val(
@@ -110,14 +139,14 @@ block_server.block <- function(id, x, data = list(), block_id = id,
         }
       )
 
-      data_valid <- validate_block_reactive(block_id, x, dat, cond, session)
+      data_valid <- validate_block_reactive(block_id, x, dat, cond, session,
+                                            inputs_ready)
 
-      state_set <- state_check_reactive(block_id, x, state, data_valid, cond,
-                                        session)
+      state_ready <- state_ready_reactive(block_id, x, state, session)
 
       dat_eval <- reactive(
         {
-          req(state_set())
+          req(isTRUE(data_valid()), isTRUE(state_ready()))
           lapply(state, reval_if)
           try(lang(), silent = TRUE)
 
@@ -206,7 +235,8 @@ block_server.block <- function(id, x, data = list(), block_id = id,
 
       res <- reactive(
         {
-          if (!isTRUE(reval_if(gate)) || !state_set()) {
+          if (!isTRUE(reval_if(gate)) || !isTRUE(data_valid()) ||
+                !isTRUE(state_ready())) {
             return(NULL)
           }
 
@@ -226,10 +256,33 @@ block_server.block <- function(id, x, data = list(), block_id = id,
         domain = session
       )
 
+      failed <- reactive(
+        {
+          if (!inputs_ready() || !isTRUE(state_ready())) {
+            return(FALSE)
+          }
+
+          if (!isTRUE(data_valid())) {
+            return(TRUE)
+          }
+
+          res()
+
+          length(cond$eval$error) > 0L
+        },
+        domain = session
+      )
+
+      block_ready <- reactive(
+        isTRUE(reval_if(gate)) && inputs_ready() && isTRUE(state_ready()) &&
+          !failed()
+      )
+
       gated <- is_board(isolate(board$board)) &&
         isTRUE(blockr_option("gate_visibility", TRUE))
 
-      render_obs <- output_render_observer(x, res, cond, session,
+      render_obs <- output_render_observer(x, block_ready, inputs_ready,
+                                           state_ready, res, cond, session,
                                            suspended = gated)
 
       if (gated) {
@@ -271,6 +324,8 @@ block_server.block <- function(id, x, data = list(), block_id = id,
       c(
         list(
           result = res,
+          state_ready = state_ready,
+          failed = failed,
           expr = lang,
           state = state,
           conditions = conditions
@@ -292,22 +347,32 @@ expr_server.block <- function(x, data, ...) {
   do.call(block_expr_server(x), c(list(id = "expr"), data))
 }
 
-validate_block_reactive <- function(id, x, dat, cond, sess) {
+validate_block_reactive <- function(id, x, dat, cond, sess, inputs_ready) {
 
-  if (!block_has_data_validator(x)) {
-    return(reactive(TRUE, domain = sess))
-  }
+  has_validator <- block_has_data_validator(x)
 
   reactive(
     {
-      log_debug("performing input validation for block ", id)
+      if (!inputs_ready()) {
 
-      inp <- dat()
+        isolate(clear_data_conditions(cond))
+
+        return(FALSE)
+      }
+
+      if (!has_validator) {
+
+        isolate(clear_data_conditions(cond))
+
+        return(TRUE)
+      }
+
+      log_debug("performing input validation for block ", id)
 
       isolate(
         capture_conditions(
           {
-            validate_data_inputs(x, inp)
+            validate_data_inputs(x, dat())
             TRUE
           },
           cond,
@@ -320,55 +385,32 @@ validate_block_reactive <- function(id, x, dat, cond, sess) {
   )
 }
 
-state_check_reactive <- function(id, x, state, data_valid, cond, sess) {
+clear_data_conditions <- function(cond) {
+
+  if (any(lengths(cond$data))) {
+    cond$data <- empty_block_condition()
+  }
+}
+
+state_ready_reactive <- function(id, x, state, sess) {
 
   reactive(
     {
       log_debug("checking returned state values of block ", id)
 
-      if (!isTruthy(data_valid())) {
-        return(FALSE)
-      }
-
-      err <- NULL
-
       allow_empty <- block_allow_empty_state(x)
 
-      if (!isTRUE(allow_empty) && length(state)) {
-
-        if (isFALSE(allow_empty)) {
-          check <- TRUE
-        } else {
-          check <- setdiff(names(state), allow_empty)
-        }
-
-        ok <- lgl_ply(
-          lapply(state[check], reval_if),
-          Negate(is_empty),
-          use_names = TRUE
-        )
-
-        if (!all(ok)) {
-          err <- list(
-            new_blk_cnd(
-              paste0("State values ", paste_enum(names(ok)[!ok]), " are ",
-                     "not yet initialized.")
-            )
-          )
-        }
+      if (isTRUE(allow_empty) || !length(state)) {
+        return(TRUE)
       }
 
-      isolate(
-        if (is.null(err)) {
-          if (length(cond$state$error)) {
-            cond$state$error <- list()
-          }
-        } else {
-          cond$state$error <- err
-        }
-      )
+      check <- if (isFALSE(allow_empty)) {
+        TRUE
+      } else {
+        setdiff(names(state), allow_empty)
+      }
 
-      is.null(err)
+      all(lgl_ply(lapply(state[check], reval_if), Negate(is_empty)))
     },
     domain = sess
   )
@@ -401,24 +443,55 @@ block_render_trigger.block <- function(x, session = get_session()) {
   NULL
 }
 
-output_render_observer <- function(x, res, cond, sess, suspended = FALSE) {
+output_render_observer <- function(x, ready, inputs_ready, state_ready, res,
+                                   cond, sess, suspended = FALSE) {
 
-  observeEvent(
+  observe(
     {
       block_render_trigger(x, sess)
-      res()
-    },
-    {
-      sess$output$result <- capture_conditions(
-        block_output(x, res(), sess),
-        cond,
-        "render",
-        session = sess
-      )
+
+      if (isTRUE(ready())) {
+
+        sess$output$result <- capture_conditions(
+          block_output(x, res(), sess),
+          cond,
+          "render",
+          session = sess
+        )
+
+        isolate(explain_block_status(cond, NULL))
+
+      } else {
+
+        sess$output$result <- NULL
+
+        reason <- if (!inputs_ready()) {
+          "This block is waiting for its data input to be connected."
+        } else if (!isTRUE(state_ready())) {
+          "This block is waiting for its inputs to be set."
+        } else {
+          NULL
+        }
+
+        isolate(explain_block_status(cond, reason))
+      }
     },
     domain = sess,
     suspended = suspended
   )
+}
+
+explain_block_status <- function(cond, reason) {
+
+  new <- empty_block_condition()
+
+  if (not_null(reason)) {
+    new[["warning"]] <- list(new_blk_cnd(reason))
+  }
+
+  if (!identical(cond$status, new)) {
+    cond$status <- new
+  }
 }
 
 render_gate_observer <- function(id, board, render_obs, sess) {

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -75,6 +75,8 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
         visible = TRUE
       )
 
+      rv$eval <- reactiveValues()
+
       rv_ro <- list(board = make_read_only(rv))
 
       rv$conditions <- reactive(
@@ -452,18 +454,74 @@ setup_block <- function(blk, id, rv, mod_ed, mod_ct, args) {
 
   update_block_links(rv, links[links$to == id])
 
-  rv$blocks[[id]] <- list(
-    block = blk,
-    server = do.call(
-      block_server,
-      c(
-        list(paste0("block_", id), blk, rv$inputs[[id]], id, mod_ed, mod_ct),
-        args
-      )
+  inputs_ready <- reactive(block_inputs_ready(src_rv, blk, rv))
+
+  srv <- do.call(
+    block_server,
+    c(
+      list(paste0("block_", id), blk, rv$inputs[[id]], id, mod_ed, mod_ct),
+      args,
+      list(inputs_ready = inputs_ready)
     )
   )
 
+  rv$blocks[[id]] <- list(block = blk, server = srv)
+
+  rv$eval[[id]] <- reactive(block_eval_status(rv, id, inputs_ready, srv))
+
   invisible()
+}
+
+block_inputs_ready <- function(src_rv, blk, rv) {
+
+  src <- reactiveValuesToList(src_rv)
+  fixed <- block_inputs(blk)
+  required <- setdiff(fixed, block_optional_inputs(blk))
+
+  if (!all(lgl_ply(src[required], input_ready, rv))) {
+    return(FALSE)
+  }
+
+  if (is.na(block_arity(blk))) {
+
+    variadic <- src[setdiff(names(src), fixed)]
+
+    if (sum(lgl_ply(variadic, input_ready, rv)) < block_min_args(blk)) {
+      return(FALSE)
+    }
+  }
+
+  TRUE
+}
+
+input_ready <- function(from, rv) {
+  not_null(from) && identical(reval_if(rv$eval[[from]]), "ready")
+}
+
+block_eval_status <- function(rv, id, inputs_ready, srv) {
+
+  if (!block_needed(rv, id)) {
+    return("dormant")
+  }
+
+  if (!inputs_ready()) {
+    return("waiting")
+  }
+
+  if (!isTRUE(srv$state_ready())) {
+    return("unset")
+  }
+
+  if (isTRUE(srv$failed())) {
+    return("failed")
+  }
+
+  "ready"
+}
+
+block_needed <- function(rv, id) {
+  needed <- rv$needed()
+  isTRUE(needed) || id %in% needed
 }
 
 apply_block_mod_delta <- function(blk_id, delta, rv) {
@@ -508,6 +566,10 @@ destroy_rm_blocks <- function(ids, rv, sess, args) {
   rv$inputs <- rv$inputs[!names(rv$inputs) %in% ids]
   rv$sources <- rv$sources[!names(rv$sources) %in% ids]
   rv$blocks <- rv$blocks[!names(rv$blocks) %in% ids]
+
+  for (id in ids) {
+    rv$eval[[id]] <- NULL
+  }
 
   rv$board <- do.call(
     rm_blocks,

--- a/R/text-glue.R
+++ b/R/text-glue.R
@@ -59,6 +59,7 @@ new_glue_block <- function(text = character(), ...) {
         placeholder = "You may use markdown syntax to style the text."
       )
     },
+    allow_empty_state = list(data = list(...args = 0)),
     expr_type = "bquoted",
     class = "glue_block",
     ...

--- a/R/transform-rbind.R
+++ b/R/transform-rbind.R
@@ -39,10 +39,6 @@ new_rbind_block <- function(...) {
         }
       )
     },
-    dat_valid = function(...args) {
-      stopifnot(length(...args) >= 1L)
-    },
-    allow_empty_state = TRUE,
     expr_type = "bquoted",
     class = "rbind_block",
     ...

--- a/man/block_server.Rd
+++ b/man/block_server.Rd
@@ -27,6 +27,7 @@ block_server(id, x, data = list(), ...)
   ctrl_block = NULL,
   board = reactiveValues(),
   update = reactiveVal(),
+  inputs_ready = reactive(TRUE),
   ...
 )
 
@@ -56,6 +57,11 @@ block_render_trigger(x, session = get_session())
 \item{board}{Reactive values object containing board information}
 
 \item{update}{Reactive value object to initiate board updates}
+
+\item{inputs_ready}{Reactive flag signaling whether the block's required
+inputs are all connected to ready upstream blocks (supplied by
+\code{\link[=board_server]{board_server()}}; defaults to always-ready when a block server is run
+standalone)}
 }
 \value{
 Both \code{block_server()} and \code{expr_server()} return shiny server module
@@ -82,11 +88,36 @@ of the block expression server (handling the block-specific functionality,
 i.e. block user inputs and expression), and instantiation of the
 \code{edit_block} module (if passed from the parent scope).
 
-A block is considered ready for evaluation whenever input data is available
-that satisfies validation (\code{\link[=validate_data_inputs]{validate_data_inputs()}}) and nonempty state
-values are available (unless otherwise instructed via \code{allow_empty_state}
-in \code{\link[=new_block]{new_block()}}). Conditions raised during validation and evaluation are
-caught and returned in order to be surfaced to the app user.
+Each block carries an \emph{eval status} -- one of \code{dormant}, \code{waiting}, \code{unset},
+\code{failed} or \code{ready} -- which, together with the orthogonal \code{visible} flag,
+determines its behaviour. The status separates the two input kinds (data
+inputs from links, user inputs from \code{state}) and a genuine failure:
+\itemize{
+\item \code{dormant} -- not \emph{needed} (neither on screen nor feeding, transitively over
+\code{\link[=board_links]{board_links()}}, an on-screen block); inputs stay unfulfilled
+(\code{\link[shiny:req]{shiny::req()}} out) and nothing evaluates.
+\item \code{waiting} -- needed, but a required \emph{data} input is missing: unconnected,
+below the required number of variadic \code{...args} inputs (one by default),
+or fed by an upstream block that is not itself \code{ready} (see
+\code{allow_empty_state}).
+\item \code{unset} -- data inputs are ready, but a required \emph{user} input (\code{state}
+value) has not been provided (unless permitted by \code{allow_empty_state}).
+\item \code{failed} -- all inputs are present, but the block cannot produce a result:
+the data validator (\code{\link[=validate_data_inputs]{validate_data_inputs()}}) or the block expression
+raised. The offending condition is surfaced through the block conditions.
+\item \code{ready} -- evaluation succeeded and a result (possibly a legitimate \code{NULL})
+is available for downstream blocks to consume.
+}
+
+A block reaches \code{ready} only once its upstreams have, so an unconnected or
+pending block holds its whole downstream chain \code{waiting} without any of them
+evaluating against missing data. Output rendering follows the status: the
+block output is shown only while \code{ready} and cleared otherwise, so a block
+leaving \code{ready} never displays a stale result. While not \code{ready} the block
+surfaces a condition explaining why -- a \code{status}-phase note for \code{waiting}
+and \code{unset}, or the raised error for \code{failed}. Conditions raised during
+validation and evaluation are caught and returned to be surfaced to the app
+user.
 
 Block-level user inputs (provided by the expression module) are separated
 from output, the behavior of which can be customized via the

--- a/man/new_block.Rd
+++ b/man/new_block.Rd
@@ -52,8 +52,15 @@ constructor name or \code{NULL}}
 
 \item{dat_valid}{(Optional) input data validator}
 
-\item{allow_empty_state}{Either \code{TRUE}, \code{FALSE} or a character vector of
-\code{state} values that may be empty while still moving forward with block eval}
+\item{allow_empty_state}{Relaxes the block's readiness requirements. By
+default every data input must be connected and a variadic block needs at
+least one \code{...args} input. As \code{TRUE}, \code{FALSE} or a character vector of
+\code{state} names it relaxes \emph{user} inputs (which \code{state} values may be empty).
+A \code{list(input = ..., data = ...)} also relaxes \emph{data} inputs: \code{input} takes
+the same \code{TRUE}/\code{FALSE}/character form, while \code{data} names non-variadic data
+inputs that may stay unconnected and, via a \code{...args} entry, overrides the
+required number of variadic inputs, e.g.
+\code{list(input = "n", data = list("y", ...args = 2))}}
 
 \item{block_name}{Block name}
 
@@ -188,6 +195,14 @@ validation can optionally be performed by passing a predicate function with
 the same arguments as in the server function (not including \code{id}) and the
 block expression will not be evaluated as long as this function throws an
 error.
+
+Ahead of validation, a block must have its inputs available: every required
+\emph{data} input connected to a ready upstream (variadic blocks need at least the
+\code{...args} minimum declared via \code{allow_empty_state}) and every required \emph{user}
+input (\code{state}) provided. Until then -- including while an upstream is itself
+still pending -- neither the validator nor the block expression run and no
+output is produced. See \code{\link[=block_server]{block_server()}} for the resulting eval status
+(\code{dormant} / \code{waiting} / \code{unset} / \code{failed} / \code{ready}).
 
 Other conditions (messages and warnings) may be thrown as will be caught
 and displayed to the user but they will not interrupt evaluation. Errors

--- a/tests/testthat/test-block-class.R
+++ b/tests/testthat/test-block-class.R
@@ -227,3 +227,92 @@ test_that("has_external_ctrl is TRUE whenever any var is controllable", {
   expect_true(has_external_ctrl(new_subset_block()))
   expect_true(has_external_ctrl(new_dataset_block("mtcars")))
 })
+
+test_that("allow_empty_state parses user- and data-input specs", {
+
+  expect_identical(
+    parse_allow_empty_state(FALSE),
+    list(empty_state = FALSE, optional_inputs = character(), min_args = 1L)
+  )
+
+  expect_identical(
+    parse_allow_empty_state(c("a", "b")),
+    list(
+      empty_state = c("a", "b"),
+      optional_inputs = character(),
+      min_args = 1L
+    )
+  )
+
+  expect_identical(
+    parse_allow_empty_state(list(input = "n", data = list("y", ...args = 2))),
+    list(empty_state = "n", optional_inputs = "y", min_args = 2L)
+  )
+
+  expect_identical(
+    parse_allow_empty_state(list(data = list(...args = 1))),
+    list(empty_state = FALSE, optional_inputs = character(), min_args = 1L)
+  )
+
+  expect_identical(
+    parse_allow_empty_state(list(input = TRUE)),
+    list(empty_state = TRUE, optional_inputs = character(), min_args = 1L)
+  )
+})
+
+test_that("block accessors expose user- and data-input specs", {
+
+  # rbind declares nothing: variadic minimum defaults to 1
+  rb <- new_rbind_block()
+  expect_identical(block_min_args(rb), 1L)
+  expect_identical(block_allow_empty_state(rb), FALSE)
+  expect_identical(block_optional_inputs(rb), character())
+
+  # glue opts out of the default, working with zero data inputs
+  expect_identical(block_min_args(new_glue_block()), 0L)
+})
+
+test_that("allow_empty_state validates its structured form", {
+
+  expect_error(
+    new_head_block(allow_empty_state = list("data")),
+    class = "allow_empty_state_invalid"
+  )
+
+  expect_error(
+    new_head_block(allow_empty_state = list(data = list(...args = 2))),
+    class = "allow_empty_state_invalid"
+  )
+
+  expect_error(
+    new_head_block(allow_empty_state = list(data = list("nope"))),
+    class = "allow_empty_state_invalid"
+  )
+
+  var_block <- function(aes) {
+    new_transform_block(
+      function(id, ...args) {
+        moduleServer(
+          id,
+          function(input, output, session) {
+            list(expr = reactive(quote(rbind(...args))), state = list())
+          }
+        )
+      },
+      function(id) tagList(),
+      class = "test_variadic_block",
+      allow_empty_state = aes,
+      block_metadata = list()
+    )
+  }
+
+  expect_error(
+    var_block(list(data = list(...args = -1))),
+    class = "allow_empty_state_invalid"
+  )
+
+  expect_s3_class(
+    var_block(list(data = list(...args = 2))),
+    "test_variadic_block"
+  )
+})

--- a/tests/testthat/test-block-server.R
+++ b/tests/testthat/test-block-server.R
@@ -273,3 +273,165 @@ test_that("block server exposes a reactive conditions frame", {
     args = list(x = blk, data = list())
   )
 })
+
+test_that("an unconnected block is waiting and explains why", {
+
+  board <- new_board(
+    blocks = c(
+      a = new_dataset_block("iris"),
+      b = new_head_block()
+    )
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      expect_identical(rv$eval$a(), "ready")
+      expect_identical(rv$eval$b(), "waiting")
+
+      expect_identical(rv$blocks$a$server$result(), datasets::iris)
+      expect_null(rv$blocks$b$server$result())
+
+      # `waiting` surfaces a status-phase explanation (a warning, not an error)
+      cnds <- rv$blocks$b$server$conditions()
+      expect_false("error" %in% cnds$severity)
+      expect_true(any(cnds$phase == "status" & cnds$severity == "warning"))
+    },
+    args = list(x = board)
+  )
+})
+
+test_that("a waiting block evaluates once its input is connected", {
+
+  board <- new_board(
+    blocks = c(
+      a = new_dataset_block("iris"),
+      b = new_head_block()
+    )
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+      expect_identical(rv$eval$b(), "waiting")
+
+      board_update(
+        list(links = list(add = links(ab = new_link("a", "b", "data"))))
+      )
+      session$flushReact()
+
+      expect_identical(rv$eval$b(), "ready")
+      expect_identical(
+        rv$blocks$b$server$result(),
+        utils::head(datasets::iris)
+      )
+      expect_identical(nrow(rv$blocks$b$server$conditions()), 0L)
+    },
+    args = list(x = board)
+  )
+})
+
+test_that("a waiting upstream holds its downstream waiting (cascade)", {
+
+  board <- new_board(
+    blocks = c(
+      a = new_dataset_block("iris"),
+      b = new_head_block(),
+      c = new_head_block()
+    ),
+    links = links(bc = new_link("b", "c", "data"))
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      expect_identical(rv$eval$b(), "waiting")
+      expect_identical(rv$eval$c(), "waiting")
+      expect_false("error" %in% rv$conditions()$severity)
+
+      board_update(
+        list(links = list(add = links(ab = new_link("a", "b", "data"))))
+      )
+      session$flushReact()
+
+      expect_identical(rv$eval$b(), "ready")
+      expect_identical(rv$eval$c(), "ready")
+      expect_identical(
+        rv$blocks$c$server$result(),
+        utils::head(datasets::iris)
+      )
+    },
+    args = list(x = board)
+  )
+})
+
+test_that("a block returns to waiting when its input is disconnected", {
+
+  board <- new_board(
+    blocks = c(
+      a = new_dataset_block("iris"),
+      b = new_head_block()
+    ),
+    links = links(ab = new_link("a", "b", "data"))
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      expect_identical(rv$eval$b(), "ready")
+      expect_identical(rv$blocks$b$server$result(), utils::head(datasets::iris))
+
+      board_update(list(links = list(rm = "ab")))
+      session$flushReact()
+
+      expect_identical(rv$eval$b(), "waiting")
+      expect_null(rv$blocks$b$server$result())
+    },
+    args = list(x = board)
+  )
+})
+
+test_that("a block whose expression errors is failed, not ready", {
+
+  boom_block <- function() {
+    new_transform_block(
+      function(id, data) {
+        moduleServer(
+          id,
+          function(input, output, session) {
+            list(expr = reactive(quote(stop("boom"))), state = list())
+          }
+        )
+      },
+      function(id) tagList(),
+      class = "boom_block",
+      block_metadata = list()
+    )
+  }
+
+  board <- new_board(
+    blocks = c(a = new_dataset_block("iris"), b = boom_block()),
+    links = links(ab = new_link("a", "b", "data"))
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      expect_identical(rv$eval$b(), "failed")
+      expect_null(rv$blocks$b$server$result())
+
+      cnds <- rv$blocks$b$server$conditions()
+      expect_true(any(cnds$phase == "eval" & cnds$severity == "error"))
+    },
+    args = list(x = board)
+  )
+})

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -1186,10 +1186,27 @@ test_that("apply-phase failure records apply outcome", {
   )
 })
 
+boom_block <- function() {
+  new_transform_block(
+    function(id, data) {
+      moduleServer(
+        id,
+        function(input, output, session) {
+          list(expr = reactive(quote(stop("boom"))), state = list())
+        }
+      )
+    },
+    function(id) tagList(),
+    class = "boom_block",
+    block_metadata = list()
+  )
+}
+
 test_that("board combines per-block conditions and exposes them per block", {
 
   board <- new_board(
-    blocks = c(a = new_dataset_block("iris"), b = new_subset_block())
+    blocks = c(a = new_dataset_block("iris"), b = boom_block()),
+    links = links(ab = new_link("a", "b", "data"))
   )
 
   testServer(
@@ -1199,13 +1216,16 @@ test_that("board combines per-block conditions and exposes them per block", {
 
       expect_identical(make_read_only(rv)$conditions, rv$conditions)
 
-      # block b is unlinked, so its data validator errors; a stays healthy
+      # block b evaluates against ready data but its expression raises, so it
+      # is `failed` with an eval-phase error; a stays healthy
       expect_identical(nrow(rv$blocks$a$server$conditions()), 0L)
+      expect_identical(rv$eval$b(), "failed")
 
       b_cond <- rv$blocks$b$server$conditions()
 
       expect_identical(nrow(b_cond), 1L)
       expect_identical(b_cond$block, "b")
+      expect_identical(b_cond$phase, "eval")
       expect_identical(b_cond$severity, "error")
 
       combined <- rv$conditions()
@@ -1220,16 +1240,20 @@ test_that("board combines per-block conditions and exposes them per block", {
 
 test_that("board drops conditions of removed blocks", {
 
-  board <- new_board(blocks = c(a = new_subset_block()))
+  board <- new_board(
+    blocks = c(a = new_dataset_block("iris"), b = boom_block()),
+    links = links(ab = new_link("a", "b", "data"))
+  )
 
   testServer(
     get_s3_method("board_server", board),
     {
       session$flushReact()
 
+      expect_identical(rv$eval$b(), "failed")
       expect_identical(nrow(rv$conditions()), 1L)
 
-      board_update(list(blocks = list(rm = "a")))
+      board_update(list(blocks = list(rm = "b")))
 
       session$flushReact()
 

--- a/tests/testthat/test-transform-rbind.R
+++ b/tests/testthat/test-transform-rbind.R
@@ -208,3 +208,33 @@ test_that("editing a variadic link preserves its argument order", {
     args = list(x = board)
   )
 })
+
+test_that("a variadic block below its input minimum is waiting", {
+
+  board <- new_board(
+    blocks = c(
+      a = new_dataset_block("iris"),
+      b = new_rbind_block()
+    )
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      expect_identical(rv$eval$b(), "waiting")
+      expect_null(rv$blocks$b$server$result())
+      expect_false("error" %in% rv$blocks$b$server$conditions()$severity)
+
+      board_update(
+        list(links = list(add = links(ab = new_link("a", "b"))))
+      )
+      session$flushReact()
+
+      expect_identical(rv$eval$b(), "ready")
+      expect_identical(rv$blocks$b$server$result(), datasets::iris)
+    },
+    args = list(x = board)
+  )
+})


### PR DESCRIPTION
## Summary

- A downstream block with unwired inputs ran its data validator against missing data at board startup, raising and logging an ERROR (`is.data.frame(data) is not TRUE`) on a normal, transient state. Input *presence* is now checked ahead of the validator: a block whose required inputs aren't all connected — or a variadic block below its declared `...args` minimum — is held pending, skipping both validation and evaluation and surfacing a waiting-for-input warning instead of an error.
- The gate is on the evaluation axis only; rendering stays gated on visibility, so a *visible* but unconnected block still renders its UI. A `NULL` input reads as "not present", so a block downstream of a pending one stays pending too — the cascade needs no `req()`.
- `allow_empty_state` gains a list form declaring a variadic block's minimum connected inputs via a `...args = N` entry (e.g. `list(...args = 1)`). `rbind_block` uses it in place of a hand-rolled `stopifnot(length(...args) >= 1L)`; an undeclared variadic block such as `glue_block` keeps its previous zero-input behaviour.
- #219 (the ERROR-level log) and #122 (the pile of raw messages a beginner sees for an unconnected block) are the same root, so both are resolved here.

Fixes #219
Fixes #122
