### PR TITLE
Force upstream key so variadic slots bind to their own link

### DIFF
--- a/R/board-server.R
+++ b/R/board-server.R
@@ -581,6 +581,8 @@ destroy_rm_blocks <- function(ids, rv, sess, args) {
 
 upstream_result <- function(key, src_rv, rv, to) {
 
+  force(key)
+
   reactive(
     {
       needed <- rv$needed()

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -551,6 +551,34 @@ test_that("removing a variadic link drops its ...args slot", {
   )
 })
 
+test_that("variadic ...args slots each bind to their own upstream", {
+
+  board <- new_board(
+    blocks = c(
+      a = new_static_block(iris[1:3, ]),
+      b = new_static_block(iris[4:6, ]),
+      v = new_rbind_block()
+    ),
+    links = links(
+      av = new_link("a", "v", "x"),
+      bv = new_link("b", "v", "y")
+    )
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      expect_identical(
+        rv$blocks$v$server$result(),
+        rbind(x = iris[1:3, ], y = iris[4:6, ])
+      )
+    },
+    args = list(x = board)
+  )
+})
+
 test_that("update validation", {
 
   expect_error(


### PR DESCRIPTION
## Summary

- Every variadic `...args` slot bound to the **last** wired link's upstream, so a block like `rbind_block` fed by two different sources silently read one source twice and dropped the other. Fixed (named) inputs were unaffected.
- Root cause: `upstream_result()` took `key` as an unforced promise, and `sync_dot_args()` constructs each slot's reactive inside a `for` loop passing `ids[[i]]`. The promise is first forced only when a slot's reactive runs — after the loop, with the loop variable at its final value — so every slot resolved to the last link. `force(key)` at the top of `upstream_result()` binds each slot to its own source at construction time.
- Regression test pins slot identity with distinguishable data (two disjoint `iris` slices row-bound into named slots); it fails on `main` and passes with the fix. The existing variadic tests all feed the *same* dataset into both inputs, so they can't distinguish correct wiring from all-slots-to-last.

Fixes #260
