### PR TITLE
Accept a partial block snapshot when serializing blocks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,12 @@
   export ("Show code") then marks every block required, so the exported
   script covers the whole board; an off-screen block that is not fully
   configured holds the export back instead of emitting broken code (#269).
+* `blockr_ser()` accepts a partial block-state snapshot: a board block omitted
+  from `blocks` (or mapped to `NULL`) serializes from its constructor scope
+  instead of aborting with `length(blocks) == length(x)`. Saving a board under
+  deferred construction, where off-screen blocks are never built and carry no
+  live state, no longer fails -- unbuilt blocks round-trip from their
+  constructors rather than being dropped (#279).
 * With a finite `background_construction_delay`, the staggered builder now
   prioritizes the on-screen view: each tick builds the next block needed by the
   visible set before the rest of the backlog, so switching view re-prioritizes

--- a/R/utils-serdes.R
+++ b/R/utils-serdes.R
@@ -61,8 +61,12 @@ blockr_ser.block <- function(x, state = NULL, ...) {
   )
 }
 
-#' @param blocks Block states (`NULL`, or a per-block `NULL` entry, defaults to
-#' values from the constructor scope)
+#' @param blocks Block states keyed by block ID. A block that is `NULL`, or
+#' omitted from `blocks` altogether, defaults to values from its constructor
+#' scope. A partial snapshot is therefore valid: under deferred construction
+#' off-screen blocks are never built and carry no live state, so `blocks` may
+#' cover only the built subset -- the rest serialize from their constructors
+#' rather than aborting the save.
 #' @rdname blockr_ser
 #' @export
 blockr_ser.blocks <- function(x, blocks = NULL, ...) {
@@ -76,7 +80,7 @@ blockr_ser.blocks <- function(x, blocks = NULL, ...) {
     stopifnot(
       is.list(blocks),
       all(lgl_ply(blocks, function(b) is.null(b) || is.list(b))),
-      length(blocks) == length(x), setequal(names(blocks), names(x))
+      !is.null(names(blocks)), all(names(blocks) %in% names(x))
     )
 
     res <- Map(blockr_ser, x, blocks[names(x)])

--- a/man/blockr_ser.Rd
+++ b/man/blockr_ser.Rd
@@ -82,8 +82,12 @@ blockr_deser(x, ...)
 
 \item{state}{Object state (as returned from an \code{expr_server})}
 
-\item{blocks}{Block states (\code{NULL}, or a per-block \code{NULL} entry, defaults to
-values from the constructor scope)}
+\item{blocks}{Block states keyed by block ID. A block that is \code{NULL}, or
+omitted from \code{blocks} altogether, defaults to values from its constructor
+scope. A partial snapshot is therefore valid: under deferred construction
+off-screen blocks are never built and carry no live state, so \code{blocks} may
+cover only the built subset -- the rest serialize from their constructors
+rather than aborting the save.}
 
 \item{options}{Board option values (\code{NULL} uses values provided by \code{x})}
 

--- a/tests/testthat/test-utils-serdes.R
+++ b/tests/testthat/test-utils-serdes.R
@@ -143,6 +143,40 @@ test_that("serialization", {
   )
 })
 
+test_that("a partial block-state snapshot serializes from constructor scope", {
+
+  blks <- blocks(
+    a = new_dataset_block("iris", "datasets"),
+    b = new_dataset_block("mtcars", "datasets")
+  )
+
+  full <- blockr_ser(
+    blks,
+    list(
+      a = list(dataset = "iris", package = "datasets"),
+      b = list(dataset = "mtcars", package = "datasets")
+    )
+  )
+
+  partial <- blockr_ser(
+    blks,
+    list(a = list(dataset = "iris", package = "datasets"))
+  )
+
+  expect_identical(partial, full)
+
+  expect_identical(
+    blks,
+    blockr_deser(partial),
+    ignore_function_env = TRUE
+  )
+
+  expect_error(
+    blockr_ser(blks, list(a = list(dataset = "iris"), z = list())),
+    "names\\(blocks\\)"
+  )
+})
+
 test_that("blockr_deser.list forwards `...` to per-class methods", {
 
   captured <- NULL


### PR DESCRIPTION
## Summary

- Under deferred construction (`background_construction_delay = Inf`), off-screen blocks are never built, so the block-state snapshot handed to `blockr_ser` covers only the built subset. `blockr_ser.blocks` asserted one entry per board block, so "Save as new workflow" / copy aborted with `length(blocks) == length(x) is not TRUE`.
- Relax that assertion to accept a partial snapshot: a block omitted from `blocks` (or mapped to `NULL`) serializes from its constructor scope via `initial_block_state()` — the same fallback a per-block `NULL` already used. Unbuilt blocks round-trip byte-identically instead of being dropped, and the board is never materialized in order to save it.
- The fix lives in the low-level serializer rather than being padded into each `serialize_board.*` method, so it holds for every downstream serializer at once. `serialize_board.dock_board` therefore needs no change of its own — the dock-side pad on `blockr.dock@301-lazy-view-fixes` (`0850c9f`) becomes redundant and can be dropped. (Issue transferred here from blockr.dock.)
- Serialization only needs constructor arguments, unlike code export ("Show code"), which force-builds every block to read its live `expr`. So save takes the no-materialize path instead of the code-gen mechanism.

Fixes #279