### PR TITLE
Link block-class docs to official example blocks

### DIFF
--- a/R/data-block.R
+++ b/R/data-block.R
@@ -10,6 +10,10 @@
 #' @return All blocks constructed via `new_data_block()` inherit from
 #' `data_block`.
 #'
+#' @seealso Real-world data blocks built on `new_data_block()` are provided by
+#' the [blockr.io](https://bristolmyerssquibb.github.io/blockr.io/) package,
+#' which sources data from a range of external formats.
+#'
 #' @export
 new_data_block <- function(server, ui, class, ctor = sys.parent(), ...) {
   new_block(server, ui, c(class, "data_block"), ctor, ...)

--- a/R/file-block.R
+++ b/R/file-block.R
@@ -11,6 +11,9 @@
 #' @return All blocks constructed via `new_file_block()` inherit from
 #' `file_block`.
 #'
+#' @seealso The [blockr.io](https://bristolmyerssquibb.github.io/blockr.io/)
+#' package provides real-world blocks for sourcing external files.
+#'
 #' @export
 new_file_block <- function(server, ui, class, ctor = sys.parent(), ...) {
   new_block(server, ui, c(class, "file_block"), ctor, ...)

--- a/R/parser-block.R
+++ b/R/parser-block.R
@@ -15,6 +15,10 @@
 #' @return All blocks constructed via `new_parser_block()` inherit from
 #' `parser_block`.
 #'
+#' @seealso The [blockr.io](https://bristolmyerssquibb.github.io/blockr.io/)
+#' package provides real-world blocks for parsing external data formats (e.g.
+#' `csv`, `xpt`).
+#'
 #' @export
 new_parser_block <- function(server, ui, class, ctor = sys.parent(),
                              dat_valid = is_file, ...) {

--- a/R/plot-block.R
+++ b/R/plot-block.R
@@ -19,6 +19,10 @@
 #' @return All blocks constructed via `new_plot_block()` inherit from
 #' `plot_block`.
 #'
+#' @seealso Real-world plot blocks built on `new_plot_block()` are provided by
+#' the [blockr.ggplot](https://bristolmyerssquibb.github.io/blockr.ggplot/)
+#' package.
+#'
 #' @export
 new_plot_block <- function(server, ui, class, ctor = sys.parent(), ...) {
   new_block(server, ui, c(class, "plot_block"), ctor, ...)

--- a/R/transform-block.R
+++ b/R/transform-block.R
@@ -11,6 +11,10 @@
 #' @return All blocks constructed via `new_transform_block()` inherit from
 #' `transform_block`.
 #'
+#' @seealso Real-world transform blocks (e.g. `select`, `mutate`, `filter` and
+#' `join`) built on `new_transform_block()` are provided by the
+#' [blockr.dplyr](https://bristolmyerssquibb.github.io/blockr.dplyr/) package.
+#'
 #' @export
 new_transform_block <- function(server, ui, class, ctor = sys.parent(), ...) {
   new_block(server, ui, c(class, "transform_block"), ctor, ...)

--- a/man/new_data_block.Rd
+++ b/man/new_data_block.Rd
@@ -59,3 +59,8 @@ be possible to reproduce results in a script that contains code from a
 static block.
 }
 
+\seealso{
+Real-world data blocks built on \code{new_data_block()} are provided by
+the \href{https://bristolmyerssquibb.github.io/blockr.io/}{blockr.io} package,
+which sources data from a range of external formats.
+}

--- a/man/new_file_block.Rd
+++ b/man/new_file_block.Rd
@@ -71,3 +71,7 @@ currently not allowed as the full data would have to be included during
 serialization.
 }
 
+\seealso{
+The \href{https://bristolmyerssquibb.github.io/blockr.io/}{blockr.io}
+package provides real-world blocks for sourcing external files.
+}

--- a/man/new_parser_block.Rd
+++ b/man/new_parser_block.Rd
@@ -53,3 +53,8 @@ Files in CSV format provided for example by a block created via
 \code{\link[=new_file_block]{new_file_block()}} may be parsed into \code{data.frame} by CSV blocks.
 }
 
+\seealso{
+The \href{https://bristolmyerssquibb.github.io/blockr.io/}{blockr.io}
+package provides real-world blocks for parsing external data formats (e.g.
+\code{csv}, \code{xpt}).
+}

--- a/man/new_plot_block.Rd
+++ b/man/new_plot_block.Rd
@@ -52,3 +52,8 @@ sophisticated (set of) block(s) for data visualization will most likely be
 required.
 }
 
+\seealso{
+Real-world plot blocks built on \code{new_plot_block()} are provided by
+the \href{https://bristolmyerssquibb.github.io/blockr.ggplot/}{blockr.ggplot}
+package.
+}

--- a/man/new_transform_block.Rd
+++ b/man/new_transform_block.Rd
@@ -99,3 +99,8 @@ as \code{subset}/\code{select} arguments or entered via shiny UI are turned into
 \code{language} objects by \code{\link[base:parse]{base::parse()}}.
 }
 
+\seealso{
+Real-world transform blocks (e.g. \code{select}, \code{mutate}, \code{filter} and
+\code{join}) built on \code{new_transform_block()} are provided by the
+\href{https://bristolmyerssquibb.github.io/blockr.dplyr/}{blockr.dplyr} package.
+}


### PR DESCRIPTION
## Summary

- Each block-class constructor reference page (`new_data_block`, `new_file_block`, `new_parser_block`, `new_transform_block`, `new_plot_block`) now carries a `See also` link to an official extension package that implements that block type, so readers can find real-world example blocks to learn from rather than only the minimal teaching examples in core.
- Transform blocks point to blockr.dplyr, plot blocks to blockr.ggplot, and data / file / parser blocks to blockr.io — each via the package's durable pkgdown URL, not the commit-pinned source link the issue illustrated with.

Fixes #167
