### PR TITLE
Prioritize the newly-visible view in staggered block construction

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,11 @@
   export ("Show code") then marks every block required, so the exported
   script covers the whole board; an off-screen block that is not fully
   configured holds the export back instead of emitting broken code (#269).
+* With a finite `background_construction_delay`, the staggered builder now
+  prioritizes the on-screen view: each tick builds the next block needed by the
+  visible set before the rest of the backlog, so switching view re-prioritizes
+  construction toward what is now on screen and the newly-visible blocks come up
+  progressively instead of in one blocking build (#275).
 
 # blockr.core 0.1.3
 

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -410,13 +410,6 @@ setup_board <- function(rv, blk_ed, blk_ct, stk_mod, args, sess, vis) {
   rv$sources <- list()
   rv$stacks <- list()
 
-  observe(
-    {
-      need <- needed_block_ids(rv, vis$required)
-      construct_blocks(need, rv, blk_ed, blk_ct, args, vis)
-    }
-  )
-
   construct_remaining_blocks(rv, blk_ed, blk_ct, args, vis)
 
   setup_stacks(rv, stk_mod, args)
@@ -513,18 +506,23 @@ construct_remaining_blocks <- function(rv, mod_ed, mod_ct, args, vis) {
   }
 
   if (is.infinite(delay)) {
+
+    construct_needed_blocks(rv, mod_ed, mod_ct, args, vis)
+
     return(invisible())
   }
 
-  gate <- observe(
+  construct_blocks_in_background(rv, mod_ed, mod_ct, args, vis)
+
+  invisible()
+}
+
+construct_needed_blocks <- function(rv, mod_ed, mod_ct, args, vis) {
+
+  observe(
     {
-      if (!gating_active(vis$required) ||
-            required_fulfilled(vis)) {
-
-        gate$destroy()
-
-        construct_blocks_in_background(rv, mod_ed, mod_ct, args, vis)
-      }
+      need <- needed_block_ids(rv, vis$required)
+      construct_blocks(need, rv, mod_ed, mod_ct, args, vis)
     }
   )
 
@@ -541,6 +539,16 @@ construct_blocks_in_background <- function(rv, mod_ed, mod_ct, args,
       if (!started) {
 
         started <<- TRUE
+
+        if (!isolate(gating_active(vis$required))) {
+
+          construct_blocks(board_block_ids(rv$board), rv, mod_ed, mod_ct,
+                           args, vis)
+          obs$destroy()
+
+          return(invisible())
+        }
+
         invalidateLater(background_construction_delay())
 
         return(invisible())
@@ -557,9 +565,24 @@ construct_blocks_in_background <- function(rv, mod_ed, mod_ct, args,
         return(invisible())
       }
 
-      isolate(
-        construct_block(remaining[[1L]], rv, mod_ed, mod_ct, args, vis)
+      needed <- isolate(
+        intersect(remaining, needed_block_ids(rv, vis$required))
       )
+
+      if (length(needed)) {
+
+        isolate(construct_block(needed[[1L]], rv, mod_ed, mod_ct, args, vis))
+
+        invalidateLater(background_construction_delay())
+
+        return(invisible())
+      }
+
+      if (gating_active(vis$required) && !required_fulfilled(vis)) {
+        return(invisible())
+      }
+
+      isolate(construct_block(remaining[[1L]], rv, mod_ed, mod_ct, args, vis))
 
       invalidateLater(background_construction_delay())
     }

--- a/tests/testthat/test-visibility-gating.R
+++ b/tests/testthat/test-visibility-gating.R
@@ -189,6 +189,8 @@ test_that("a producer gates evaluation and rendering on visibility", {
 
   reset_probes()
 
+  withr::local_options(blockr.background_construction_delay = 0)
+
   board <- new_board(
     blocks = c(
       a = with_id(probe_source(), "a"),
@@ -286,6 +288,8 @@ test_that("a link change re-routes the pulled upstream", {
 
   reset_probes()
 
+  withr::local_options(blockr.background_construction_delay = 0)
+
   board <- new_board(
     blocks = c(
       a = with_id(probe_source(), "a"),
@@ -332,6 +336,8 @@ test_that("an off-screen data-observing block does not pull its upstream", {
 
   reset_probes()
 
+  withr::local_options(blockr.background_construction_delay = 0)
+
   board <- new_board(
     blocks = c(
       a = with_id(probe_source(), "a"),
@@ -365,6 +371,8 @@ test_that("an off-screen data-observing block does not pull its upstream", {
 test_that("an unrelated structural edit does not re-evaluate needed blocks", {
 
   reset_probes()
+
+  withr::local_options(blockr.background_construction_delay = 0)
 
   board <- new_board(
     blocks = c(
@@ -410,6 +418,8 @@ test_that("adding a block does not re-evaluate existing needed blocks", {
 
   reset_probes()
 
+  withr::local_options(blockr.background_construction_delay = 0)
+
   board <- new_board(
     blocks = c(
       a = with_id(probe_source(), "a"),
@@ -453,6 +463,8 @@ test_that("a variadic block receives its inputs as values, not reactives", {
   reset_probes()
   probe_args$entry_classes <- NULL
 
+  withr::local_options(blockr.background_construction_delay = 0)
+
   board <- new_board(
     blocks = c(
       a = with_id(probe_source(), "a"),
@@ -484,6 +496,8 @@ test_that("a variadic block receives its inputs as values, not reactives", {
 test_that("an off-screen variadic block does not pull its inputs", {
 
   reset_probes()
+
+  withr::local_options(blockr.background_construction_delay = 0)
 
   board <- new_board(
     blocks = c(
@@ -538,7 +552,7 @@ visible_b <- function(visibility, ...) {
   render_blocks(visibility, "b")
 }
 
-test_that("only the needed blocks are constructed before first paint", {
+test_that("the priority lane builds the needed set ahead of the backlog", {
 
   reset_probes()
 
@@ -546,24 +560,29 @@ test_that("only the needed blocks are constructed before first paint", {
     get_s3_method("board_server", ordered_board()),
     {
       session$flushReact()
-
-      expect_true(constructed("a"))
-      expect_true(constructed("b"))
-
-      expect_false(constructed("c"))
-      expect_false(constructed("d"))
-
       session$elapse(5000)
       session$flushReact()
 
-      expect_true(constructed("c"))
-      expect_true(constructed("d"))
+      built <- probe_construct$ids
+
+      expect_setequal(built, c("a", "b", "c", "d"))
+
+      # d is off the needed path; it builds last, after the needed set a, b, c,
+      # even though topo order (a, d, b, c) would otherwise place it second
+      expect_identical(built[[length(built)]], "d")
     },
-    args = list(x = ordered_board(), plugins = list(), callbacks = visible_b)
+    args = list(
+      x = ordered_board(),
+      plugins = list(),
+      callbacks = function(visibility, ...) {
+        require_blocks(visibility, "c")
+        render_blocks(visibility, "c")
+      }
+    )
   )
 })
 
-test_that("opening a view constructs its blocks without the background", {
+test_that("opening a view pulls its blocks ahead of a gated backlog", {
 
   reset_probes()
 
@@ -571,8 +590,12 @@ test_that("opening a view constructs its blocks without the background", {
     get_s3_method("board_server", ordered_board()),
     {
       session$flushReact()
+      session$elapse(5000)
+      session$flushReact()
 
+      expect_true(constructed("b"))
       expect_false(constructed("c"))
+      expect_false(constructed("d"))
 
       require_blocks(vis, "c")
       render_blocks(vis, "c")
@@ -581,7 +604,11 @@ test_that("opening a view constructs its blocks without the background", {
       expect_true(constructed("c"))
       expect_false(constructed("d"))
     },
-    args = list(x = ordered_board(), plugins = list(), callbacks = visible_b)
+    args = list(
+      x = ordered_board(),
+      plugins = list(),
+      callbacks = function(visibility, ...) require_blocks(visibility, "b")
+    )
   )
 })
 
@@ -772,12 +799,11 @@ test_that("the background waits for the front-end's rendered report", {
     get_s3_method("board_server", ordered_board()),
     {
       session$flushReact()
+      session$elapse(5000)
+      session$flushReact()
 
       expect_true(constructed("a"))
       expect_true(constructed("b"))
-
-      session$elapse(5000)
-      session$flushReact()
 
       expect_false(constructed("c"))
       expect_false(constructed("d"))


### PR DESCRIPTION
## Summary

- Follow-up to #269 finishing the `background_construction_delay` arc. With a finite delay, `construct_blocks_in_background()` now builds the topo-first unbuilt block in `rv$needed()` (the on-screen closure) before the rest of the backlog, re-reading `rv$needed()` each tick so a view switch re-prioritizes the queue for free. This closes both gaps the issue names: the demand build is no longer a synchronous burst (Gap 1), and the background drain is no longer visibility-blind (Gap 2).
- The separate synchronous demand observer in `setup_board()` is gone, so the newly-visible set now comes up progressively rather than in one blocking build. That is the trade-off the issue flags, settled toward progressive-but-smooth.
- The #257 render-gate is preserved by moving it inside the ticker: the needed lane always runs, but the backlog fallback still waits on `required_fulfilled()` and parks on a reactive read (no busy-poll). Dropping the demand build while keeping the old standalone gate would deadlock — nothing would build the visible set, so it never reports rendered, so the gate never opens.
- Ungated / gate-off boards are untouched. The ticker's first tick detects `!gating_active` and builds the whole board synchronously, exactly as before, so standalone boards keep eager construction; `Inf` also stays demand-only. This scopes the behaviour change to the dock case.
- Gated eval/render tests now pin `background_construction_delay = 0` to exercise gating independent of construction timing (the off-screen-does-not-pull assertions now hold against a *constructed* block — strictly stronger). The construction-timing tests are reworked for the progressive contract, each verified to fail against a topo-blind builder.

Fixes #275
