### PR TITLE
Correct block-registry overwrite hint and document reloads

### DIFF
--- a/R/block-registry.R
+++ b/R/block-registry.R
@@ -168,7 +168,8 @@ register_block <- function(ctor, name, description, classes = NULL, uid = NULL,
 
   if (uid %in% list_blocks() && !isTRUE(overwrite)) {
     blockr_abort(
-      "Block {uid} already exists. Try removing or `overwrite = FALSE`.",
+      "Block {uid} already exists. Set `overwrite = TRUE` to replace it, ",
+      "or remove it first with `unregister_blocks(\"{uid}\")`.",
       class = "block_already_in_registry"
     )
   }

--- a/tests/testthat/test-block-registry.R
+++ b/tests/testthat/test-block-registry.R
@@ -57,7 +57,8 @@ test_that("registry", {
 
   expect_error(
     register_block(get(candidates[1L]), "test", "test"),
-    class = "block_already_in_registry"
+    class = "block_already_in_registry",
+    regexp = "overwrite = TRUE"
   )
 
   expect_error(

--- a/vignettes/blocks-registry.qmd
+++ b/vignettes/blocks-registry.qmd
@@ -72,8 +72,8 @@ names(available_blocks())
 ## Register a block
 To register your own blocks, user facing functions are:
 
-- `register_block()` to register a block in the __registry__. If the __block__ is already registered,
-it __overwrites__ the existing one.
+- `register_block()` to register a block in the __registry__. If a block with
+the same ID is already registered, it errors unless you pass `overwrite = TRUE`.
 - `register_blocks()` to register multiple blocks.
 
 Note that, if you develop your block outside a package context, you must call `register_block` (or `register_blocks`)
@@ -122,6 +122,30 @@ Finally, we create a `.R/zzz.R` script where you run this code to register the b
   invisible(NULL)
 }
 ```
+
+Because `.onLoad()` runs on every load of the package (including each
+`devtools::load_all()`, `document()` or `check()`), this registration must be
+idempotent. That is why `register_dummy_blocks()` passes `overwrite = TRUE`:
+without it, reloading the package aborts with `Block dummy_block already
+exists`, forcing you to restart R between reloads.
+
+For blocks that ship in a package, the recommended alternative removes the
+hand-written registration altogether. Declaring the block metadata as `@block`
+roxygen tags on the constructor, and adding
+`blockr.core::block_registration_roclet` to the `Roxygen` field of the
+`DESCRIPTION`, lets `devtools::document()` generate an `inst/registry/blocks.yml`
+registry. A one-line `.onLoad()` then registers every block from it:
+
+```r
+# ./R/zzz.R
+.onLoad <- function(libname, pkgname) {
+  register_package_blocks()
+  invisible(NULL)
+}
+```
+
+`register_package_blocks()` defaults to `overwrite = TRUE`, so it is reload-safe
+by construction. See `?block_registration_roclet` for the full tag vocabulary.
 
 If we now query the registry, the new block is available:
 


### PR DESCRIPTION
## Summary

- The abort for a duplicate block ID told users to pass `overwrite = FALSE` — the default that had just triggered the error — instead of `overwrite = TRUE`; it now names the flag that actually resolves it and points at `unregister_blocks()`.
- The registry vignette claimed `register_block()` overwrites an existing block by default (it aborts), and never noted that `.onLoad()` reruns on every `load_all()`/`document()`/`check()`. It now documents the reload-safe registration paths: the `@block` roclet with `register_package_blocks()` (idempotent by default), or an explicit `overwrite = TRUE`.
- On whether the issue is stale: the reload pain itself is already handled by the block-registration roclet (#140) that blockr.core uses internally — what survived were the misleading message and the docs that walked package authors straight into it.

Fixes #165
