### PR TITLE
Gate code export on all blocks being ready

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,13 @@
   chain `waiting`. Output rendering follows the status -- shown only while
   `ready` and cleared otherwise -- so a block leaving `ready` no longer shows a
   stale result.
+* Code export (`generate_code()`) now waits on this status: "Show code" emits a
+  script only once every block is settled, and otherwise opens the modal with a
+  short "board not ready" note rather than a stale or partial script (#256). A
+  `waiting`, `unset` or `failed` block -- a removed link, an unset required
+  input, an expression that raises -- holds the export back; an off-screen
+  `dormant` block does not, as its expression already reflects its
+  configuration.
 * By default a block requires every data input to be connected and a variadic
   block to have at least one `...args` input. `new_block()`'s
   `allow_empty_state` argument gains a structured `list(input = ..., data =

--- a/R/plugin-code.R
+++ b/R/plugin-code.R
@@ -33,10 +33,12 @@ generate_code_server <- function(id, board, ...) {
     function(input, output, session) {
 
       code <- reactive(
-        export_wrapped_code(
-          lst_xtr_reval(board$blocks, "server", "expr"),
-          board$board
-        )
+        if (isTRUE(code_export_ready(board))) {
+          export_wrapped_code(
+            lst_xtr_reval(board$blocks, "server", "expr"),
+            board$board
+          )
+        }
       )
 
       observeEvent(
@@ -44,11 +46,7 @@ generate_code_server <- function(id, board, ...) {
         showModal(
           modalDialog(
             title = "Generated code",
-            div(
-              id = session$ns("code_out"),
-              class = "text-decoration-none position-relative",
-              pre(paste0(code(), collapse = "\n"))
-            ),
+            code_modal_body(code(), session$ns("code_out")),
             easyClose = TRUE,
             footer = NULL,
             size = "l"
@@ -70,5 +68,37 @@ generate_code_ui <- function(id, board) {
       "Show code",
       icon = icon("code")
     )
+  )
+}
+
+code_export_ready <- function(board) {
+
+  status <- reactiveValuesToList(board$eval)
+
+  if (!setequal(names(status), board_block_ids(board$board))) {
+    return(FALSE)
+  }
+
+  all(chr_ply(status, reval_if) %in% c("ready", "dormant"))
+}
+
+code_modal_body <- function(script, out_id) {
+
+  if (is.null(script)) {
+    return(
+      div(
+        class = "text-muted",
+        paste(
+          "The board is not ready. Finish configuring all blocks",
+          "before exporting code."
+        )
+      )
+    )
+  }
+
+  div(
+    id = out_id,
+    class = "text-decoration-none position-relative",
+    pre(paste0(script, collapse = "\n"))
   )
 }

--- a/tests/testthat/test-plugin-code.R
+++ b/tests/testthat/test-plugin-code.R
@@ -27,6 +27,75 @@ test_that("generate code", {
   )
 })
 
+test_that("code export is gated on all blocks being ready", {
+
+  board <- new_board(
+    blocks = c(
+      a = new_dataset_block("BOD"),
+      c = new_merge_block(by = "Time")
+    )
+  )
+
+  testServer(
+    generate_code_server,
+    {
+      expect_false(code_export_ready(board))
+      expect_null(code())
+
+      session$setInputs(code_mod = 1)
+    },
+    args = generate_plugin_args(board)
+  )
+})
+
+test_that("code_export_ready settles on ready or dormant", {
+
+  reactiveConsole(TRUE)
+  on.exit(reactiveConsole(FALSE))
+
+  board <- new_board(
+    blocks = c(a = new_dataset_block("BOD"), b = new_dataset_block("BOD"))
+  )
+
+  make_rv <- function(...) {
+    list(eval = do.call(reactiveValues, list(...)), board = board)
+  }
+
+  expect_true(
+    code_export_ready(make_rv(a = reactive("ready"), b = reactive("ready")))
+  )
+  expect_true(
+    code_export_ready(make_rv(a = reactive("ready"), b = reactive("dormant")))
+  )
+
+  expect_false(
+    code_export_ready(make_rv(a = reactive("ready"), b = reactive("waiting")))
+  )
+  expect_false(
+    code_export_ready(make_rv(a = reactive("ready"), b = reactive("unset")))
+  )
+  expect_false(
+    code_export_ready(make_rv(a = reactive("ready"), b = reactive("failed")))
+  )
+
+  expect_false(
+    code_export_ready(make_rv(a = reactive("ready")))
+  )
+})
+
+test_that("code modal body shows script or a not-ready note", {
+
+  note <- code_modal_body(NULL, "out")
+
+  expect_s3_class(note, "shiny.tag")
+  expect_match(as.character(note), "not ready")
+
+  body <- code_modal_body("y <- 1", "out")
+
+  expect_match(as.character(body), "<pre>")
+  expect_match(as.character(body), "y &lt;- 1")
+})
+
 test_that("dummy add/rm block ui test", {
   expect_s3_class(generate_code_ui("gen", new_board()), "shiny.tag.list")
 })


### PR DESCRIPTION
## Summary

- `generate_code()` stitched every block's `server$expr` unconditionally, so a board caught mid-edit — a removed link, an unset required input, an expression that raises — exported a stale or partial script with no signal that anything was wrong; on an unconnected block the export could error outright.
- Code export is now gated on the per-block eval status from #219. "Show code" produces a script only once every block is settled, and otherwise opens the modal with a short "board not ready" note instead of a stale script.
- `waiting` (removed or missing data link), `unset` (required user input) and `failed` (validator or expression raised) each hold the export back — exactly the states whose expression can't be trusted. An off-screen `dormant` block does not: its expression already reflects its configuration, and forcing it to evaluate purely to validate an export is the eager materialization rejected for #243.
- The gate requires every board block to have a settled status entry, so it also covers #243's ordered-construction startup window — a not-yet-built block has no entry and holds the export until construction settles.

Fixes #256
