### PR TITLE
Stop background block construction from starving user input

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,8 @@ Imports:
     digest,
     cli,
     glue,
-    yaml
+    yaml,
+    later
 Suggests:
     testthat (>= 3.0.0),
     memuse,

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,10 @@
   visible set before the rest of the backlog, so switching view re-prioritizes
   construction toward what is now on screen and the newly-visible blocks come up
   progressively instead of in one blocking build (#275).
+* The staggered builder no longer monopolizes the event loop while it runs.
+  Each tick's pacing delay now begins once the just-built block has flushed
+  rather than while its reactive graph is still flushing, so pending user input
+  is serviced within one tick instead of behind the entire backlog (#276).
 
 # blockr.core 0.1.3
 

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -529,13 +529,17 @@ construct_needed_blocks <- function(rv, mod_ed, mod_ct, args, vis) {
   invisible()
 }
 
-construct_blocks_in_background <- function(rv, mod_ed, mod_ct, args,
-                                           vis) {
+construct_blocks_in_background <- function(rv, mod_ed, mod_ct, args, vis) {
+
+  session <- getDefaultReactiveDomain()
+  pace <- reactiveVal(0L)
 
   started <- FALSE
 
   obs <- observe(
     {
+      pace()
+
       if (!started) {
 
         started <<- TRUE
@@ -549,7 +553,7 @@ construct_blocks_in_background <- function(rv, mod_ed, mod_ct, args,
           return(invisible())
         }
 
-        invalidateLater(background_construction_delay())
+        schedule_construction(pace, session)
 
         return(invisible())
       }
@@ -573,7 +577,7 @@ construct_blocks_in_background <- function(rv, mod_ed, mod_ct, args,
 
         isolate(construct_block(needed[[1L]], rv, mod_ed, mod_ct, args, vis))
 
-        invalidateLater(background_construction_delay())
+        schedule_construction(pace, session)
 
         return(invisible())
       }
@@ -584,11 +588,31 @@ construct_blocks_in_background <- function(rv, mod_ed, mod_ct, args,
 
       isolate(construct_block(remaining[[1L]], rv, mod_ed, mod_ct, args, vis))
 
-      invalidateLater(background_construction_delay())
+      schedule_construction(pace, session)
     }
   )
 
   invisible()
+}
+
+schedule_construction <- function(pace, session) {
+
+  advance <- function() {
+    if (!isTRUE(session$isClosed())) {
+      withReactiveDomain(session, pace(isolate(pace()) + 1L))
+    }
+  }
+
+  # Begin the pacing delay only once the block just built has flushed: an
+  # in-flush invalidateLater() clock is consumed by that flush (which runs the
+  # new block's reactive graph), leaving the event loop no idle window to
+  # service user input between ticks. Re-arming via `onFlushed()` starts the
+  # delay after the flush drains, so the window is genuine idle.
+  onFlushed(
+    function() later::later(advance, background_construction_delay() / 1000),
+    once = TRUE,
+    session = session
+  )
 }
 
 background_construction_delay <- function() {

--- a/tests/testthat/test-visibility-gating.R
+++ b/tests/testthat/test-visibility-gating.R
@@ -126,6 +126,14 @@ reset_probes <- function() {
   probe_construct$ids <- character()
 }
 
+# Drives the background builder synchronously: the production scheduler paces
+# the next tick behind a post-flush `later::later()`, which a mock session does
+# not run, so bump the pace channel directly to re-run the ticker on the next
+# flush.
+drive_construction <- function(pace, session) {
+  pace(isolate(pace()) + 1L)
+}
+
 rendered <- function(id) {
   any(endsWith(probe_render$ids, paste0("block_", id)))
 }
@@ -556,11 +564,11 @@ test_that("the priority lane builds the needed set ahead of the backlog", {
 
   reset_probes()
 
+  local_mocked_bindings(schedule_construction = drive_construction)
+
   testServer(
     get_s3_method("board_server", ordered_board()),
     {
-      session$flushReact()
-      session$elapse(5000)
       session$flushReact()
 
       built <- probe_construct$ids
@@ -586,11 +594,11 @@ test_that("opening a view pulls its blocks ahead of a gated backlog", {
 
   reset_probes()
 
+  local_mocked_bindings(schedule_construction = drive_construction)
+
   testServer(
     get_s3_method("board_server", ordered_board()),
     {
-      session$flushReact()
-      session$elapse(5000)
       session$flushReact()
 
       expect_true(constructed("b"))
@@ -616,11 +624,11 @@ test_that("the background constructs every block exactly once", {
 
   reset_probes()
 
+  local_mocked_bindings(schedule_construction = drive_construction)
+
   testServer(
     get_s3_method("board_server", ordered_board()),
     {
-      session$flushReact()
-      session$elapse(5000)
       session$flushReact()
 
       built <- probe_construct$ids
@@ -628,7 +636,6 @@ test_that("the background constructs every block exactly once", {
       expect_setequal(built, c("a", "b", "c", "d"))
       expect_length(built, 4L)
 
-      session$elapse(5000)
       session$flushReact()
 
       expect_identical(probe_construct$ids, built)
@@ -675,12 +682,12 @@ test_that("an infinite background delay never arms the scheduler", {
 
   reset_probes()
 
-  scheduled <- new.env()
-  scheduled$millis <- numeric()
+  armed <- new.env(parent = emptyenv())
+  armed$called <- FALSE
 
   local_mocked_bindings(
-    invalidateLater = function(millis, ...) {
-      scheduled$millis <- c(scheduled$millis, millis)
+    schedule_construction = function(pace, session) {
+      armed$called <- TRUE
       invisible()
     }
   )
@@ -692,7 +699,7 @@ test_that("an infinite background delay never arms the scheduler", {
     {
       session$flushReact()
 
-      expect_false(any(is.infinite(scheduled$millis)))
+      expect_false(armed$called)
     },
     args = list(x = ordered_board(), plugins = list(), callbacks = visible_b)
   )
@@ -795,11 +802,11 @@ test_that("the background waits for the front-end's rendered report", {
 
   reset_probes()
 
+  local_mocked_bindings(schedule_construction = drive_construction)
+
   testServer(
     get_s3_method("board_server", ordered_board()),
     {
-      session$flushReact()
-      session$elapse(5000)
       session$flushReact()
 
       expect_true(constructed("a"))
@@ -809,8 +816,6 @@ test_that("the background waits for the front-end's rendered report", {
       expect_false(constructed("d"))
 
       render_blocks(vis, "b")
-      session$flushReact()
-      session$elapse(5000)
       session$flushReact()
 
       expect_true(constructed("c"))


### PR DESCRIPTION
## Summary

- Background construction starved user input: each staggered tick armed an in-flush `invalidateLater(delay)`, but that window was consumed by the just-built block's ~0.4–1.6s reactive flush, so the next tick fired with no idle gap and the event loop never serviced pending input until the whole backlog drained.
- Fix, as diagnosed in the issue: re-arm the ticker only after the block's flush drains — `onFlushed()` schedules a `later::later()` continuation that advances the pacing channel — so the delay is a genuine idle window. Bounds input latency to ~one tick instead of the whole backlog, independent of per-block cost. Layers on the #275 priority lane (needed-first, then backlog).
- Verified with a `later::later` heartbeat over a real `board_server` with slow blocks (same code both runs): across a ~6s / 7-block construction it fired **1×** before (max gap 6.4s — fully monopolized) vs **12×** after (max gap 1.1s ≈ one block's flush); a concurrent input is serviced immediately rather than behind the backlog.

Fixes #276
