### PR TITLE
Gate background construction on the visible set being rendered

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,17 @@
   background cadence is the `background_construction_delay` option
   (milliseconds between successive blocks, default 50); setting it to 0
   builds every block up front and opts out of the staggering.
+* The background block-construction pass (#243) now waits for the front-end to
+  arrange the on-screen blocks before it starts (#257). It previously
+  self-started in the same flush that first paint was still evaluating, so on a
+  large multi-view board the off-screen construction saturated the single R
+  thread and starved the active view's arrangement. The `visible` write-channel
+  now carries a per-block status (off screen / on screen / rendered) instead of
+  a flat id set; the on-screen set that feeds the eval/needed gate is derived
+  from it unchanged, and the background pass holds until every on-screen block
+  is reported rendered. With nothing driving `visible` the board is all on
+  screen and ready, as before, and `background_construction_delay = 0` still
+  builds every block up front.
 * Board options contributed by blocks or the block registry -- such as the
   table preview `page_size`, `n_rows` and `filter_rows` -- are now serialized
   and restored along with the board. Previously only options owned by the board

--- a/R/block-server.R
+++ b/R/block-server.R
@@ -52,8 +52,9 @@
 #' control rendering of outputs.
 #'
 #' When a front-end (such as blockr.dock) drives the `visible` write-channel
-#' that [board_server()] hands to the board callback, naming the block IDs
-#' currently on screen, evaluation and rendering are gated on visibility.
+#' that [board_server()] hands to the board callback, reporting each block's
+#' visibility status (off screen, on screen, or rendered into its view),
+#' evaluation and rendering are gated on visibility.
 #' Rendering is gated on plain visibility: the render observer is suspended
 #' while a block is off screen and resumed once it is on screen, starting
 #' suspended so nothing renders before the front-end first reports. Evaluation
@@ -68,7 +69,10 @@
 #' render. Block-server *construction* is prioritized the same way: the needed
 #' set is instantiated first so that first paint waits only for the on-screen
 #' blocks and their upstreams, and the remaining block servers are built
-#' progressively in the background. Until a block is built it is absent from
+#' progressively in the background. That background pass holds until the
+#' front-end reports every on-screen block as rendered (arranged into its
+#' view), so it never competes with first paint. Until a block is built it is
+#' absent from
 #' the `board$blocks` handed to plugins and callbacks, which simply see it
 #' appear once constructed. The background cadence is set by the
 #' `background_construction_delay` [blockr_option()] (milliseconds between
@@ -508,7 +512,8 @@ render_gate_observer <- function(id, board, render_obs, sess) {
 
   observe(
     {
-      do_render <- isTRUE(board$visible) || id %in% board$visible
+      do_render <- isTRUE(board$visible) ||
+        isTRUE(board$visible[id] %in% c("required", "rendered"))
 
       if (do_render) render_obs$resume() else render_obs$suspend()
 

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -95,7 +95,7 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
           cur <- if (isTRUE(rv$visible)) {
             TRUE
           } else {
-            upstream_blocks(rv$visible, rv$board)
+            upstream_blocks(on_screen_blocks(rv$visible), rv$board)
           }
 
           old <- isolate(rv$needed())
@@ -130,12 +130,15 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
           vis <- board_visible()
 
           if (is.null(vis) || !isTRUE(blockr_option("gate_visibility", TRUE))) {
+
             rv$visible <- TRUE
+
           } else {
+
             rv$visible <- vis
 
             log_debug(
-              "visibility update: {length(vis)}/",
+              "visibility update: {length(on_screen_blocks(vis))}/",
               "{length(board_block_ids(rv$board))} on screen"
             )
           }
@@ -509,6 +512,22 @@ construct_remaining_blocks <- function(rv, mod_ed, mod_ct, args) {
     return(invisible())
   }
 
+  gate <- observe(
+    {
+      if (isTRUE(rv$visible) || visible_set_rendered(rv$visible)) {
+
+        gate$destroy()
+
+        construct_blocks_in_background(rv, mod_ed, mod_ct, args)
+      }
+    }
+  )
+
+  invisible()
+}
+
+construct_blocks_in_background <- function(rv, mod_ed, mod_ct, args) {
+
   started <- FALSE
 
   obs <- observe(
@@ -543,6 +562,14 @@ construct_remaining_blocks <- function(rv, mod_ed, mod_ct, args) {
 
 background_construction_delay <- function() {
   as.numeric(blockr_option("background_construction_delay", 50L))
+}
+
+on_screen_blocks <- function(status) {
+  names(status)[status %in% c("required", "rendered")]
+}
+
+visible_set_rendered <- function(status) {
+  all(status[on_screen_blocks(status)] == "rendered")
 }
 
 needed_block_ids <- function(rv) {

--- a/man/block_server.Rd
+++ b/man/block_server.Rd
@@ -125,8 +125,9 @@ from output, the behavior of which can be customized via the
 control rendering of outputs.
 
 When a front-end (such as blockr.dock) drives the \code{visible} write-channel
-that \code{\link[=board_server]{board_server()}} hands to the board callback, naming the block IDs
-currently on screen, evaluation and rendering are gated on visibility.
+that \code{\link[=board_server]{board_server()}} hands to the board callback, reporting each block's
+visibility status (off screen, on screen, or rendered into its view),
+evaluation and rendering are gated on visibility.
 Rendering is gated on plain visibility: the render observer is suspended
 while a block is off screen and resumed once it is on screen, starting
 suspended so nothing renders before the front-end first reports. Evaluation
@@ -141,7 +142,10 @@ but off-screen block (one feeding a visible block) evaluates but does not
 render. Block-server \emph{construction} is prioritized the same way: the needed
 set is instantiated first so that first paint waits only for the on-screen
 blocks and their upstreams, and the remaining block servers are built
-progressively in the background. Until a block is built it is absent from
+progressively in the background. That background pass holds until the
+front-end reports every on-screen block as rendered (arranged into its
+view), so it never competes with first paint. Until a block is built it is
+absent from
 the \code{board$blocks} handed to plugins and callbacks, which simply see it
 appear once constructed. The background cadence is set by the
 \code{background_construction_delay} \code{\link[=blockr_option]{blockr_option()}} (milliseconds between

--- a/tests/testthat/test-visibility-gating.R
+++ b/tests/testthat/test-visibility-gating.R
@@ -138,6 +138,11 @@ constructed <- function(id) {
   id %in% probe_construct$ids
 }
 
+vis_map <- function(..., level = "rendered") {
+  ids <- c(...)
+  set_names(rep(level, length(ids)), ids)
+}
+
 test_that("with no producer every block is visible", {
 
   reset_probes()
@@ -190,7 +195,7 @@ test_that("a producer gates evaluation and rendering on visibility", {
     {
       session$flushReact()
 
-      expect_setequal(rv$visible, "b")
+      expect_setequal(on_screen_blocks(rv$visible), "b")
 
       expect_true(evaluated("b"))
       expect_true(rendered("b"))
@@ -204,7 +209,7 @@ test_that("a producer gates evaluation and rendering on visibility", {
       expect_false(evaluated("d"))
       expect_false(rendered("d"))
 
-      board_visible(c("b", "c", "d"))
+      board_visible(vis_map("b", "c", "d"))
       session$flushReact()
 
       expect_true(evaluated("c"))
@@ -217,7 +222,7 @@ test_that("a producer gates evaluation and rendering on visibility", {
       x = board,
       plugins = list(),
       callbacks = function(visible, ...) {
-        visible("b")
+        visible(vis_map("b"))
         NULL
       }
     )
@@ -256,7 +261,7 @@ test_that("the gate_visibility option disables gating", {
       x = board,
       plugins = list(),
       callbacks = function(visible, ...) {
-        visible("b")
+        visible(vis_map("b"))
         NULL
       }
     )
@@ -302,7 +307,7 @@ test_that("a link change re-routes the pulled upstream", {
       x = board,
       plugins = list(),
       callbacks = function(visible, ...) {
-        visible("b")
+        visible(vis_map("b"))
         NULL
       }
     )
@@ -336,7 +341,7 @@ test_that("an off-screen data-observing block does not pull its upstream", {
       x = board,
       plugins = list(),
       callbacks = function(visible, ...) {
-        visible("c")
+        visible(vis_map("c"))
         NULL
       }
     )
@@ -380,7 +385,7 @@ test_that("an unrelated structural edit does not re-evaluate needed blocks", {
       x = board,
       plugins = list(),
       callbacks = function(visible, ...) {
-        visible("b")
+        visible(vis_map("b"))
         NULL
       }
     )
@@ -422,7 +427,7 @@ test_that("adding a block does not re-evaluate existing needed blocks", {
       x = board,
       plugins = list(),
       callbacks = function(visible, ...) {
-        visible("b")
+        visible(vis_map("b"))
         NULL
       }
     )
@@ -455,7 +460,7 @@ test_that("a variadic block receives its inputs as values, not reactives", {
       x = board,
       plugins = list(),
       callbacks = function(visible, ...) {
-        visible("c")
+        visible(vis_map("c"))
         NULL
       }
     )
@@ -491,7 +496,7 @@ test_that("an off-screen variadic block does not pull its inputs", {
       x = board,
       plugins = list(),
       callbacks = function(visible, ...) {
-        visible("e")
+        visible(vis_map("e"))
         NULL
       }
     )
@@ -515,7 +520,7 @@ ordered_board <- function() {
 }
 
 visible_b <- function(visible, ...) {
-  visible("b")
+  visible(vis_map("b"))
   NULL
 }
 
@@ -555,7 +560,7 @@ test_that("opening a view constructs its blocks without the background", {
 
       expect_false(constructed("c"))
 
-      board_visible(c("b", "c"))
+      board_visible(vis_map("b", "c"))
       session$flushReact()
 
       expect_true(constructed("c"))
@@ -587,6 +592,67 @@ test_that("the background constructs every block exactly once", {
       expect_identical(probe_construct$ids, built)
     },
     args = list(x = ordered_board(), plugins = list(), callbacks = visible_b)
+  )
+})
+
+test_that("on_screen_blocks is the union of the required and rendered ids", {
+
+  expect_setequal(
+    on_screen_blocks(c(a = "rendered", b = "required", z = "hidden")),
+    c("a", "b")
+  )
+
+  expect_length(on_screen_blocks(c(z = "hidden")), 0L)
+  expect_length(on_screen_blocks(character()), 0L)
+})
+
+test_that("visible_set_rendered is TRUE only when all on-screen rendered", {
+
+  expect_true(visible_set_rendered(c(a = "rendered", b = "rendered")))
+
+  expect_false(visible_set_rendered(c(a = "rendered", b = "required")))
+  expect_false(visible_set_rendered(c(b = "required")))
+
+  expect_true(visible_set_rendered(c(a = "rendered", z = "hidden")))
+
+  expect_true(visible_set_rendered(character()))
+  expect_true(visible_set_rendered(c(z = "hidden")))
+})
+
+test_that("the background waits for the front-end's rendered report", {
+
+  reset_probes()
+
+  testServer(
+    get_s3_method("board_server", ordered_board()),
+    {
+      session$flushReact()
+
+      expect_true(constructed("a"))
+      expect_true(constructed("b"))
+
+      session$elapse(5000)
+      session$flushReact()
+
+      expect_false(constructed("c"))
+      expect_false(constructed("d"))
+
+      board_visible(vis_map("b"))
+      session$flushReact()
+      session$elapse(5000)
+      session$flushReact()
+
+      expect_true(constructed("c"))
+      expect_true(constructed("d"))
+    },
+    args = list(
+      x = ordered_board(),
+      plugins = list(),
+      callbacks = function(visible, ...) {
+        visible(vis_map("b", level = "required"))
+        NULL
+      }
+    )
   )
 })
 


### PR DESCRIPTION
## Summary

Stacked on #254 (`243-defer-instantiation`); follow-up per #257.

#254 orders construction visible-first, but the background pass self-started on its first observe pass -- the same flush the visible set is still evaluating and painting -- so on a large board off-screen construction saturates the single R thread and starves first paint (cdex: 93s to paint at the default delay vs. ~77s without deferring). The lever is *when* the loop starts, not the tick size.

- Adds a per-block `rendered` signal, sourced from core's render machinery (`block_rendered_observer`) and returned by `block_server()`. It flips once the result has settled while the block is on screen -- quiescence, not paint -- so an input-waiting visible block showing a prompt still counts and can't hang the gate. It reads `res()` only when on screen, exactly where `output_render_observer` already forces it, so off-screen laziness is unchanged.
- `construct_remaining_blocks()` now holds until `visible_set_rendered(rv)` -- every on-screen block constructed and `rendered` -- then hands off to the background ticker. The status `hidden | visible | rendered` is the front-end's `visible` set (unchanged) with core's per-block `rendered` layered on top.
- The gate and the ticker are separate observers so the ticker is driven only by `invalidateLater`; folding them let a later `visible` change retrigger construction, which the existing "opening a view" test caught.

`background_construction_delay = 0` still builds every block up front.

The acceptance -- active view paints at ~its own data-load time regardless of total block count -- is a wall-clock property, verified on cdex against #257's numbers; unit coverage is the gate predicate and the quiescence trigger, both with regression teeth.

Fixes #257


Revdep pin (temporary — drop once blockr.dock#306 merges): core#259 reshapes the `visible` channel into a per-block status map, which the released dock does not yet write, so the blockr.dock revdep must build against the coupled adaptation PR rather than dock `main`.

```deps
BristolMyersSquibb/blockr.dock#306
```
