### PR TITLE
Stop panel/view switches re-evaluating the whole shared upstream

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,12 @@
   no longer aborts the reactive with "Failed to evaluate glue component". This
   extends the `notify()` toast path's `use_glue = FALSE` treatment to the
   `capture_conditions()` handlers and the `replay()` methods (#268).
+* Switching the active panel or view no longer re-evaluates blocks whose needed
+  status is unchanged. Each block gates its data inputs and eval status on its
+  own per-block `needed` slot rather than the whole needed set, and skips
+  re-evaluation when its interpolated expression and input data are unchanged,
+  so switching panel or view re-evaluates only the newly-visible block, not the
+  entire shared upstream pipeline (#271).
 
 # blockr.core 0.1.3
 

--- a/R/block-eval.R
+++ b/R/block-eval.R
@@ -53,6 +53,21 @@ pkg_export_env <- function(pkg, parent) {
   e
 }
 
+#' @section Evaluation trigger:
+#' `block_eval_trigger()` lets a block declare reactive state its evaluation
+#' depends on that is not visible in the block expression or its data inputs
+#' -- the `plot_block` method returns the `thematic` and `dark_mode` board
+#' options, so a theme change re-renders the plot. Its value joins the block's
+#' unchanged-inputs check: the block re-evaluates when its interpolated
+#' expression, its input data, *or* the value returned here changes. Reading a
+#' reactive inside the method registers the dependency that wakes the block,
+#' but it is the returned value *changing* -- not the method being re-run --
+#' that forces re-evaluation: returning a value equal to the previous one skips
+#' it, even if the reactives it read invalidated. To force re-evaluation on an
+#' event with no natural value, return a value that changes on it, such as an
+#' incrementing counter. The default method returns `NULL`, declaring no such
+#' dependency.
+#'
 #' @param session Shiny session object
 #' @rdname block_server
 #' @export

--- a/R/block-server.R
+++ b/R/block-server.R
@@ -288,6 +288,9 @@ block_server.block <- function(id, x, data = list(), block_id = id,
 
       gate <- cb_res
 
+      # Last successful evaluation, for the unchanged-inputs skip below.
+      last_eval <- new.env(parent = emptyenv())
+
       res <- reactive(
         {
           if (!isTRUE(reval_if(gate)) || !isTRUE(data_valid()) ||
@@ -296,17 +299,43 @@ block_server.block <- function(id, x, data = list(), block_id = id,
           }
 
           eval_data <- dat_eval()
+          eval_lang <- isolate(lang())
+
+          # Re-evaluate only when the interpolated expression or the input
+          # data actually changed. Spurious invalidations reach this reactive
+          # through board-wide transitions with the inputs untouched -- e.g. a
+          # view switch whose visibility updates land across several flushes,
+          # transiently collapsing and re-expanding the needed closure so that
+          # every needed slot (and with it the whole input chain) takes a real
+          # FALSE -> TRUE round trip. Upstream results are cached, so
+          # `eval_data` then holds the very same objects and identical()
+          # short-circuits on pointer equality. Without this guard each such
+          # transition re-ran the block expression, re-evaluating whole shared
+          # pipelines (data adapters included) on every first visit to a view.
+          if (isTRUE(last_eval$has) &&
+                identical(eval_lang, last_eval$lang) &&
+                identical(eval_data, last_eval$data)) {
+            log_debug("unchanged inputs for block ", block_id, ", skipping eval")
+            return(last_eval$result)
+          }
 
           log_debug("evaluating block ", block_id)
 
-          isolate(
+          result <- isolate(
             capture_conditions(
-              eval_impl(x, lang(), eval_data),
+              eval_impl(x, eval_lang, eval_data),
               cond,
               "eval",
               session = session
             )
           )
+
+          last_eval$has <- TRUE
+          last_eval$lang <- eval_lang
+          last_eval$data <- eval_data
+          last_eval$result <- result
+
+          result
         },
         domain = session
       )

--- a/R/block-server.R
+++ b/R/block-server.R
@@ -301,6 +301,14 @@ block_server.block <- function(id, x, data = list(), block_id = id,
           eval_data <- dat_eval()
           eval_lang <- isolate(lang())
 
+          # The eval trigger's VALUE joins the skip key below: a block can
+          # request re-evaluation with unchanged (expr, data) by returning a
+          # changed value from block_eval_trigger() -- plot blocks return the
+          # thematic / dark_mode option values so a theme flip re-renders the
+          # plot. The reactive dependency is registered inside dat_eval();
+          # here only the current value is read.
+          eval_trigger <- isolate(block_eval_trigger(x, session))
+
           # Re-evaluate only when the interpolated expression or the input
           # data actually changed. Spurious invalidations reach this reactive
           # through board-wide transitions with the inputs untouched -- e.g. a
@@ -314,7 +322,8 @@ block_server.block <- function(id, x, data = list(), block_id = id,
           # pipelines (data adapters included) on every first visit to a view.
           if (isTRUE(last_eval$has) &&
                 identical(eval_lang, last_eval$lang) &&
-                identical(eval_data, last_eval$data)) {
+                identical(eval_data, last_eval$data) &&
+                identical(eval_trigger, last_eval$trigger)) {
             log_debug("unchanged inputs for block ", block_id, ", skipping eval")
             return(last_eval$result)
           }
@@ -333,6 +342,7 @@ block_server.block <- function(id, x, data = list(), block_id = id,
           last_eval$has <- TRUE
           last_eval$lang <- eval_lang
           last_eval$data <- eval_data
+          last_eval$trigger <- eval_trigger
           last_eval$result <- result
 
           result

--- a/R/block-server.R
+++ b/R/block-server.R
@@ -324,7 +324,7 @@ block_server.block <- function(id, x, data = list(), block_id = id,
                 identical(eval_lang, last_eval$lang) &&
                 identical(eval_data, last_eval$data) &&
                 identical(eval_trigger, last_eval$trigger)) {
-            log_debug("unchanged inputs for block ", block_id, ", skipping eval")
+            log_debug("skipping block ", block_id, " (inputs unchanged)")
             return(last_eval$result)
           }
 

--- a/R/block-server.R
+++ b/R/block-server.R
@@ -309,20 +309,20 @@ block_server.block <- function(id, x, data = list(), block_id = id,
           # here only the current value is read.
           eval_trigger <- isolate(block_eval_trigger(x, session))
 
-          # Re-evaluate only when the interpolated expression or the input
-          # data actually changed. Spurious invalidations reach this reactive
-          # through board-wide transitions with the inputs untouched -- e.g. a
-          # view switch whose visibility updates land across several flushes,
-          # transiently collapsing and re-expanding the needed closure so that
-          # every needed slot (and with it the whole input chain) takes a real
-          # FALSE -> TRUE round trip. Upstream results are cached, so
-          # `eval_data` then holds the very same objects and identical()
-          # short-circuits on pointer equality. Without this guard each such
-          # transition re-ran the block expression, re-evaluating whole shared
-          # pipelines (data adapters included) on every first visit to a view.
+          # Re-evaluate only when the expression, input data or eval trigger
+          # changed. Board-wide transitions invalidate this reactive with the
+          # inputs untouched -- e.g. a view switch lands its visibility across
+          # several flushes, so every needed slot takes a spurious FALSE -> TRUE
+          # round trip and the input chain re-pulls the same cached objects.
+          # Expression and data are compared by object identity: an unchanged
+          # reactive hands back its cached object, so this is O(1) whatever the
+          # size and side-steps identical()'s environment-sensitive walk of
+          # language objects. The trade is that a recomputed-but-equal, freshly
+          # allocated input re-evaluates rather than skipping. The eval trigger
+          # stays value-compared -- it is rebuilt on each read (see below).
           if (isTRUE(last_eval$has) &&
-                identical(eval_lang, last_eval$lang) &&
-                identical(eval_data, last_eval$data) &&
+                same_ref(eval_lang, last_eval$lang) &&
+                same_refs(eval_data, last_eval$data) &&
                 identical(eval_trigger, last_eval$trigger)) {
             log_debug("skipping block ", block_id, " (inputs unchanged)")
             return(last_eval$result)
@@ -340,6 +340,8 @@ block_server.block <- function(id, x, data = list(), block_id = id,
           )
 
           last_eval$has <- TRUE
+          # Keep the objects themselves (not just addresses) so they stay alive
+          # and their addresses cannot be reused by a later allocation.
           last_eval$lang <- eval_lang
           last_eval$data <- eval_data
           last_eval$trigger <- eval_trigger
@@ -509,6 +511,15 @@ state_ready_reactive <- function(id, x, state, sess) {
     },
     domain = sess
   )
+}
+
+same_ref <- function(x, y) {
+  identical(rlang::obj_address(x), rlang::obj_address(y))
+}
+
+same_refs <- function(x, y) {
+  identical(names(x), names(y)) &&
+    identical(chr_ply(x, rlang::obj_address), chr_ply(y, rlang::obj_address))
 }
 
 eval_impl <- function(x, expr, dat) {

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -489,7 +489,17 @@ construct_block <- function(id, rv, mod_ed, mod_ct, args, vis) {
 
   rv$blocks[[id]] <- list(block = blk, server = srv)
 
-  rv$eval[[id]] <- reactive(block_eval_status(rv, id, inputs_ready, srv))
+  # Install the eval-status reactive WITHOUT the complex assignment
+  # `rv$eval[[id]] <- ...`: that form desugars to a rebind of the `eval` key on
+  # `rv`, which invalidates EVERY reactive that read `rv$eval` -- i.e. every
+  # built block's inputs_ready (via input_ready()) -- so constructing one new
+  # block re-fired inputs_ready -> data_valid -> dat_eval -> res for the whole
+  # already-computed board and re-evaluated the shared upstream pipeline on
+  # every first visit to a view. Mutating the reactiveValues through a local
+  # binding keeps per-key granularity: only readers of THIS block's slot (its
+  # direct downstreams, waking up on the upstream's construction) are notified.
+  ev <- isolate(rv$eval)
+  ev[[id]] <- reactive(block_eval_status(rv, id, inputs_ready, srv))
 
   invisible()
 }
@@ -783,7 +793,13 @@ block_inputs_ready <- function(src_rv, blk, rv) {
 }
 
 input_ready <- function(from, rv) {
-  not_null(from) && identical(reval_if(rv$eval[[from]]), "ready")
+  # Fetch the container under isolate() so the caller does not depend on the
+  # `eval` key of `rv` (rebound on every block construction before the local-
+  # binding install in construct_block, and still guarded against here). The
+  # `[[from]]` read happens OUTSIDE the isolate, so the per-key dependency
+  # remains: a downstream still wakes when its upstream's status reactive is
+  # installed at construction, and still tracks that status thereafter.
+  not_null(from) && identical(reval_if(isolate(rv$eval)[[from]]), "ready")
 }
 
 block_eval_status <- function(rv, id, inputs_ready, srv) {
@@ -817,22 +833,30 @@ block_needed <- function(rv, id) {
 # thereafter that observer keeps it value-guarded. Reading THIS slot -- not
 # rv$needed() -- is what confines a needed-set change to the blocks whose
 # membership flipped, so a shared upstream block does not re-evaluate on a view
-# switch that only swaps leaves. The isolate() keeps lazy creation from taking a
-# dependency on the whole set; the caller depends on the returned slot instead.
+# switch that only swaps leaves.
+#
+# Both helpers fetch the container under isolate() and mutate it through a
+# local binding: `rv$needed_slots[[id]] <- ...` would rebind the `needed_slots`
+# key on `rv`, invalidating every reactive that touched the container (the same
+# whole-container churn this file fixes for `rv$eval` in construct_block).
+# Callers depend on the returned reactiveVal alone, never on the container; the
+# environment mutates by reference so all readers share the slots.
 block_needed_slot <- function(rv, id) {
-  slot <- rv$needed_slots[[id]]
+  slots <- isolate(rv$needed_slots)
+  slot <- slots[[id]]
   if (is.null(slot)) {
     n <- isolate(rv$needed())
     slot <- reactiveVal(isTRUE(n) || id %in% n)
-    rv$needed_slots[[id]] <- slot
+    slots[[id]] <- slot
   }
   slot
 }
 
 set_needed_slot <- function(rv, id, val) {
-  slot <- rv$needed_slots[[id]]
+  slots <- isolate(rv$needed_slots)
+  slot <- slots[[id]]
   if (is.null(slot)) {
-    rv$needed_slots[[id]] <- reactiveVal(val)
+    slots[[id]] <- reactiveVal(val)
   } else if (!identical(isolate(slot()), val)) {
     slot(val)
   }
@@ -882,10 +906,15 @@ destroy_rm_blocks <- function(ids, rv, sess, args) {
   rv$sources <- rv$sources[!names(rv$sources) %in% ids]
   rv$blocks <- rv$blocks[!names(rv$blocks) %in% ids]
 
+  # Local bindings for both containers: `rv$eval[[id]] <- NULL` would rebind
+  # the `eval` key on `rv` (see construct_block) and churn every reader.
+  ev <- isolate(rv$eval)
+  slots <- isolate(rv$needed_slots)
+
   for (id in ids) {
-    rv$eval[[id]] <- NULL
-    if (!is.null(rv$needed_slots[[id]])) {
-      rm(list = id, envir = rv$needed_slots)
+    ev[[id]] <- NULL
+    if (!is.null(slots[[id]])) {
+      rm(list = id, envir = slots)
     }
   }
 

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -105,6 +105,17 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
 
       rv$needed <- reactiveVal(TRUE)
 
+      # Per-block `needed` slots: an env of reactiveVals, one per block, kept in
+      # step with the whole-set rv$needed() below. A block's data-input and
+      # eval-status reactives read ONLY their own slot (see block_needed()), not
+      # the whole set, so a view switch that flips which LEAF blocks are needed
+      # does not invalidate a shared upstream block whose needed status is
+      # unchanged. Reading rv$needed() directly took a dependency on the entire
+      # set, so any switch re-fired every block's inputs and re-evaluated the
+      # whole shared pipeline (and everything downstream) even though no data
+      # changed.
+      rv$needed_slots <- new.env(parent = emptyenv())
+
       observe(
         {
           cur <- if (!gating_active(vis$required)) {
@@ -123,6 +134,12 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
 
           if (!same) {
             rv$needed(cur)
+          }
+
+          # Fan the set out to per-block slots, value-guarded so only blocks
+          # whose membership actually flipped invalidate their readers.
+          for (id in board_block_ids(rv$board)) {
+            set_needed_slot(rv, id, isTRUE(cur) || id %in% cur)
           }
         }
       )
@@ -791,8 +808,35 @@ block_eval_status <- function(rv, id, inputs_ready, srv) {
 }
 
 block_needed <- function(rv, id) {
-  needed <- rv$needed()
-  isTRUE(needed) || id %in% needed
+  isTRUE(block_needed_slot(rv, id)())
+}
+
+# The per-block `needed` reactiveVal for `id`. Created on first read from the
+# current whole-set value if the maintaining observer in board_server() has not
+# populated it yet (a block read in the same flush it is constructed);
+# thereafter that observer keeps it value-guarded. Reading THIS slot -- not
+# rv$needed() -- is what confines a needed-set change to the blocks whose
+# membership flipped, so a shared upstream block does not re-evaluate on a view
+# switch that only swaps leaves. The isolate() keeps lazy creation from taking a
+# dependency on the whole set; the caller depends on the returned slot instead.
+block_needed_slot <- function(rv, id) {
+  slot <- rv$needed_slots[[id]]
+  if (is.null(slot)) {
+    n <- isolate(rv$needed())
+    slot <- reactiveVal(isTRUE(n) || id %in% n)
+    rv$needed_slots[[id]] <- slot
+  }
+  slot
+}
+
+set_needed_slot <- function(rv, id, val) {
+  slot <- rv$needed_slots[[id]]
+  if (is.null(slot)) {
+    rv$needed_slots[[id]] <- reactiveVal(val)
+  } else if (!identical(isolate(slot()), val)) {
+    slot(val)
+  }
+  invisible()
 }
 
 apply_block_mod_delta <- function(blk_id, delta, rv) {
@@ -840,6 +884,9 @@ destroy_rm_blocks <- function(ids, rv, sess, args) {
 
   for (id in ids) {
     rv$eval[[id]] <- NULL
+    if (!is.null(rv$needed_slots[[id]])) {
+      rm(list = id, envir = rv$needed_slots)
+    }
   }
 
   rv$board <- do.call(
@@ -856,8 +903,10 @@ upstream_result <- function(key, src_rv, rv, to) {
 
   reactive(
     {
-      needed <- rv$needed()
-      req(isTRUE(needed) || to %in% needed)
+      # Gate on THIS block's per-block needed slot, not the whole rv$needed()
+      # set, so a view switch that flips other blocks does not invalidate this
+      # input reactive and force a re-evaluation of unchanged upstream data.
+      req(block_needed(rv, to))
 
       from <- src_rv[[key]]
 

--- a/man/block_server.Rd
+++ b/man/block_server.Rd
@@ -179,3 +179,20 @@ write while frozen -- so not even the programmatic control channel can drive
 a frozen block. Upstream data still flows through, and unfreezing resumes
 normal input handling.
 }
+\section{Evaluation trigger}{
+
+\code{block_eval_trigger()} lets a block declare reactive state its evaluation
+depends on that is not visible in the block expression or its data inputs
+-- the \code{plot_block} method returns the \code{thematic} and \code{dark_mode} board
+options, so a theme change re-renders the plot. Its value joins the block's
+unchanged-inputs check: the block re-evaluates when its interpolated
+expression, its input data, \emph{or} the value returned here changes. Reading a
+reactive inside the method registers the dependency that wakes the block,
+but it is the returned value \emph{changing} -- not the method being re-run --
+that forces re-evaluation: returning a value equal to the previous one skips
+it, even if the reactives it read invalidated. To force re-evaluation on an
+event with no natural value, return a value that changes on it, such as an
+incrementing counter. The default method returns \code{NULL}, declaring no such
+dependency.
+}
+

--- a/tests/testthat/test-visibility-gating.R
+++ b/tests/testthat/test-visibility-gating.R
@@ -57,7 +57,7 @@ probe_source <- function() {
 
 # Same probe source, different dataset (zero-arg on purpose: constructor
 # arguments double as block state). For tests where a re-routed input must
-# actually differ in value -- an input identical in value to the previous one
+# resolve to a different object -- an input that is the same object as before
 # is skipped by the unchanged-inputs guard in block_server().
 probe_source_alt <- function() {
   new_data_block(
@@ -322,8 +322,8 @@ test_that("a link change re-routes the pulled upstream", {
     blocks = c(
       a = with_id(probe_source(), "a"),
       # A different dataset than a's: the re-routed input must actually change
-      # for b to re-evaluate -- an input identical in value to the previous one
-      # is skipped (see the unchanged-inputs test below).
+      # for b to re-evaluate -- an input that is the same object as before is
+      # skipped (see the unchanged-inputs test below).
       c = with_id(probe_source_alt(), "c"),
       b = with_id(probe_passthrough(), "b")
     ),
@@ -465,6 +465,57 @@ test_that("a view switch does not re-evaluate shared upstream left needed", {
       callbacks = function(visibility, ...) {
         require_blocks(visibility, "t1")
         render_blocks(visibility, "t1")
+      }
+    )
+  )
+})
+
+test_that("a variadic block skips re-evaluation on unchanged inputs", {
+
+  reset_probes()
+
+  withr::local_options(blockr.background_construction_delay = 0)
+
+  board <- new_board(
+    blocks = c(
+      a = with_id(probe_source(), "a"),
+      b = with_id(probe_source_alt(), "b"),
+      v = with_id(probe_variadic(), "v")
+    ),
+    links = links(new_link("a", "v", "1"), new_link("b", "v", "2"))
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      expect_true(evaluated("a"))
+      expect_true(evaluated("b"))
+      expect_true(evaluated("v"))
+
+      reset_probes()
+
+      # A variadic block's `...args` are repackaged into a fresh list on every
+      # pull, but the element objects are the cached upstream results. Park the
+      # block across separate flushes and bring it back: the by-reference skip
+      # sees the same objects and nothing re-evaluates.
+      vis$required[["v"]](FALSE)
+      session$flushReact()
+
+      vis$required[["v"]](TRUE)
+      session$flushReact()
+
+      expect_false(evaluated("a"))
+      expect_false(evaluated("b"))
+      expect_false(evaluated("v"))
+    },
+    args = list(
+      x = board,
+      plugins = list(),
+      callbacks = function(visibility, ...) {
+        require_blocks(visibility, "v")
+        render_blocks(visibility, "v")
       }
     )
   )

--- a/tests/testthat/test-visibility-gating.R
+++ b/tests/testthat/test-visibility-gating.R
@@ -55,6 +55,26 @@ probe_source <- function() {
   )
 }
 
+# Same probe source, different dataset (zero-arg on purpose: constructor
+# arguments double as block state). For tests where a re-routed input must
+# actually differ in value -- an input identical in value to the previous one
+# is skipped by the unchanged-inputs guard in block_server().
+probe_source_alt <- function() {
+  new_data_block(
+    function(id) {
+      moduleServer(
+        id,
+        function(input, output, session) {
+          list(expr = reactive(quote(datasets::ChickWeight)), state = list())
+        }
+      )
+    },
+    function(id) shiny::tagList(),
+    class = "probe_block",
+    block_metadata = FALSE
+  )
+}
+
 probe_passthrough <- function() {
   new_transform_block(
     function(id, data) {
@@ -301,7 +321,10 @@ test_that("a link change re-routes the pulled upstream", {
   board <- new_board(
     blocks = c(
       a = with_id(probe_source(), "a"),
-      c = with_id(probe_source(), "c"),
+      # A different dataset than a's: the re-routed input must actually change
+      # for b to re-evaluate -- an input identical in value to the previous one
+      # is skipped (see the unchanged-inputs test below).
+      c = with_id(probe_source_alt(), "c"),
       b = with_id(probe_passthrough(), "b")
     ),
     links = links(ab = new_link("a", "b", "data"))
@@ -333,6 +356,58 @@ test_that("a link change re-routes the pulled upstream", {
       x = board,
       plugins = list(),
       callbacks = function(visibility, ...) {
+        require_blocks(visibility, "b")
+        render_blocks(visibility, "b")
+      }
+    )
+  )
+})
+
+test_that("a needed round trip with unchanged inputs does not re-evaluate", {
+
+  reset_probes()
+
+  withr::local_options(blockr.background_construction_delay = 0)
+
+  vis_env <- NULL
+
+  board <- new_board(
+    blocks = c(
+      a = with_id(probe_source(), "a"),
+      b = with_id(probe_passthrough(), "b")
+    ),
+    links = links(ab = new_link("a", "b", "data"))
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      expect_true(evaluated("a"))
+      expect_true(evaluated("b"))
+
+      reset_probes()
+
+      # Park the chain, as a view switch whose visibility updates land across
+      # several flushes does: b goes un-needed, taking a with it ...
+      vis_env$required[["b"]](FALSE)
+      session$flushReact()
+
+      # ... and comes back. Nothing upstream changed, so nothing re-evaluates:
+      # the unchanged-inputs guard returns the cached results instead of
+      # re-running the block expressions.
+      vis_env$required[["b"]](TRUE)
+      session$flushReact()
+
+      expect_false(evaluated("a"))
+      expect_false(evaluated("b"))
+    },
+    args = list(
+      x = board,
+      plugins = list(),
+      callbacks = function(visibility, ...) {
+        vis_env <<- visibility
         require_blocks(visibility, "b")
         render_blocks(visibility, "b")
       }

--- a/tests/testthat/test-visibility-gating.R
+++ b/tests/testthat/test-visibility-gating.R
@@ -415,6 +415,61 @@ test_that("a needed round trip with unchanged inputs does not re-evaluate", {
   )
 })
 
+test_that("a view switch does not re-evaluate shared upstream left needed", {
+
+  reset_probes()
+
+  withr::local_options(blockr.background_construction_delay = 0)
+
+  board <- new_board(
+    blocks = c(
+      src = with_id(probe_source(), "src"),
+      mid = with_id(probe_passthrough(), "mid"),
+      t1 = with_id(probe_passthrough(), "t1"),
+      t2 = with_id(probe_passthrough(), "t2")
+    ),
+    links = links(
+      new_link("src", "mid", "data"),
+      new_link("mid", "t1", "data"),
+      new_link("mid", "t2", "data")
+    )
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      expect_true(evaluated("src"))
+      expect_true(evaluated("mid"))
+      expect_true(evaluated("t1"))
+
+      reset_probes()
+
+      # Switch to the sibling view: t1 leaves the needed set and t2 enters, but
+      # the shared upstream (src, mid) stays needed throughout. Only the newly
+      # visible leaf evaluates -- the upstream slots never flip, so nothing
+      # pulls the shared pipeline again.
+      vis$required[["t1"]](FALSE)
+      vis$required[["t2"]](TRUE)
+      render_blocks(vis, "t2")
+      session$flushReact()
+
+      expect_true(evaluated("t2"))
+      expect_false(evaluated("src"))
+      expect_false(evaluated("mid"))
+    },
+    args = list(
+      x = board,
+      plugins = list(),
+      callbacks = function(visibility, ...) {
+        require_blocks(visibility, "t1")
+        render_blocks(visibility, "t1")
+      }
+    )
+  )
+})
+
 test_that("an off-screen data-observing block does not pull its upstream", {
 
   reset_probes()


### PR DESCRIPTION
## Summary

- Fixes the panel/view-switch whole-upstream re-evaluation: `upstream_result()` / `block_eval_status()` now gate on per-block, value-guarded `needed` slots instead of the whole `rv$needed()` set, with an eval-site `identical()` backstop for multi-flush transitions. Minimal repro 6 → 1 (7 → 1 on the real CEDX board).
- **@christophsax's** work from `fix/per-block-needed-gate`, rebased onto current `main` and finalized (regression test, NEWS, one line-length tidy); his three commits keep their authorship. His branch can be deleted once this lands.
- Rebased over two changes that landed in these same files since he branched — #278 (post-flush background scheduler) and #232 (per-block `frozen` channel). They compose cleanly: a frozen block pins `lang`, so the eval-site skip fires and it does not re-evaluate on unchanged inputs while upstream data still flows through; #232's freeze tests pass alongside this change.
- **Semantics change:** value-identical results are no longer recomputed. `block_eval_trigger()` is the sanctioned escape hatch — it joins the skip key, so plot blocks still re-render on a theme flip.
- Adds a regression test for the issue's primary scenario — a shared upstream left needed while leaves swap on a view switch must re-evaluate only the newly-visible leaf; it fails on the pre-fix code.

Fixes #271