### PR TITLE
Support background_construction_delay = Inf to defer construction

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@
   through two per-block `reactiveValues` it receives as `visibility` --
   `required` (which blocks are needed) and `visible` (which are on screen) --
   in place of the single `visible` write-channel. Breaking for front-ends.
+* `background_construction_delay` now accepts `Inf`, skipping the background
+  construction pass so a block is built only once it becomes required. Code
+  export ("Show code") then marks every block required, so the exported
+  script covers the whole board; an off-screen block that is not fully
+  configured holds the export back instead of emitting broken code (#269).
 
 # blockr.core 0.1.3
 

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -316,7 +316,7 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
 
       call_plugin_server(
         "generate_code",
-        server_args = read_plugin_args,
+        server_args = c(read_plugin_args, list(visibility = vis)),
         plugins = plugins
       )
 
@@ -502,11 +502,17 @@ construct_blocks <- function(ids, rv, mod_ed, mod_ct, args, vis) {
 
 construct_remaining_blocks <- function(rv, mod_ed, mod_ct, args, vis) {
 
-  if (background_construction_delay() <= 0) {
+  delay <- background_construction_delay()
+
+  if (delay <= 0) {
 
     construct_blocks(board_block_ids(rv$board), rv, mod_ed, mod_ct, args,
                      vis)
 
+    return(invisible())
+  }
+
+  if (is.infinite(delay)) {
     return(invisible())
   }
 

--- a/R/plugin-code.R
+++ b/R/plugin-code.R
@@ -23,11 +23,17 @@ generate_code <- function(server = generate_code_server,
 
 #' @param id Namespace ID
 #' @param board Reactive values object
+#' @param visibility Visibility channel bundle (supplied by [board_server()]).
+#' On a gated board, "Show code" marks every block `required`, so the exported
+#' script covers the whole board and not only what is on screen; an off-screen
+#' block that is not fully configured then holds the export back rather than
+#' emitting broken code. `NULL` (the standalone default) leaves the board
+#' untouched.
 #' @param ... Extra arguments passed from parent scope
 #'
 #' @rdname generate_code
 #' @export
-generate_code_server <- function(id, board, ...) {
+generate_code_server <- function(id, board, visibility = NULL, ...) {
   moduleServer(
     id,
     function(input, output, session) {
@@ -41,17 +47,23 @@ generate_code_server <- function(id, board, ...) {
         }
       )
 
+      output$code_out <- renderUI(code_modal_body(code()))
+
       observeEvent(
         input$code_mod,
-        showModal(
-          modalDialog(
-            title = "Generated code",
-            code_modal_body(code(), session$ns("code_out")),
-            easyClose = TRUE,
-            footer = NULL,
-            size = "l"
+        {
+          require_all_blocks(board, visibility)
+
+          showModal(
+            modalDialog(
+              title = "Generated code",
+              uiOutput(session$ns("code_out")),
+              easyClose = TRUE,
+              footer = NULL,
+              size = "l"
+            )
           )
-        )
+        }
       )
 
       NULL
@@ -82,7 +94,7 @@ code_export_ready <- function(board) {
   all(chr_ply(status, reval_if) %in% c("ready", "dormant"))
 }
 
-code_modal_body <- function(script, out_id) {
+code_modal_body <- function(script) {
 
   if (is.null(script)) {
     return(
@@ -97,8 +109,20 @@ code_modal_body <- function(script, out_id) {
   }
 
   div(
-    id = out_id,
     class = "text-decoration-none position-relative",
     pre(paste0(script, collapse = "\n"))
   )
+}
+
+require_all_blocks <- function(board, visibility) {
+
+  if (is.null(visibility) || !gating_active(visibility$required)) {
+    return(invisible())
+  }
+
+  for (id in board_block_ids(board$board)) {
+    visibility$required[[id]](TRUE)
+  }
+
+  invisible()
 }

--- a/man/generate_code.Rd
+++ b/man/generate_code.Rd
@@ -8,7 +8,7 @@
 \usage{
 generate_code(server = generate_code_server, ui = generate_code_ui)
 
-generate_code_server(id, board, ...)
+generate_code_server(id, board, visibility = NULL, ...)
 
 generate_code_ui(id, board)
 }
@@ -18,6 +18,13 @@ generate_code_ui(id, board)
 \item{id}{Namespace ID}
 
 \item{board}{Reactive values object}
+
+\item{visibility}{Visibility channel bundle (supplied by \code{\link[=board_server]{board_server()}}).
+On a gated board, "Show code" marks every block \code{required}, so the exported
+script covers the whole board and not only what is on screen; an off-screen
+block that is not fully configured then holds the export back rather than
+emitting broken code. \code{NULL} (the standalone default) leaves the board
+untouched.}
 
 \item{...}{Extra arguments passed from parent scope}
 }

--- a/tests/testthat/test-plugin-code.R
+++ b/tests/testthat/test-plugin-code.R
@@ -85,15 +85,120 @@ test_that("code_export_ready settles on ready or dormant", {
 
 test_that("code modal body shows script or a not-ready note", {
 
-  note <- code_modal_body(NULL, "out")
+  note <- code_modal_body(NULL)
 
   expect_s3_class(note, "shiny.tag")
   expect_match(as.character(note), "not ready")
 
-  body <- code_modal_body("y <- 1", "out")
+  body <- code_modal_body("y <- 1")
 
   expect_match(as.character(body), "<pre>")
   expect_match(as.character(body), "y &lt;- 1")
+})
+
+test_that("require_all_blocks marks every block required on a gated board", {
+
+  reactiveConsole(TRUE)
+  on.exit(reactiveConsole(FALSE))
+
+  board <- list(
+    board = new_board(
+      blocks = c(
+        a = new_dataset_block("BOD"),
+        b = new_dataset_block("BOD"),
+        c = new_dataset_block("BOD")
+      )
+    )
+  )
+
+  vis <- list(
+    required = new.env(parent = emptyenv()),
+    visible = new.env(parent = emptyenv())
+  )
+  add_vis_slots(vis, c("a", "b", "c"))
+  vis$required[["a"]](TRUE)
+
+  require_all_blocks(board, vis)
+
+  expect_true(vis$required[["a"]]())
+  expect_true(vis$required[["b"]]())
+  expect_true(vis$required[["c"]]())
+})
+
+test_that("require_all_blocks is a no-op when ungated or standalone", {
+
+  reactiveConsole(TRUE)
+  on.exit(reactiveConsole(FALSE))
+
+  board <- list(board = new_board(blocks = c(a = new_dataset_block("BOD"))))
+
+  vis <- list(
+    required = new.env(parent = emptyenv()),
+    visible = new.env(parent = emptyenv())
+  )
+  add_vis_slots(vis, "a")
+
+  expect_null(require_all_blocks(board, vis))
+  expect_true(is.na(vis$required[["a"]]()))
+
+  expect_null(require_all_blocks(board, NULL))
+})
+
+test_that("show code requires the whole board, gating export on config", {
+
+  drive <- function(m) {
+
+    board <- new_board(
+      blocks = c(
+        a = new_dataset_block("BOD"),
+        b = new_dataset_block("BOD"),
+        m = m
+      ),
+      links = links(new_link("a", "m", "x"), new_link("b", "m", "y"))
+    )
+
+    withr::local_options(blockr.background_construction_delay = Inf)
+
+    out <- NULL
+
+    testServer(
+      get_s3_method("board_server", board),
+      {
+        for (id in c("a", "b")) {
+          vis$required[[id]](TRUE)
+          vis$visible[[id]]("main")
+        }
+        session$flushReact()
+
+        built <- "m" %in% names(reactiveValuesToList(rv$eval))
+
+        require_all_blocks(list(board = rv$board), vis)
+        session$flushReact()
+
+        out <<- list(
+          built = built,
+          status = reval_if(rv$eval[["m"]]),
+          ready = isTRUE(
+            code_export_ready(list(eval = rv$eval, board = rv$board))
+          )
+        )
+      },
+      args = list(x = board, plugins = list())
+    )
+
+    out
+  }
+
+  configured <- drive(new_merge_block(by = "Time"))
+
+  expect_false(configured$built)
+  expect_identical(configured$status, "ready")
+  expect_true(configured$ready)
+
+  unconfigured <- drive(new_merge_block())
+
+  expect_identical(unconfigured$status, "unset")
+  expect_false(unconfigured$ready)
 })
 
 test_that("dummy add/rm block ui test", {

--- a/tests/testthat/test-visibility-gating.R
+++ b/tests/testthat/test-visibility-gating.R
@@ -610,6 +610,67 @@ test_that("the background constructs every block exactly once", {
   )
 })
 
+test_that("an infinite background delay never fills in the background", {
+
+  reset_probes()
+
+  withr::local_options(blockr.background_construction_delay = Inf)
+
+  testServer(
+    get_s3_method("board_server", ordered_board()),
+    {
+      session$flushReact()
+
+      expect_true(constructed("a"))
+      expect_true(constructed("b"))
+
+      expect_false(constructed("c"))
+      expect_false(constructed("d"))
+
+      session$elapse(5000)
+      session$flushReact()
+
+      expect_false(constructed("c"))
+      expect_false(constructed("d"))
+
+      require_blocks(vis, "c")
+      render_blocks(vis, "c")
+      session$flushReact()
+
+      expect_true(constructed("c"))
+      expect_false(constructed("d"))
+    },
+    args = list(x = ordered_board(), plugins = list(), callbacks = visible_b)
+  )
+})
+
+test_that("an infinite background delay never arms the scheduler", {
+
+  reset_probes()
+
+  scheduled <- new.env()
+  scheduled$millis <- numeric()
+
+  local_mocked_bindings(
+    invalidateLater = function(millis, ...) {
+      scheduled$millis <- c(scheduled$millis, millis)
+      invisible()
+    }
+  )
+
+  withr::local_options(blockr.background_construction_delay = Inf)
+
+  testServer(
+    get_s3_method("board_server", ordered_board()),
+    {
+      session$flushReact()
+
+      expect_false(any(is.infinite(scheduled$millis)))
+    },
+    args = list(x = ordered_board(), plugins = list(), callbacks = visible_b)
+  )
+})
+
 test_that("is_visible is a non-NA check on the slot value", {
 
   expect_true(is_visible("main"))


### PR DESCRIPTION
## Summary

Reworked onto the `required`/`visible` visibility channels landed in #274 (the old `rv$materialize` flag is gone).

- **`background_construction_delay = Inf`** skips the background construction pass entirely, so a block is built only once it becomes *required* — the demand-only end of the knob (`0` builds everything up front, finite `N` staggers, `Inf` never fills). The explicit `is.infinite` branch is load-bearing, not cosmetic: without it `Inf` falls through and the background pass calls `invalidateLater(Inf)`, which blocks the session's event loop (verified — `later::run_now()` never returns with an `Inf`-delay task pending). The `testServer` mock scheduler parks it instead, so the regression test asserts the scheduler is never armed with a non-finite delay and fails without the branch.
- **Code export materializes the whole board.** "Show code" marks every block `required` (via the visibility channel from #274), so the exported script covers off-screen blocks too. An off-screen block that isn't fully configured — e.g. a `merge` with no `by`, which is `unset` — then holds the export back with the "board not ready" note, instead of silently emitting broken `merge(by = character(0))`.
- **No undo needed, and guarded so it can't misfire.** Construction keys on the *ever-required* set (the not-`NA` slots), which is monotonic — a block required at any point stays built regardless of later layout writes — so there is nothing to release when the modal closes. And `require_all_blocks` is a no-op on an ungated or standalone board (nothing else declares `required`): there, writing `required` would flip gating on and suspend every block's rendering, and every block is already needed anyway.

Fixes #269
