### PR TITLE
Test that a block clears its stale output when disconnected

### DIFF
--- a/tests/testthat/test-block-server.R
+++ b/tests/testthat/test-block-server.R
@@ -398,6 +398,34 @@ test_that("a block returns to waiting when its input is disconnected", {
   )
 })
 
+test_that("output clears when a ready block's input is disconnected", {
+
+  blk <- new_head_block()
+  inputs_ready <- reactiveVal(TRUE)
+
+  testServer(
+    get_s3_method("block_server", blk),
+    {
+      session$flushReact()
+
+      expect_false(is.null(output$result))
+
+      inputs_ready(FALSE)
+      session$flushReact()
+
+      expect_null(session$returned$result())
+
+      # a cleared output holds no value, so fetching it errors
+      expect_error(output$result)
+    },
+    args = list(
+      x = blk,
+      data = list(data = reactive(utils::head(datasets::iris))),
+      inputs_ready = inputs_ready
+    )
+  )
+})
+
 test_that("a block whose expression errors is failed, not ready", {
 
   boom_block <- function() {


### PR DESCRIPTION
## Summary

- #141 (a block keeps its stale output after its input link is removed or repointed) was already fixed by #251. The old render observer used `observeEvent(res())`, which with the default `ignoreNULL = TRUE` never fired when a disconnected block's result went `NULL` — so the previous render stayed on screen. #251 rewrote it to an `observe()` that clears `output$result` whenever the block leaves `ready`.
- No existing test guards that render-layer behaviour. The disconnection test (`a block returns to waiting when its input is disconnected`) only asserts `result()` goes `NULL`; reverting *only* the render observer to its pre-#251 form keeps that test green while #141 regresses.
- This adds one focused `block_server` test: a ready block renders its output, and once `inputs_ready` flips false (the signal `board_server` derives from links), the stale output is cleared. Verified to fail against the pre-#251 observer and pass on current `main`.

Fixes #141
