### PR TITLE
Gate blocks on separate required and visible channels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: blockr.core
 Title: Graphical Web-Framework for Data Manipulation and Visualization
-Version: 0.1.3
+Version: 0.1.4
 Authors@R: 
     c(person(given = "Nicolas",
              family = "Bennett",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# blockr.core 0.1.4
+
+* The board callback now gates block construction, evaluation and rendering
+  through two per-block `reactiveValues` it receives as `visibility` --
+  `required` (which blocks are needed) and `visible` (which are on screen) --
+  in place of the single `visible` write-channel. Breaking for front-ends.
+
 # blockr.core 0.1.3
 
 * Block-server construction is now ordered by visibility -- on-screen blocks

--- a/R/block-server.R
+++ b/R/block-server.R
@@ -18,8 +18,9 @@
 #' `edit_block` module (if passed from the parent scope).
 #'
 #' Each block carries an *eval status* -- one of `dormant`, `waiting`, `unset`,
-#' `failed` or `ready` -- which, together with the orthogonal `visible` flag,
-#' determines its behaviour. The status separates the two input kinds (data
+#' `failed` or `ready` -- which, together with its orthogonal front-end
+#' visibility, determines its behaviour. The status separates the two input
+#' kinds (data
 #' inputs from links, user inputs from `state`) and a genuine failure:
 #' * `dormant` -- not *needed* (neither on screen nor feeding, transitively over
 #'   [board_links()], an on-screen block); inputs stay unfulfilled
@@ -51,34 +52,36 @@
 #' [block_output()] generic. The [block_ui()] generic can then be used to
 #' control rendering of outputs.
 #'
-#' When a front-end (such as blockr.dock) drives the `visible` write-channel
-#' that [board_server()] hands to the board callback, reporting each block's
-#' visibility status (off screen, on screen, or rendered into its view),
-#' evaluation and rendering are gated on visibility.
-#' Rendering is gated on plain visibility: the render observer is suspended
-#' while a block is off screen and resumed once it is on screen, starting
-#' suspended so nothing renders before the front-end first reports. Evaluation
-#' is gated on the *needed* set, the on-screen blocks together with their
-#' upstream closure over [board_links()] (derived from `visible`, recomputed
-#' only when it or the links change). A block's input data reactives stay
+#' A front-end (such as blockr.dock) drives two per-block channels that
+#' [board_server()] hands to the board callback as `visibility`: `required`
+#' (which blocks it needs built and evaluated) and `visible` (which blocks it
+#' has arranged on screen). Requirements are a cause the front-end -- and
+#' core-side features such as code export -- declare; visibility is the effect
+#' the front-end reports back once it has painted a block. Rendering is gated
+#' on `visible`: the render observer is suspended while a block carries no
+#' visible slot and resumed once the front-end writes a non-empty string for
+#' it, starting suspended so nothing renders before the first report.
+#' Evaluation is gated on the *needed* set, the `required` blocks together with
+#' their upstream closure over [board_links()] (recomputed only when
+#' requirements or links change). A block's input data reactives stay
 #' unfulfilled (they [shiny::req()] out) unless the block is needed, so a block
-#' that is neither visible nor feeding a visible block pulls no input and stays
-#' fully quiescent: its result reactive, and any observer its expression server
-#' registers on the incoming data, all short-circuit and do nothing. A needed
-#' but off-screen block (one feeding a visible block) evaluates but does not
-#' render. Block-server *construction* is prioritized the same way: the needed
-#' set is instantiated first so that first paint waits only for the on-screen
-#' blocks and their upstreams, and the remaining block servers are built
-#' progressively in the background. That background pass holds until the
-#' front-end reports every on-screen block as rendered (arranged into its
-#' view), so it never competes with first paint. Until a block is built it is
-#' absent from
-#' the `board$blocks` handed to plugins and callbacks, which simply see it
-#' appear once constructed. The background cadence is set by the
-#' `background_construction_delay` [blockr_option()] (milliseconds between
-#' successive blocks, default 50); a value of 0 disables the staggering and
-#' builds every block up front. With nothing driving
-#' `visible` every block is needed and behaviour is unchanged; the
+#' that is neither required nor feeding a required block pulls no input and
+#' stays fully quiescent: its result reactive, and any observer its expression
+#' server registers on the incoming data, all short-circuit and do nothing. A
+#' needed but off-screen block (one feeding a required block) evaluates but
+#' does not render. Block-server *construction* is prioritized the same way:
+#' the needed set is instantiated first so that first paint waits only for the
+#' required blocks and their upstreams, and the remaining block servers are
+#' built progressively in the background. That background pass holds until the
+#' front-end reports every required block as visible, so it never competes with
+#' first paint. A `required` slot of `FALSE` keeps a block built but dormant
+#' (ever required, not needed now); an absent slot leaves it unbuilt. Until a
+#' block is built it is absent from the `board$blocks` handed to plugins and
+#' callbacks, which simply see it appear once constructed. The background
+#' cadence is set by the `background_construction_delay` [blockr_option()]
+#' (milliseconds between successive blocks, default 50); a value of 0 disables
+#' the staggering and builds every block up front. With nothing writing
+#' `required` every block is needed and behaviour is unchanged; the
 #' `gate_visibility` [blockr_option()] (default `TRUE`) turns gating off
 #' entirely.
 #'
@@ -105,13 +108,18 @@ block_server <- function(id, x, data = list(), ...) {
 #' inputs are all connected to ready upstream blocks (supplied by
 #' [board_server()]; defaults to always-ready when a block server is run
 #' standalone)
+#' @param visibility Visibility channel bundle -- a list with two channels,
+#' `required` and `visible`, each an environment of per-block `reactiveVal`s,
+#' supplied by [board_server()] to gate rendering; `NULL` (the standalone
+#' default) leaves the block ungated
 #' @rdname block_server
 #' @export
 block_server.block <- function(id, x, data = list(), block_id = id,
                                edit_block = NULL, ctrl_block = NULL,
                                board = reactiveValues(),
                                update = reactiveVal(),
-                               inputs_ready = reactive(TRUE), ...) {
+                               inputs_ready = reactive(TRUE),
+                               visibility = NULL, ...) {
 
   dot_args <- list(...)
 
@@ -291,14 +299,15 @@ block_server.block <- function(id, x, data = list(), block_id = id,
       )
 
       gated <- is_board(isolate(board$board)) &&
-        isTRUE(blockr_option("gate_visibility", TRUE))
+        isTRUE(blockr_option("gate_visibility", TRUE)) &&
+        not_null(visibility)
 
       render_obs <- output_render_observer(x, block_ready, inputs_ready,
                                            state_ready, res, cond, session,
                                            suspended = gated)
 
       if (gated) {
-        render_gate_observer(block_id, board, render_obs, session)
+        render_gate_observer(block_id, visibility, render_obs, session)
       }
 
       eb_res <- call_plugin_server(
@@ -506,14 +515,14 @@ explain_block_status <- function(cond, reason) {
   }
 }
 
-render_gate_observer <- function(id, board, render_obs, sess) {
+render_gate_observer <- function(id, visibility, render_obs, sess) {
 
   prev_render <- NA
 
   observe(
     {
-      do_render <- isTRUE(board$visible) ||
-        isTRUE(board$visible[id] %in% c("required", "rendered"))
+      do_render <- !gating_active(visibility$required) ||
+        block_visible(id, visibility)
 
       if (do_render) render_obs$resume() else render_obs$suspend()
 

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -33,8 +33,14 @@ board_server <- function(id, x, ...) {
 #' @param plugins Board plugins as modules
 #' @param options Board options (`NULL` defaults to the union of board, block
 #' and registry sourced options)
-#' @param callbacks Single (or list of) callback function(s), called only
-#' for their side-effects)
+#' @param callbacks Single (or list of) callback function(s) registering
+#' additional observers. Each receives a `visibility` list with two channels,
+#' `required` and `visible`, each an environment of per-block `reactiveVal`s
+#' (core keeps one per board block as blocks are added and removed). Declare a
+#' block needed with `visibility$required[[id]](TRUE)` (or `FALSE` for built
+#' but dormant) and report the view it is rendered into with
+#' `visibility$visible[[id]](view)` (or `NA_character_` for off screen); the
+#' board reads both to gate construction, evaluation and rendering.
 #' @param callback_location Location of callback invocation (before or after
 #' plugins)
 #' @rdname board_server
@@ -74,11 +80,17 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
         board_id = id,
         stacks = list(),
         last_update = NULL,
-        conditions = NULL,
-        visible = TRUE
+        conditions = NULL
       )
 
       rv$eval <- reactiveValues()
+
+      vis <- list(
+        required = new.env(parent = emptyenv()),
+        visible = new.env(parent = emptyenv())
+      )
+
+      add_vis_slots(vis, isolate(board_block_ids(rv$board)))
 
       rv_ro <- list(board = make_read_only(rv))
 
@@ -92,10 +104,10 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
 
       observe(
         {
-          cur <- if (isTRUE(rv$visible)) {
+          cur <- if (!gating_active(vis$required)) {
             TRUE
           } else {
-            upstream_blocks(on_screen_blocks(rv$visible), rv$board)
+            upstream_blocks(required_now(vis$required), rv$board)
           }
 
           old <- isolate(rv$needed())
@@ -112,6 +124,11 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
         }
       )
 
+      observe(
+        validate_vis(vis),
+        priority = Inf
+      )
+
       do.call(
         board_options_to_userdata,
         c(
@@ -123,27 +140,6 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
       )
 
       board_update <- reactiveVal()
-      board_visible <- reactiveVal()
-
-      observe(
-        {
-          vis <- board_visible()
-
-          if (is.null(vis) || !isTRUE(blockr_option("gate_visibility", TRUE))) {
-
-            rv$visible <- TRUE
-
-          } else {
-
-            rv$visible <- vis
-
-            log_debug(
-              "visibility update: {length(on_screen_blocks(vis))}/",
-              "{length(board_block_ids(rv$board))} on screen"
-            )
-          }
-        }
-      )
 
       cb_res <- set_names(
         vector("list", length(callbacks)),
@@ -152,7 +148,7 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
 
       cb_args <- c(
         rv_ro,
-        list(update = board_update, visible = board_visible),
+        list(update = board_update, visibility = vis),
         dot_args,
         list(session = session)
       )
@@ -184,7 +180,7 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
       observeEvent(
         TRUE,
         setup_board(rv, edit_block, ctrl_block, edit_stack, edit_plugin_args,
-                    session),
+                    session, vis),
         once = TRUE
       )
 
@@ -271,7 +267,8 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
                 ctrl_block = ctrl_block,
                 edit_stack = edit_stack,
                 edit_plugin_args = edit_plugin_args,
-                dot_args = dot_args
+                dot_args = dot_args,
+                vis = vis
               )
 
               new_board <- do.call(
@@ -400,7 +397,7 @@ deduped_board_reactive <- function(board, accessor) {
   val
 }
 
-setup_board <- function(rv, blk_ed, blk_ct, stk_mod, args, sess) {
+setup_board <- function(rv, blk_ed, blk_ct, stk_mod, args, sess, vis) {
 
   stopifnot(
     is.reactivevalues(rv),
@@ -415,12 +412,12 @@ setup_board <- function(rv, blk_ed, blk_ct, stk_mod, args, sess) {
 
   observe(
     {
-      need <- needed_block_ids(rv)
-      construct_blocks(need, rv, blk_ed, blk_ct, args)
+      need <- needed_block_ids(rv, vis$required)
+      construct_blocks(need, rv, blk_ed, blk_ct, args, vis)
     }
   )
 
-  construct_remaining_blocks(rv, blk_ed, blk_ct, args)
+  construct_remaining_blocks(rv, blk_ed, blk_ct, args, vis)
 
   setup_stacks(rv, stk_mod, args)
   add_blocks_to_stacks(rv, board_stacks(rv$board), sess)
@@ -440,7 +437,7 @@ combine_block_conditions <- function(frames) {
   res
 }
 
-construct_block <- function(id, rv, mod_ed, mod_ct, args) {
+construct_block <- function(id, rv, mod_ed, mod_ct, args, vis) {
 
   if (id %in% names(rv$blocks)) {
     return(invisible())
@@ -473,7 +470,7 @@ construct_block <- function(id, rv, mod_ed, mod_ct, args) {
     c(
       list(paste0("block_", id), blk, rv$inputs[[id]], id, mod_ed, mod_ct),
       args,
-      list(inputs_ready = inputs_ready)
+      list(inputs_ready = inputs_ready, visibility = vis)
     )
   )
 
@@ -484,7 +481,7 @@ construct_block <- function(id, rv, mod_ed, mod_ct, args) {
   invisible()
 }
 
-construct_blocks <- function(ids, rv, mod_ed, mod_ct, args) {
+construct_blocks <- function(ids, rv, mod_ed, mod_ct, args, vis) {
 
   ordered <- isolate(
     intersect(topo_sort(as.matrix(rv$board)), setdiff(ids, names(rv$blocks)))
@@ -497,28 +494,30 @@ construct_blocks <- function(ids, rv, mod_ed, mod_ct, args) {
   log_debug("constructing block{?s} {ordered}")
 
   for (id in ordered) {
-    isolate(construct_block(id, rv, mod_ed, mod_ct, args))
+    isolate(construct_block(id, rv, mod_ed, mod_ct, args, vis))
   }
 
   invisible()
 }
 
-construct_remaining_blocks <- function(rv, mod_ed, mod_ct, args) {
+construct_remaining_blocks <- function(rv, mod_ed, mod_ct, args, vis) {
 
   if (background_construction_delay() <= 0) {
 
-    construct_blocks(board_block_ids(rv$board), rv, mod_ed, mod_ct, args)
+    construct_blocks(board_block_ids(rv$board), rv, mod_ed, mod_ct, args,
+                     vis)
 
     return(invisible())
   }
 
   gate <- observe(
     {
-      if (isTRUE(rv$visible) || visible_set_rendered(rv$visible)) {
+      if (!gating_active(vis$required) ||
+            required_fulfilled(vis)) {
 
         gate$destroy()
 
-        construct_blocks_in_background(rv, mod_ed, mod_ct, args)
+        construct_blocks_in_background(rv, mod_ed, mod_ct, args, vis)
       }
     }
   )
@@ -526,7 +525,8 @@ construct_remaining_blocks <- function(rv, mod_ed, mod_ct, args) {
   invisible()
 }
 
-construct_blocks_in_background <- function(rv, mod_ed, mod_ct, args) {
+construct_blocks_in_background <- function(rv, mod_ed, mod_ct, args,
+                                           vis) {
 
   started <- FALSE
 
@@ -551,7 +551,9 @@ construct_blocks_in_background <- function(rv, mod_ed, mod_ct, args) {
         return(invisible())
       }
 
-      isolate(construct_block(remaining[[1L]], rv, mod_ed, mod_ct, args))
+      isolate(
+        construct_block(remaining[[1L]], rv, mod_ed, mod_ct, args, vis)
+      )
 
       invalidateLater(background_construction_delay())
     }
@@ -564,19 +566,106 @@ background_construction_delay <- function() {
   as.numeric(blockr_option("background_construction_delay", 50L))
 }
 
-on_screen_blocks <- function(status) {
-  names(status)[status %in% c("required", "rendered")]
+add_vis_slots <- function(vis, ids) {
+
+  for (id in ids) {
+    vis$required[[id]] <- reactiveVal(NA)
+    vis$visible[[id]] <- reactiveVal(NA_character_)
+  }
+
+  invisible()
 }
 
-visible_set_rendered <- function(status) {
-  all(status[on_screen_blocks(status)] == "rendered")
+rm_vis_slots <- function(vis, ids) {
+
+  gone <- intersect(ids, ls(vis$required))
+
+  if (length(gone)) {
+    rm(list = gone, envir = vis$required)
+    rm(list = gone, envir = vis$visible)
+  }
+
+  invisible()
 }
 
-needed_block_ids <- function(rv) {
+gating_active <- function(required) {
+  isTRUE(blockr_option("gate_visibility", TRUE)) && has_required(required)
+}
+
+has_required <- function(required) {
+  length(ever_required(required)) > 0L
+}
+
+ever_required <- function(required) {
+  ids <- ls(required)
+  ids[lgl_ply(ids, slot_declared, required)]
+}
+
+slot_declared <- function(id, required) {
+  !is.na(required[[id]]())
+}
+
+required_now <- function(required) {
+  ids <- ls(required)
+  ids[lgl_ply(ids, slot_needed, required)]
+}
+
+slot_needed <- function(id, required) {
+  isTRUE(required[[id]]())
+}
+
+is_visible <- function(x) {
+  !is.na(x)
+}
+
+block_visible <- function(id, vis) {
+  is_visible(vis$visible[[id]]())
+}
+
+required_fulfilled <- function(vis) {
+  all(lgl_ply(required_now(vis$required), block_visible, vis))
+}
+
+validate_vis <- function(vis) {
+
+  for (id in ls(vis$required)) {
+    if (!valid_required(vis$required[[id]]())) {
+      blockr_abort(
+        "required[[{id}]] must be TRUE, FALSE or NA",
+        class = "invalid_required"
+      )
+    }
+  }
+
+  for (id in ls(vis$visible)) {
+    if (!valid_visible(vis$visible[[id]]())) {
+      blockr_abort(
+        "visible[[{id}]] must be a non-empty string or NA_character_",
+        class = "invalid_visible"
+      )
+    }
+  }
+
+  invisible()
+}
+
+valid_required <- function(x) {
+  is.logical(x) && length(x) == 1L
+}
+
+valid_visible <- function(x) {
+  is.character(x) && length(x) == 1L && (is.na(x) || nzchar(x))
+}
+
+needed_block_ids <- function(rv, required) {
 
   need <- rv$needed()
 
-  if (isTRUE(need)) board_block_ids(rv$board) else need
+  if (isTRUE(need)) {
+    return(board_block_ids(rv$board))
+  }
+
+  union(need, ever_required(required))
 }
 
 block_inputs_ready <- function(src_rv, blk, rv) {
@@ -1498,13 +1587,16 @@ apply_board_update.board <- function(board, upd, ...,
 
 apply_core_board_update <- function(rv, upd, session,
                                     edit_block, ctrl_block, edit_stack,
-                                    edit_plugin_args, dot_args = list()) {
+                                    edit_plugin_args, vis,
+                                    dot_args = list()) {
 
   ns <- session$ns
 
   if (length(upd$blocks$add)) {
 
     log_debug("adding block{?s} {names(upd$blocks$add)}")
+
+    add_vis_slots(vis, names(upd$blocks$add))
 
     do.call(
       insert_block_ui,
@@ -1522,7 +1614,7 @@ apply_core_board_update <- function(rv, upd, session,
     board_blocks(rv$board) <- c(board_blocks(rv$board), upd$blocks$add)
 
     construct_blocks(names(upd$blocks$add), rv, edit_block, ctrl_block,
-                     edit_plugin_args)
+                     edit_plugin_args, vis)
   }
 
   if (length(upd$blocks$mod)) {
@@ -1534,7 +1626,8 @@ apply_core_board_update <- function(rv, upd, session,
       delta <- upd$blocks$mod[[blk_id]]
 
       if (length(delta)) {
-        construct_block(blk_id, rv, edit_block, ctrl_block, edit_plugin_args)
+        construct_block(blk_id, rv, edit_block, ctrl_block, edit_plugin_args,
+                        vis)
         apply_block_mod_delta(blk_id, delta, rv)
       }
     }
@@ -1621,6 +1714,8 @@ apply_core_board_update <- function(rv, upd, session,
     )
 
     destroy_rm_blocks(upd$blocks$rm, rv, session, dot_args)
+
+    rm_vis_slots(vis, upd$blocks$rm)
   }
 
   invisible()

--- a/man/block_server.Rd
+++ b/man/block_server.Rd
@@ -28,6 +28,7 @@ block_server(id, x, data = list(), ...)
   board = reactiveValues(),
   update = reactiveVal(),
   inputs_ready = reactive(TRUE),
+  visibility = NULL,
   ...
 )
 
@@ -62,6 +63,11 @@ block_render_trigger(x, session = get_session())
 inputs are all connected to ready upstream blocks (supplied by
 \code{\link[=board_server]{board_server()}}; defaults to always-ready when a block server is run
 standalone)}
+
+\item{visibility}{Visibility channel bundle -- a list with two channels,
+\code{required} and \code{visible}, each an environment of per-block \code{reactiveVal}s,
+supplied by \code{\link[=board_server]{board_server()}} to gate rendering; \code{NULL} (the standalone
+default) leaves the block ungated}
 }
 \value{
 Both \code{block_server()} and \code{expr_server()} return shiny server module
@@ -89,8 +95,9 @@ i.e. block user inputs and expression), and instantiation of the
 \code{edit_block} module (if passed from the parent scope).
 
 Each block carries an \emph{eval status} -- one of \code{dormant}, \code{waiting}, \code{unset},
-\code{failed} or \code{ready} -- which, together with the orthogonal \code{visible} flag,
-determines its behaviour. The status separates the two input kinds (data
+\code{failed} or \code{ready} -- which, together with its orthogonal front-end
+visibility, determines its behaviour. The status separates the two input
+kinds (data
 inputs from links, user inputs from \code{state}) and a genuine failure:
 \itemize{
 \item \code{dormant} -- not \emph{needed} (neither on screen nor feeding, transitively over
@@ -124,34 +131,36 @@ from output, the behavior of which can be customized via the
 \code{\link[=block_output]{block_output()}} generic. The \code{\link[=block_ui]{block_ui()}} generic can then be used to
 control rendering of outputs.
 
-When a front-end (such as blockr.dock) drives the \code{visible} write-channel
-that \code{\link[=board_server]{board_server()}} hands to the board callback, reporting each block's
-visibility status (off screen, on screen, or rendered into its view),
-evaluation and rendering are gated on visibility.
-Rendering is gated on plain visibility: the render observer is suspended
-while a block is off screen and resumed once it is on screen, starting
-suspended so nothing renders before the front-end first reports. Evaluation
-is gated on the \emph{needed} set, the on-screen blocks together with their
-upstream closure over \code{\link[=board_links]{board_links()}} (derived from \code{visible}, recomputed
-only when it or the links change). A block's input data reactives stay
+A front-end (such as blockr.dock) drives two per-block channels that
+\code{\link[=board_server]{board_server()}} hands to the board callback as \code{visibility}: \code{required}
+(which blocks it needs built and evaluated) and \code{visible} (which blocks it
+has arranged on screen). Requirements are a cause the front-end -- and
+core-side features such as code export -- declare; visibility is the effect
+the front-end reports back once it has painted a block. Rendering is gated
+on \code{visible}: the render observer is suspended while a block carries no
+visible slot and resumed once the front-end writes a non-empty string for
+it, starting suspended so nothing renders before the first report.
+Evaluation is gated on the \emph{needed} set, the \code{required} blocks together with
+their upstream closure over \code{\link[=board_links]{board_links()}} (recomputed only when
+requirements or links change). A block's input data reactives stay
 unfulfilled (they \code{\link[shiny:req]{shiny::req()}} out) unless the block is needed, so a block
-that is neither visible nor feeding a visible block pulls no input and stays
-fully quiescent: its result reactive, and any observer its expression server
-registers on the incoming data, all short-circuit and do nothing. A needed
-but off-screen block (one feeding a visible block) evaluates but does not
-render. Block-server \emph{construction} is prioritized the same way: the needed
-set is instantiated first so that first paint waits only for the on-screen
-blocks and their upstreams, and the remaining block servers are built
-progressively in the background. That background pass holds until the
-front-end reports every on-screen block as rendered (arranged into its
-view), so it never competes with first paint. Until a block is built it is
-absent from
-the \code{board$blocks} handed to plugins and callbacks, which simply see it
-appear once constructed. The background cadence is set by the
-\code{background_construction_delay} \code{\link[=blockr_option]{blockr_option()}} (milliseconds between
-successive blocks, default 50); a value of 0 disables the staggering and
-builds every block up front. With nothing driving
-\code{visible} every block is needed and behaviour is unchanged; the
+that is neither required nor feeding a required block pulls no input and
+stays fully quiescent: its result reactive, and any observer its expression
+server registers on the incoming data, all short-circuit and do nothing. A
+needed but off-screen block (one feeding a required block) evaluates but
+does not render. Block-server \emph{construction} is prioritized the same way:
+the needed set is instantiated first so that first paint waits only for the
+required blocks and their upstreams, and the remaining block servers are
+built progressively in the background. That background pass holds until the
+front-end reports every required block as visible, so it never competes with
+first paint. A \code{required} slot of \code{FALSE} keeps a block built but dormant
+(ever required, not needed now); an absent slot leaves it unbuilt. Until a
+block is built it is absent from the \code{board$blocks} handed to plugins and
+callbacks, which simply see it appear once constructed. The background
+cadence is set by the \code{background_construction_delay} \code{\link[=blockr_option]{blockr_option()}}
+(milliseconds between successive blocks, default 50); a value of 0 disables
+the staggering and builds every block up front. With nothing writing
+\code{required} every block is needed and behaviour is unchanged; the
 \code{gate_visibility} \code{\link[=blockr_option]{blockr_option()}} (default \code{TRUE}) turns gating off
 entirely.
 }

--- a/man/board_server.Rd
+++ b/man/board_server.Rd
@@ -29,8 +29,14 @@ board_server(id, x, ...)
 \item{options}{Board options (\code{NULL} defaults to the union of board, block
 and registry sourced options)}
 
-\item{callbacks}{Single (or list of) callback function(s), called only
-for their side-effects)}
+\item{callbacks}{Single (or list of) callback function(s) registering
+additional observers. Each receives a \code{visibility} list with two channels,
+\code{required} and \code{visible}, each an environment of per-block \code{reactiveVal}s
+(core keeps one per board block as blocks are added and removed). Declare a
+block needed with \code{visibility$required[[id]](TRUE)} (or \code{FALSE} for built
+but dormant) and report the view it is rendered into with
+\code{visibility$visible[[id]](view)} (or \code{NA_character_} for off screen); the
+board reads both to gate construction, evaluation and rendering.}
 
 \item{callback_location}{Location of callback invocation (before or after
 plugins)}

--- a/tests/testthat/test-visibility-gating.R
+++ b/tests/testthat/test-visibility-gating.R
@@ -138,9 +138,22 @@ constructed <- function(id) {
   id %in% probe_construct$ids
 }
 
-vis_map <- function(..., level = "rendered") {
-  ids <- c(...)
-  set_names(rep(level, length(ids)), ids)
+require_blocks <- function(vis, ...) {
+
+  for (id in c(...)) {
+    vis$required[[id]](TRUE)
+  }
+
+  invisible()
+}
+
+render_blocks <- function(vis, ...) {
+
+  for (id in c(...)) {
+    vis$visible[[id]]("main")
+  }
+
+  invisible()
 }
 
 test_that("with no producer every block is visible", {
@@ -160,7 +173,7 @@ test_that("with no producer every block is visible", {
     {
       session$flushReact()
 
-      expect_true(rv$visible)
+      expect_true(rv$needed())
 
       expect_true(evaluated("a"))
       expect_true(evaluated("b"))
@@ -195,7 +208,7 @@ test_that("a producer gates evaluation and rendering on visibility", {
     {
       session$flushReact()
 
-      expect_setequal(on_screen_blocks(rv$visible), "b")
+      expect_setequal(required_now(vis$required), "b")
 
       expect_true(evaluated("b"))
       expect_true(rendered("b"))
@@ -209,7 +222,8 @@ test_that("a producer gates evaluation and rendering on visibility", {
       expect_false(evaluated("d"))
       expect_false(rendered("d"))
 
-      board_visible(vis_map("b", "c", "d"))
+      require_blocks(vis, "c", "d")
+      render_blocks(vis, "c", "d")
       session$flushReact()
 
       expect_true(evaluated("c"))
@@ -221,9 +235,9 @@ test_that("a producer gates evaluation and rendering on visibility", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visible, ...) {
-        visible(vis_map("b"))
-        NULL
+      callbacks = function(visibility, ...) {
+        require_blocks(visibility, "b")
+        render_blocks(visibility, "b")
       }
     )
   )
@@ -260,9 +274,9 @@ test_that("the gate_visibility option disables gating", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visible, ...) {
-        visible(vis_map("b"))
-        NULL
+      callbacks = function(visibility, ...) {
+        require_blocks(visibility, "b")
+        render_blocks(visibility, "b")
       }
     )
   )
@@ -306,9 +320,9 @@ test_that("a link change re-routes the pulled upstream", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visible, ...) {
-        visible(vis_map("b"))
-        NULL
+      callbacks = function(visibility, ...) {
+        require_blocks(visibility, "b")
+        render_blocks(visibility, "b")
       }
     )
   )
@@ -340,9 +354,9 @@ test_that("an off-screen data-observing block does not pull its upstream", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visible, ...) {
-        visible(vis_map("c"))
-        NULL
+      callbacks = function(visibility, ...) {
+        require_blocks(visibility, "c")
+        render_blocks(visibility, "c")
       }
     )
   )
@@ -384,9 +398,9 @@ test_that("an unrelated structural edit does not re-evaluate needed blocks", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visible, ...) {
-        visible(vis_map("b"))
-        NULL
+      callbacks = function(visibility, ...) {
+        require_blocks(visibility, "b")
+        render_blocks(visibility, "b")
       }
     )
   )
@@ -426,9 +440,9 @@ test_that("adding a block does not re-evaluate existing needed blocks", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visible, ...) {
-        visible(vis_map("b"))
-        NULL
+      callbacks = function(visibility, ...) {
+        require_blocks(visibility, "b")
+        render_blocks(visibility, "b")
       }
     )
   )
@@ -459,9 +473,9 @@ test_that("a variadic block receives its inputs as values, not reactives", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visible, ...) {
-        visible(vis_map("c"))
-        NULL
+      callbacks = function(visibility, ...) {
+        require_blocks(visibility, "c")
+        render_blocks(visibility, "c")
       }
     )
   )
@@ -495,9 +509,9 @@ test_that("an off-screen variadic block does not pull its inputs", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visible, ...) {
-        visible(vis_map("e"))
-        NULL
+      callbacks = function(visibility, ...) {
+        require_blocks(visibility, "e")
+        render_blocks(visibility, "e")
       }
     )
   )
@@ -519,9 +533,9 @@ ordered_board <- function() {
   )
 }
 
-visible_b <- function(visible, ...) {
-  visible(vis_map("b"))
-  NULL
+visible_b <- function(visibility, ...) {
+  require_blocks(visibility, "b")
+  render_blocks(visibility, "b")
 }
 
 test_that("only the needed blocks are constructed before first paint", {
@@ -560,7 +574,8 @@ test_that("opening a view constructs its blocks without the background", {
 
       expect_false(constructed("c"))
 
-      board_visible(vis_map("b", "c"))
+      require_blocks(vis, "c")
+      render_blocks(vis, "c")
       session$flushReact()
 
       expect_true(constructed("c"))
@@ -595,28 +610,97 @@ test_that("the background constructs every block exactly once", {
   )
 })
 
-test_that("on_screen_blocks is the union of the required and rendered ids", {
+test_that("is_visible is a non-NA check on the slot value", {
 
-  expect_setequal(
-    on_screen_blocks(c(a = "rendered", b = "required", z = "hidden")),
-    c("a", "b")
-  )
-
-  expect_length(on_screen_blocks(c(z = "hidden")), 0L)
-  expect_length(on_screen_blocks(character()), 0L)
+  expect_true(is_visible("main"))
+  expect_false(is_visible(NA_character_))
 })
 
-test_that("visible_set_rendered is TRUE only when all on-screen rendered", {
+test_that("channel validators enforce the required and visible contracts", {
 
-  expect_true(visible_set_rendered(c(a = "rendered", b = "rendered")))
+  expect_true(valid_required(TRUE))
+  expect_true(valid_required(FALSE))
+  expect_true(valid_required(NA))
+  expect_false(valid_required("x"))
+  expect_false(valid_required(NA_character_))
 
-  expect_false(visible_set_rendered(c(a = "rendered", b = "required")))
-  expect_false(visible_set_rendered(c(b = "required")))
+  expect_true(valid_visible("main"))
+  expect_true(valid_visible(NA_character_))
+  expect_false(valid_visible(""))
+  expect_false(valid_visible(NA))
+  expect_false(valid_visible(c("a", "b")))
+})
 
-  expect_true(visible_set_rendered(c(a = "rendered", z = "hidden")))
+test_that("validate_vis hard-errors on an off-contract slot", {
 
-  expect_true(visible_set_rendered(character()))
-  expect_true(visible_set_rendered(c(z = "hidden")))
+  isolate({
+    vis <- list(
+      required = new.env(parent = emptyenv()),
+      visible = new.env(parent = emptyenv())
+    )
+    add_vis_slots(vis, "a")
+
+    vis$required[["a"]](1L)
+    expect_error(validate_vis(vis), class = "invalid_required")
+
+    vis$required[["a"]](TRUE)
+    vis$visible[["a"]]("")
+    expect_error(validate_vis(vis), class = "invalid_visible")
+  })
+})
+
+test_that("required_now returns the TRUE-required blocks", {
+
+  isolate({
+    req <- new.env(parent = emptyenv())
+    req$a <- reactiveVal(TRUE)
+    req$b <- reactiveVal(FALSE)
+    req$c <- reactiveVal(NA)
+    req$d <- reactiveVal(TRUE)
+
+    expect_setequal(required_now(req), c("a", "d"))
+    expect_length(required_now(new.env(parent = emptyenv())), 0L)
+  })
+})
+
+test_that("ever_required and has_required track declared (non-NA) slots", {
+
+  isolate({
+    req <- new.env(parent = emptyenv())
+    req$a <- reactiveVal(TRUE)
+    req$b <- reactiveVal(FALSE)
+    req$c <- reactiveVal(NA)
+
+    expect_setequal(ever_required(req), c("a", "b"))
+    expect_true(has_required(req))
+    expect_false(has_required(new.env(parent = emptyenv())))
+  })
+})
+
+test_that("required_fulfilled holds only when every required block is shown", {
+
+  isolate({
+    vis <- list(
+      required = new.env(parent = emptyenv()),
+      visible = new.env(parent = emptyenv())
+    )
+    add_vis_slots(vis, c("a", "b"))
+    vis$required[["a"]](TRUE)
+    vis$required[["b"]](TRUE)
+    vis$visible[["a"]]("main")
+    vis$visible[["b"]]("main")
+
+    expect_true(required_fulfilled(vis))
+
+    vis$visible[["b"]](NA_character_)
+    expect_false(required_fulfilled(vis))
+
+    empty <- list(
+      required = new.env(parent = emptyenv()),
+      visible = new.env(parent = emptyenv())
+    )
+    expect_true(required_fulfilled(empty))
+  })
 })
 
 test_that("the background waits for the front-end's rendered report", {
@@ -637,7 +721,7 @@ test_that("the background waits for the front-end's rendered report", {
       expect_false(constructed("c"))
       expect_false(constructed("d"))
 
-      board_visible(vis_map("b"))
+      render_blocks(vis, "b")
       session$flushReact()
       session$elapse(5000)
       session$flushReact()
@@ -648,10 +732,7 @@ test_that("the background waits for the front-end's rendered report", {
     args = list(
       x = ordered_board(),
       plugins = list(),
-      callbacks = function(visible, ...) {
-        visible(vis_map("b", level = "required"))
-        NULL
-      }
+      callbacks = function(visibility, ...) require_blocks(visibility, "b")
     )
   )
 })


### PR DESCRIPTION
## Summary

Block-visibility gating moves from one core-owned `visible` push channel to **two per-block channels that core and the front-end share**: `required` (the *cause* — which blocks are needed) and `visible` (the *fulfillment* — which view each block is painted into). Core creates both, owns their per-block slot lifecycle, validates them, and reads them to drive building and evaluation; the front-end (blockr.dock) writes them.

This fixes the root problem behind #273: `needed` was single-sourced from `visible`, so a second writer — e.g. code export marking a block needed — was clobbered within a flush. Splitting cause from fulfillment gives `needed` a genuine multi-writer source and keeps `visible` as the front-end's paint report.

## The two channels

Core bundles them as `vis = list(required = <env>, visible = <env>)` and threads it as an **explicit argument** through block construction — never on the read-only board. Each channel is an **environment of per-block `reactiveVal`s** (`id → reactiveVal`) rather than a `reactiveValues`, because a `reactiveValues` can't shrink (`rv[[id]] <- NULL` leaves the key) whereas `rm(list = id, envir = …)` removes a slot cleanly, and an environment is reference-shared so both value writes and slot add/remove reach every holder. Writers set a slot by calling its reactiveVal — `visibility$required[[id]](TRUE)`, `visibility$visible[[id]](view)`.

- **`required[[id]]`** — `TRUE` (needed now: build + evaluate), `FALSE` (was required, kept built but dormant), `NA` (never required: unbuilt). The one shared object takes writes from any source — dock, plugins, core-side features like code export.
- **`visible[[id]]`** — the view id the block is painted into, or `NA_character_`. Core reads only whether it's a non-`NA` string; the value itself is opaque to core.

Core seeds a block's slots (`add_vis_slots`) at construction and on block-add — before any of that block's plugins run — drops them on remove (`rm_vis_slots`), and a max-priority observer hard-errors on any off-contract write, so readers can trust the types.

The `NULL` → all-visible default and the `gate_visibility` option are unchanged: a board with no `required` set (any non-dock board) builds and renders everything, as before.

## Breaking change — callback contract

The board callback now receives `visibility` (the `vis` bundle) instead of a `visible` reactiveVal to write, and reports by calling the per-block reactiveVals rather than pushing a status map. blockr.dock adopts this in the linked PR.

```deps
BristolMyersSquibb/blockr.dock#289
BristolMyersSquibb/blockr.dag@core274-pin
BristolMyersSquibb/blockr.assistant@core274-pin
```

## Notes

- **Version / NEWS:** first PR into freshly-released `main` — patch-bumped to 0.1.4 with a breaking-change entry.
- **Merge order:** the queue-only revdep builds the downstream stack against this PR, so it must resolve to the adopted dock. dock#289 adopts the new channels and pins `core@273-visible-pull`; blockr.dag and blockr.assistant transitively depend on dock, so throwaway `core274-pin` branches repin them to dock#289 for the revdep. The deps block points the revdep at all three. Once this lands, those throwaway pins are dropped and dock#289 repins to `main`.

Fixes #273
