### PR TITLE
Do not glue-interpolate captured condition messages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,12 @@
   Each tick's pacing delay now begins once the just-built block has flushed
   rather than while its reactive graph is still flushing, so pending user input
   is serviced within one tick instead of behind the entire backlog (#276).
+* Captured block conditions are no longer glue-interpolated when logged, so a
+  block whose warning or error text contains braces -- e.g. the `{summary_fun}`
+  / `{data}` placeholders in `tidyr::pivot_wider()`'s duplicate-value warning --
+  no longer aborts the reactive with "Failed to evaluate glue component". This
+  extends the `notify()` toast path's `use_glue = FALSE` treatment to the
+  `capture_conditions()` handlers and the `replay()` methods (#268).
 
 # blockr.core 0.1.3
 

--- a/R/utils-cnd.R
+++ b/R/utils-cnd.R
@@ -141,17 +141,17 @@ show_condition.error <- function(x) {
 #' @importFrom evaluate replay
 #' @export
 replay.message <- function(x) {
-  log_info(fmt_cnd_msg(x))
+  log_info(fmt_cnd_msg(x), use_glue = FALSE)
 }
 
 #' @export
 replay.warning <- function(x) {
-  log_warn(fmt_cnd_msg(x))
+  log_warn(fmt_cnd_msg(x), use_glue = FALSE)
 }
 
 #' @export
 replay.error <- function(x) {
-  log_error(fmt_cnd_msg(x))
+  log_error(fmt_cnd_msg(x), use_glue = FALSE)
 }
 
 msg_handler <- function(cond, conds) {
@@ -160,7 +160,7 @@ msg_handler <- function(cond, conds) {
     if ("message" %in% conds) {
       cond$message <- c(cond$message, list(as_blk_cnd(m)))
     }
-    log_info(fmt_cnd_msg(m))
+    log_info(fmt_cnd_msg(m), use_glue = FALSE)
     tryInvokeRestart("muffleMessage")
   }
 }
@@ -171,7 +171,7 @@ warn_handler <- function(cond, conds) {
     if ("warning" %in% conds) {
       cond$warning <- c(cond$warning, list(as_blk_cnd(w)))
     }
-    log_warn(fmt_cnd_msg(w))
+    log_warn(fmt_cnd_msg(w), use_glue = FALSE)
     tryInvokeRestart("muffleWarning")
   }
 }
@@ -182,7 +182,7 @@ err_handler <- function(cond, conds, err_val = NULL) {
     if ("error" %in% conds) {
       cond$error <- list(as_blk_cnd(e))
     }
-    log_error(fmt_cnd_msg(e))
+    log_error(fmt_cnd_msg(e), use_glue = FALSE)
     err_val
   }
 }

--- a/tests/testthat/test-utils-cnd.R
+++ b/tests/testthat/test-utils-cnd.R
@@ -78,6 +78,43 @@ test_that("conditions", {
   expect_identical(cnd, as_blk_cnd(cnd))
 })
 
+test_that("captured condition messages with braces do not glue-interpolate", {
+
+  # tidyr::pivot_wider() emits duplicate-value warnings whose text contains
+  # literal `{summary_fun}`/`{data}` placeholders. Captured condition messages
+  # are already-formatted text and must never be run through glue, or the
+  # missing object aborts the whole reactive.
+  brace_msg <- "Use `values_fn = {summary_fun}` to summarise duplicates."
+
+  with_mock_session(
+    {
+      vals <- reactiveValues(test = NULL)
+
+      expect_no_error(
+        withr::with_options(
+          list(blockr.show_conditions = c("message", "warning", "error")),
+          capture_conditions(
+            {
+              message(brace_msg)
+              warning(brace_msg)
+              stop(brace_msg)
+            },
+            rv = vals,
+            slot = "test",
+            error_val = NULL
+          )
+        )
+      )
+
+      expect_identical(cnd_message(vals$test$warning[[1L]]), brace_msg)
+      expect_identical(cnd_message(vals$test$error[[1L]]), brace_msg)
+    }
+  )
+
+  expect_no_error(replay(simpleWarning(brace_msg)))
+  expect_no_error(replay(simpleError(brace_msg)))
+})
+
 test_that("blk_cnd data api", {
 
   cnd <- new_blk_cnd("xyz")


### PR DESCRIPTION
## Summary

- A block whose captured warning or error text contains brace characters aborted the whole reactive with `Failed to evaluate glue component {summary_fun}`. The common trigger is a Pivot Wider block: `tidyr::pivot_wider()`'s duplicate-value warning embeds literal `{summary_fun}` / `{data}` placeholders, and the already-formatted captured text was being fed back through glue.
- `#223` de-glued the `notify()` toast path but left the six sites in `R/utils-cnd.R` that log captured condition text with glue still on — the `capture_conditions()` handlers (`msg_handler` / `warn_handler` / `err_handler`) and the `replay.message` / `replay.warning` / `replay.error` methods. This passes `use_glue = FALSE` at those six sites so captured text is logged verbatim.
- Adds a regression test in `test-utils-cnd.R` covering both the capture and replay paths (it fails on the unfixed code and passes after).

Adopts the fix from the existing `fix/glue-injection-captured-conditions` branch (authorship preserved), rebased onto current `main` with the NEWS entry moved into the unreleased `0.1.4` section.

Fixes #268
