### PR TITLE
Migrate DESCRIPTION to Config/roxygen2/version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,6 @@ BugReports: https://github.com/BristolMyersSquibb/blockr.core/issues
 License: GPL (>= 3)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE, packages = c("roxy.shinylive"))
-RoxygenNote: 8.0.0
 Imports:
     shiny (>= 1.5.0),
     DT,
@@ -127,3 +126,4 @@ Collate:
     'utils-shiny.R'
     'utils-tests.R'
     'zzz-onload.R'
+Config/roxygen2/version: 8.0.0


### PR DESCRIPTION
## Summary

- roxygen2 8.0.0 records its version in `Config/roxygen2/version` and drops `RoxygenNote` on migration. #249 hand-set `RoxygenNote: 8.0.0` before documenting, which made recorded == running and suppressed that migration, leaving the field non-canonical.
- Remove the `RoxygenNote` line and let `roxygenise()` write `Config/roxygen2/version: 8.0.0` — no hand-edit, which would re-suppress the migration. This matches the already-migrated fleet (blockr.session, blockr.assistant) and the field name the fleet docs-freshness gate keys on.
- DESCRIPTION-only: `man/` is already 8.0.0, so regenerating produces no doc churn (verified byte-identical `man/` + `NAMESPACE`).

Fixes #250
