### PR TITLE
Order block-server construction by visibility

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # blockr.core 0.1.3
 
+* Block-server construction is now ordered by visibility (#243). On a large
+  multi-view board `setup_board()` built every block's server up front, so
+  first paint waited for the full per-block construction cost regardless of
+  how many blocks were on screen. Construction is now prioritized by the
+  same *needed* set (on-screen blocks plus their upstream closure) as
+  evaluation: those blocks are built first and the rest are built
+  progressively in the background, so first paint waits only for what is
+  shown. A block still building is absent from the read-only board handed to
+  plugins, and serialization falls back to its constructor state until it
+  appears. Requires a front-end driving the `visible` channel; without one
+  every block is needed and all servers are built up front, as before. The
+  background cadence is the `background_construction_delay` option
+  (milliseconds between successive blocks, default 50); setting it to 0
+  builds every block up front and opts out of the staggering.
 * Board options contributed by blocks or the block registry -- such as the
   table preview `page_size`, `n_rows` and `filter_rows` -- are now serialized
   and restored along with the board. Previously only options owned by the board

--- a/R/block-server.R
+++ b/R/block-server.R
@@ -65,7 +65,15 @@
 #' fully quiescent: its result reactive, and any observer its expression server
 #' registers on the incoming data, all short-circuit and do nothing. A needed
 #' but off-screen block (one feeding a visible block) evaluates but does not
-#' render. With nothing driving
+#' render. Block-server *construction* is prioritized the same way: the needed
+#' set is instantiated first so that first paint waits only for the on-screen
+#' blocks and their upstreams, and the remaining block servers are built
+#' progressively in the background. Until a block is built it is absent from
+#' the `board$blocks` handed to plugins and callbacks, which simply see it
+#' appear once constructed. The background cadence is set by the
+#' `background_construction_delay` [blockr_option()] (milliseconds between
+#' successive blocks, default 50); a value of 0 disables the staggering and
+#' builds every block up front. With nothing driving
 #' `visible` every block is needed and behaviour is unchanged; the
 #' `gate_visibility` [blockr_option()] (default `TRUE`) turns gating off
 #' entirely.

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -410,11 +410,14 @@ setup_board <- function(rv, blk_ed, blk_ct, stk_mod, args, sess) {
   rv$sources <- list()
   rv$stacks <- list()
 
-  blks <- board_blocks(rv$board)
+  observe(
+    {
+      need <- needed_block_ids(rv)
+      construct_blocks(need, rv, blk_ed, blk_ct, args)
+    }
+  )
 
-  for (i in names(blks)) {
-    setup_block(blks[[i]], i, rv, blk_ed, blk_ct, args)
-  }
+  construct_remaining_blocks(rv, blk_ed, blk_ct, args)
 
   setup_stacks(rv, stk_mod, args)
   add_blocks_to_stacks(rv, board_stacks(rv$board), sess)
@@ -434,20 +437,23 @@ combine_block_conditions <- function(frames) {
   res
 }
 
-setup_block <- function(blk, id, rv, mod_ed, mod_ct, args) {
+construct_block <- function(id, rv, mod_ed, mod_ct, args) {
 
-  arity <- block_arity(blk)
-  inpts <- block_inputs(blk)
+  if (id %in% names(rv$blocks)) {
+    return(invisible())
+  }
+
+  blk <- board_blocks(rv$board)[[id]]
 
   rv$sources[[id]] <- reactiveValues()
   src_rv <- rv$sources[[id]]
 
   inpts <- set_names(
-    lapply(inpts, upstream_result, src_rv, rv, id),
-    inpts
+    lapply(block_inputs(blk), upstream_result, src_rv, rv, id),
+    block_inputs(blk)
   )
 
-  if (is.na(arity)) {
+  if (is.na(block_arity(blk))) {
     inpts <- c(inpts, list(`...args` = reactives()))
   }
 
@@ -473,6 +479,77 @@ setup_block <- function(blk, id, rv, mod_ed, mod_ct, args) {
   rv$eval[[id]] <- reactive(block_eval_status(rv, id, inputs_ready, srv))
 
   invisible()
+}
+
+construct_blocks <- function(ids, rv, mod_ed, mod_ct, args) {
+
+  ordered <- isolate(
+    intersect(topo_sort(as.matrix(rv$board)), setdiff(ids, names(rv$blocks)))
+  )
+
+  if (!length(ordered)) {
+    return(invisible())
+  }
+
+  log_debug("constructing block{?s} {ordered}")
+
+  for (id in ordered) {
+    isolate(construct_block(id, rv, mod_ed, mod_ct, args))
+  }
+
+  invisible()
+}
+
+construct_remaining_blocks <- function(rv, mod_ed, mod_ct, args) {
+
+  if (background_construction_delay() <= 0) {
+
+    construct_blocks(board_block_ids(rv$board), rv, mod_ed, mod_ct, args)
+
+    return(invisible())
+  }
+
+  started <- FALSE
+
+  obs <- observe(
+    {
+      if (!started) {
+
+        started <<- TRUE
+        invalidateLater(background_construction_delay())
+
+        return(invisible())
+      }
+
+      remaining <- isolate(
+        setdiff(topo_sort(as.matrix(rv$board)), names(rv$blocks))
+      )
+
+      if (!length(remaining)) {
+
+        obs$destroy()
+
+        return(invisible())
+      }
+
+      isolate(construct_block(remaining[[1L]], rv, mod_ed, mod_ct, args))
+
+      invalidateLater(background_construction_delay())
+    }
+  )
+
+  invisible()
+}
+
+background_construction_delay <- function() {
+  as.numeric(blockr_option("background_construction_delay", 50L))
+}
+
+needed_block_ids <- function(rv) {
+
+  need <- rv$needed()
+
+  if (isTRUE(need)) board_block_ids(rv$board) else need
 }
 
 block_inputs_ready <- function(src_rv, blk, rv) {
@@ -593,11 +670,9 @@ upstream_result <- function(key, src_rv, rv, to) {
 
       from <- src_rv[[key]]
 
-      if (is.null(from)) {
-        NULL
-      } else {
-        isolate(rv$blocks[[from]])$server$result()
-      }
+      srv <- if (is.null(from)) NULL else isolate(rv$blocks[[from]])[["server"]]
+
+      if (is.null(srv)) NULL else srv$result()
     }
   )
 }
@@ -1419,16 +1494,8 @@ apply_core_board_update <- function(rv, upd, session,
 
     board_blocks(rv$board) <- c(board_blocks(rv$board), upd$blocks$add)
 
-    for (blk in names(upd$blocks$add)) {
-      setup_block(
-        upd$blocks$add[[blk]],
-        blk,
-        rv,
-        edit_block,
-        ctrl_block,
-        edit_plugin_args
-      )
-    }
+    construct_blocks(names(upd$blocks$add), rv, edit_block, ctrl_block,
+                     edit_plugin_args)
   }
 
   if (length(upd$blocks$mod)) {
@@ -1440,6 +1507,7 @@ apply_core_board_update <- function(rv, upd, session,
       delta <- upd$blocks$mod[[blk_id]]
 
       if (length(delta)) {
+        construct_block(blk_id, rv, edit_block, ctrl_block, edit_plugin_args)
         apply_block_mod_delta(blk_id, delta, rv)
       }
     }

--- a/R/plugin-serdes.R
+++ b/R/plugin-serdes.R
@@ -142,10 +142,12 @@ serialize_board <- function(x, blocks, id = NULL, ...,
 serialize_board.board <- function(x, blocks, id = NULL, ...,
                                   session = get_session()) {
 
+  states <- lst_xtr(blocks, "server", "state")
+  states <- set_names(states[board_block_ids(x)], board_block_ids(x))
+
   blocks <- lapply(
-    lst_xtr(blocks, "server", "state"),
-    lapply,
-    reval_if
+    states,
+    function(st) if (is.null(st)) NULL else lapply(st, reval_if)
   )
 
   opts <- lapply(

--- a/R/utils-serdes.R
+++ b/R/utils-serdes.R
@@ -61,7 +61,8 @@ blockr_ser.block <- function(x, state = NULL, ...) {
   )
 }
 
-#' @param blocks Block states (`NULL` defaults to values from ctor scope)
+#' @param blocks Block states (`NULL`, or a per-block `NULL` entry, defaults to
+#' values from the constructor scope)
 #' @rdname blockr_ser
 #' @export
 blockr_ser.blocks <- function(x, blocks = NULL, ...) {
@@ -73,7 +74,8 @@ blockr_ser.blocks <- function(x, blocks = NULL, ...) {
   } else {
 
     stopifnot(
-      is.list(blocks), all(lgl_ply(blocks, is.list)),
+      is.list(blocks),
+      all(lgl_ply(blocks, function(b) is.null(b) || is.list(b))),
       length(blocks) == length(x), setequal(names(blocks), names(x))
     )
 

--- a/R/utils-serve.R
+++ b/R/utils-serve.R
@@ -301,12 +301,18 @@ blockr_test_exports <- function(x, rv, ...) {
 #' @export
 blockr_test_exports.board <- function(x, rv, ...) {
   exportTestValues(
-    result = lapply(
+    result = {
+
+      blocks <- rv[[1L]]$blocks
+      ids <- intersect(board_block_ids(rv[[1L]]$board), names(blocks))
+
       lapply(
-        lapply(lst_xtr(rv[[1L]]$blocks, "server", "result"), export_safely),
+        lapply(
+          lapply(lst_xtr(blocks[ids], "server", "result"), export_safely),
+          reval
+        ),
         reval
-      ),
-      reval
-    )
+      )
+    }
   )
 }

--- a/man/block_server.Rd
+++ b/man/block_server.Rd
@@ -138,7 +138,15 @@ that is neither visible nor feeding a visible block pulls no input and stays
 fully quiescent: its result reactive, and any observer its expression server
 registers on the incoming data, all short-circuit and do nothing. A needed
 but off-screen block (one feeding a visible block) evaluates but does not
-render. With nothing driving
+render. Block-server \emph{construction} is prioritized the same way: the needed
+set is instantiated first so that first paint waits only for the on-screen
+blocks and their upstreams, and the remaining block servers are built
+progressively in the background. Until a block is built it is absent from
+the \code{board$blocks} handed to plugins and callbacks, which simply see it
+appear once constructed. The background cadence is set by the
+\code{background_construction_delay} \code{\link[=blockr_option]{blockr_option()}} (milliseconds between
+successive blocks, default 50); a value of 0 disables the staggering and
+builds every block up front. With nothing driving
 \code{visible} every block is needed and behaviour is unchanged; the
 \code{gate_visibility} \code{\link[=blockr_option]{blockr_option()}} (default \code{TRUE}) turns gating off
 entirely.

--- a/man/blockr_ser.Rd
+++ b/man/blockr_ser.Rd
@@ -82,7 +82,8 @@ blockr_deser(x, ...)
 
 \item{state}{Object state (as returned from an \code{expr_server})}
 
-\item{blocks}{Block states (\code{NULL} defaults to values from ctor scope)}
+\item{blocks}{Block states (\code{NULL}, or a per-block \code{NULL} entry, defaults to
+values from the constructor scope)}
 
 \item{options}{Board option values (\code{NULL} uses values provided by \code{x})}
 

--- a/tests/testthat/test-plugin-serdes.R
+++ b/tests/testthat/test-plugin-serdes.R
@@ -377,6 +377,20 @@ test_that("block-contributed board options survive save/restore", {
   )
 })
 
+test_that("serialize_board uses constructor state for a not-yet-built block", {
+
+  board <- new_board(blocks = c(a = new_dataset_block("iris")))
+
+  # `blocks` empty: block `a` has not been constructed (still building in the
+  # background), so it serializes from its constructor defaults.
+  ser <- serialize_board(board, list(), id = "board")
+
+  expect_identical(
+    ser$payload$blocks$payload$a$payload$dataset,
+    "iris"
+  )
+})
+
 test_that("dummy ser/deser ui test", {
   expect_s3_class(preserve_board_ui("ser_deser", new_board()), "shiny.tag.list")
 })

--- a/tests/testthat/test-visibility-gating.R
+++ b/tests/testthat/test-visibility-gating.R
@@ -7,11 +7,22 @@ probe_eval$ids <- character()
 probe_args <- new.env()
 probe_args$entry_classes <- NULL
 
+probe_construct <- new.env()
+probe_construct$ids <- character()
+
 registerS3method(
   "block_output", "probe_block",
   function(x, result, session) {
     probe_render$ids <- c(probe_render$ids, session$ns(NULL))
     NULL
+  }
+)
+
+registerS3method(
+  "expr_server", "probe_block",
+  function(x, data, ...) {
+    probe_construct$ids <- c(probe_construct$ids, attr(x, "probe_id"))
+    NextMethod()
   }
 )
 
@@ -112,6 +123,7 @@ with_id <- function(blk, id) {
 reset_probes <- function() {
   probe_render$ids <- character()
   probe_eval$ids <- character()
+  probe_construct$ids <- character()
 }
 
 rendered <- function(id) {
@@ -120,6 +132,10 @@ rendered <- function(id) {
 
 evaluated <- function(id) {
   id %in% probe_eval$ids
+}
+
+constructed <- function(id) {
+  id %in% probe_construct$ids
 }
 
 test_that("with no producer every block is visible", {
@@ -479,5 +495,117 @@ test_that("an off-screen variadic block does not pull its inputs", {
         NULL
       }
     )
+  )
+})
+
+ordered_board <- function() {
+  new_board(
+    blocks = c(
+      a = with_id(probe_source(), "a"),
+      b = with_id(probe_passthrough(), "b"),
+      c = with_id(probe_passthrough(), "c"),
+      d = with_id(probe_passthrough(), "d")
+    ),
+    links = links(
+      new_link(from = "a", to = "b"),
+      new_link(from = "b", to = "c"),
+      new_link(from = "a", to = "d")
+    )
+  )
+}
+
+visible_b <- function(visible, ...) {
+  visible("b")
+  NULL
+}
+
+test_that("only the needed blocks are constructed before first paint", {
+
+  reset_probes()
+
+  testServer(
+    get_s3_method("board_server", ordered_board()),
+    {
+      session$flushReact()
+
+      expect_true(constructed("a"))
+      expect_true(constructed("b"))
+
+      expect_false(constructed("c"))
+      expect_false(constructed("d"))
+
+      session$elapse(5000)
+      session$flushReact()
+
+      expect_true(constructed("c"))
+      expect_true(constructed("d"))
+    },
+    args = list(x = ordered_board(), plugins = list(), callbacks = visible_b)
+  )
+})
+
+test_that("opening a view constructs its blocks without the background", {
+
+  reset_probes()
+
+  testServer(
+    get_s3_method("board_server", ordered_board()),
+    {
+      session$flushReact()
+
+      expect_false(constructed("c"))
+
+      board_visible(c("b", "c"))
+      session$flushReact()
+
+      expect_true(constructed("c"))
+      expect_false(constructed("d"))
+    },
+    args = list(x = ordered_board(), plugins = list(), callbacks = visible_b)
+  )
+})
+
+test_that("the background constructs every block exactly once", {
+
+  reset_probes()
+
+  testServer(
+    get_s3_method("board_server", ordered_board()),
+    {
+      session$flushReact()
+      session$elapse(5000)
+      session$flushReact()
+
+      built <- probe_construct$ids
+
+      expect_setequal(built, c("a", "b", "c", "d"))
+      expect_length(built, 4L)
+
+      session$elapse(5000)
+      session$flushReact()
+
+      expect_identical(probe_construct$ids, built)
+    },
+    args = list(x = ordered_board(), plugins = list(), callbacks = visible_b)
+  )
+})
+
+test_that("a zero background delay builds every block up front", {
+
+  reset_probes()
+
+  withr::local_options(blockr.background_construction_delay = 0)
+
+  testServer(
+    get_s3_method("board_server", ordered_board()),
+    {
+      session$flushReact()
+
+      expect_true(constructed("a"))
+      expect_true(constructed("b"))
+      expect_true(constructed("c"))
+      expect_true(constructed("d"))
+    },
+    args = list(x = ordered_board(), plugins = list(), callbacks = visible_b)
   )
 })


### PR DESCRIPTION
## Summary

- `setup_board()` built every block's server on the first flush, so a large multi-view board paid the full per-block construction cost at first paint regardless of how many blocks were on screen — the instantiation cost that demand-driven evaluation (#204/#211) left on the startup critical path. Construction now follows the same *needed* set (on-screen blocks plus their upstream closure over `board_links()`) as evaluation: the needed set is built synchronously for first paint, and the remaining block servers are built progressively in the background by a self-rescheduling observer, so first paint waits only for what is on screen.
- This is *ordering*, not deferral — every block is still constructed, just off the first-paint path. An unbuilt block is simply *absent* from `rv$blocks` rather than a permanent placeholder, so the enumerating consumers (conditions, notifications, code export) need no changes. Opening a view builds its blocks immediately through the needed-set observer rather than waiting for the background queue; blocks added through the UI, and blocks targeted by an external-control `mod`, build immediately too.
- Serialization is the one consumer that copes with a block still building: it falls back to the block's constructor state (`initial_block_state()`) for any block absent from `rv$blocks`, which is lossless since an unbuilt block has never been touched. The shinytest2 result export is pinned to board order so construction order does not perturb snapshots.
- The background cadence is the `background_construction_delay` option (milliseconds between successive blocks, default 50); setting it to 0 builds every block up front and opts out of the staggering.
- Code export is deliberately *not* touched here. Its output is only correct once every block is ready — a missing link or unset input already yields stale code today — which is a standing correctness concern tracked in #256; gating the export on the per-block ready status from #251 covers the brief startup window as a side effect.

The startup win is realized once a front-end drives the `visible` channel (blockr.dock's producer); standalone core has no producer, so every block is needed and all servers build up front, unchanged.

Fixes #243
