### PR TITLE
Serialize block- and registry-contributed board options

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # blockr.core 0.1.3
 
+* Board options contributed by blocks or the block registry -- such as the
+  table preview `page_size`, `n_rows` and `filter_rows` -- are now serialized
+  and restored along with the board. Previously only options owned by the board
+  itself (e.g. its name) survived a save/restore cycle, so customizations to
+  these block-sourced options were silently lost (#146).
 * Blocks now carry an eval status -- `dormant`, `waiting`, `unset`, `failed` or
   `ready` -- that, alongside the orthogonal visibility flag, gates evaluation,
   rendering and the data a block exposes downstream (#219, #122). A block whose

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -59,6 +59,9 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
 
   stopifnot(is_board_options(options))
 
+  # carry the resolved option set on rv$board so it serializes in full
+  board_options(x) <- options
+
   moduleServer(
     id,
     function(input, output, session) {

--- a/tests/testthat/test-plugin-serdes.R
+++ b/tests/testthat/test-plugin-serdes.R
@@ -345,6 +345,38 @@ test_that("restore_board returns the deserialized board", {
   )
 })
 
+test_that("block-contributed board options survive save/restore", {
+
+  brd <- new_board(blocks = c(a = new_dataset_block("iris")))
+
+  temp <- withr::local_tempfile(fileext = ".json")
+
+  testServer(
+    get_s3_method("board_server", brd),
+    {
+      session$flushReact()
+      session$setInputs(page_size = "25")
+      session$flushReact()
+
+      ser_deser <- session$makeScope("preserve_board")
+      file.copy(ser_deser$output$serialize, temp)
+    },
+    args = list(
+      x = brd,
+      plugins = preserve_board(),
+      options = blockr_app_options(brd)
+    )
+  )
+
+  restored <- blockr_deser(read_json(temp))
+
+  expect_true("page_size" %in% board_option_ids(restored))
+  expect_identical(
+    board_option_value(blockr_app_options(restored)[["page_size"]]),
+    25L
+  )
+})
+
 test_that("dummy ser/deser ui test", {
   expect_s3_class(preserve_board_ui("ser_deser", new_board()), "shiny.tag.list")
 })


### PR DESCRIPTION
## Summary

- `serialize_board()` reads the board from `rv$board`, but `board_server()` seeded that with only the board's *own* options — so options contributed by blocks or the block registry (the table preview `page_size`, `n_rows`, `filter_rows`) were never serialized, dropped on save and reverted on restore, while board-owned options like the name round-tripped, exactly as reported.
- Fix at the source: `board_server.board()` records the resolved option set onto the board (`board_options(x) <- options`) before the module starts. The full set then round-trips, the restored board owns those options, and their saved values win the `blockr_app_options()` union (board-owned first, dedup keeps first) — so `serialize_board()`, `restore_board()` and `blockr_ser()` are all unchanged.
- `blockr.dock` inherits this via core's `board_server` (it has no override), so its serialize side is fixed for free; its restore needs a separate one-line change, tracked in BristolMyersSquibb/blockr.dock#302.

Fixes #146
