### PR TITLE
Preserve link/stack/block string fields matching JSON Inf/NA tokens

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,11 @@
   and restored along with the board. Previously only options owned by the board
   itself (e.g. its name) survived a save/restore cycle, so customizations to
   these block-sourced options were silently lost (#146).
+* A board with a `link` input, a `stack` name or member block ID, or a block
+  name that is exactly `"Inf"`, `"-Inf"`, `"NaN"` or `"NA"` now survives a
+  save/restore cycle. `jsonlite` parses these JSON tokens back to the
+  numeric/logical values they encode, so the field previously returned as a
+  non-character value and aborted the restore (#136).
 * Blocks now carry an eval status -- `dormant`, `waiting`, `unset`, `failed` or
   `ready` -- that, alongside the orthogonal visibility flag, gates evaluation,
   rendering and the data a block exposes downstream (#219, #122). A block whose

--- a/R/utils-serdes.R
+++ b/R/utils-serdes.R
@@ -279,6 +279,16 @@ blockr_deser.list <- function(x, ...) {
   res
 }
 
+restore_chr <- function(x) {
+
+  out <- as.character(x)
+
+  # the JSON token "NA" decodes to a bare NA; NaN (also NA-ish) stays "NaN"
+  out[is.na(x) & !is.nan(x)] <- "NA"
+
+  out
+}
+
 #' @param data List valued data (converted from JSON)
 #' @rdname blockr_ser
 #' @export
@@ -290,8 +300,14 @@ blockr_deser.block <- function(x, data, ...) {
 
   ctor <- blockr_deser(data[["constructor"]])
 
+  payload <- data[["payload"]]
+
+  if ("block_name" %in% names(payload)) {
+    payload[["block_name"]] <- restore_chr(payload[["block_name"]])
+  }
+
   args <- c(
-    data[["payload"]],
+    payload,
     list(
       ctor = coal(ctor_name(ctor), ctor_fun(ctor)),
       ctor_pkg = ctor_pkg(ctor)
@@ -342,9 +358,14 @@ blockr_deser.link <- function(x, data, ...) {
     all(c("constructor", "payload") %in% names(data))
   )
 
+  payload <- data[["payload"]]
+  fields <- intersect(c("from", "to", "input"), names(payload))
+
+  payload[fields] <- lapply(payload[fields], restore_chr)
+
   do.call(
     blockr_deser(data[["constructor"]]),
-    data[["payload"]]
+    payload
   )
 }
 
@@ -364,9 +385,14 @@ blockr_deser.stack <- function(x, data, ...) {
     all(c("constructor", "payload") %in% names(data))
   )
 
+  payload <- data[["payload"]]
+  fields <- intersect(c("blocks", "name"), names(payload))
+
+  payload[fields] <- lapply(payload[fields], restore_chr)
+
   do.call(
     blockr_deser(data[["constructor"]]),
-    data[["payload"]]
+    payload
   )
 }
 

--- a/tests/testthat/test-utils-serdes.R
+++ b/tests/testthat/test-utils-serdes.R
@@ -205,3 +205,48 @@ test_that("a board with variadic links round-trips and still evaluates", {
     args = list(x = restored)
   )
 })
+
+test_that("restore_chr re-stringifies JSON-decoded non-finite tokens", {
+
+  expect_identical(restore_chr(Inf), "Inf")
+  expect_identical(restore_chr(-Inf), "-Inf")
+  expect_identical(restore_chr(NaN), "NaN")
+  expect_identical(restore_chr(NA), "NA")
+
+  expect_identical(restore_chr(c("keep", NA)), c("keep", "NA"))
+  expect_identical(restore_chr("plain"), "plain")
+})
+
+test_that("character values matching JSON Inf/NA tokens survive restore", {
+
+  json_round_trip <- function(x) {
+    blockr_deser(read_json(write_json(blockr_ser(x))))
+  }
+
+  for (tok in c("Inf", "-Inf", "NaN", "NA")) {
+    expect_identical(
+      json_round_trip(new_link("a", "b", tok)),
+      new_link("a", "b", tok),
+      info = tok
+    )
+  }
+
+  expect_identical(
+    json_round_trip(new_stack("x", "NA")),
+    new_stack("x", "NA")
+  )
+
+  expect_identical(
+    json_round_trip(new_stack(c("Inf", "-Inf"), "grp")),
+    new_stack(c("Inf", "-Inf"), "grp")
+  )
+
+  blk <- new_dataset_block("iris", "datasets")
+  block_name(blk) <- "Inf"
+
+  expect_identical(
+    json_round_trip(blk),
+    blk,
+    ignore_function_env = TRUE
+  )
+})


### PR DESCRIPTION
## Summary

- `jsonlite` decodes the JSON tokens `"Inf"`, `"-Inf"`, `"NaN"` and `"NA"` back to the numeric/logical values they usually encode, so a contractually-character field equal to one of them came back non-character through a `write_json`/`read_json` cycle and aborted the board restore (found in prod with a link input `"Inf"`).
- Coerce the affected fields back to character on deserialization via a shared `restore_chr()` helper: link `from`/`to`/`input`, stack `name` and member block IDs, and block `block_name`.
- Block IDs need no fix — they serialize as JSON object keys, and keys are never type-coerced on read.
- Out of scope by design: block state and board-option *values*, which are genuinely type-ambiguous (a value may legitimately be numeric `Inf` or the string `"Inf"`). No global `toJSON`/`fromJSON` setting disambiguates them — `serializeJSON` would, at the cost of verbose, opaque JSON and a breaking format change — so that remains a documented limitation of the interchange format.

Fixes #136
