### PR TITLE
Drop un-deserializable blocks instead of aborting board load

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,16 @@
   re-evaluation when its interpolated expression and input data are unchanged,
   so switching panel or view re-evaluates only the newly-visible block, not the
   entire shared upstream pipeline (#271).
+* Board deserialization can degrade gracefully instead of aborting the whole
+  load when a block cannot be restored -- its constructor or the providing
+  package is unavailable, its payload cannot be reconstructed, or the
+  round-trip class check fails. `blockr_deser()` for `blocks` gains an
+  `on_error` argument (`"abort"` or `"drop"`), defaulting to
+  `blockr_option("deser_on_error", "abort")` so a deployment can opt into
+  dropping offending blocks (with a warning) via
+  `options(blockr.deser_on_error = "drop")` or the `BLOCKR_DESER_ON_ERROR`
+  environment variable. Links and stacks referencing a dropped block are
+  pruned so the surrounding board still loads (#264).
 
 # blockr.core 0.1.3
 

--- a/R/board-class.R
+++ b/R/board-class.R
@@ -319,7 +319,7 @@ rm_blocks.board <- function(x, rm, ..., session = get_session()) {
 
     # nolint start: object_usage_linter.
     blk <- intersect(rm, c(links$from, links$to))
-    lnk <- names(links[links$from %in% rm | links$to %in% rm])
+    lnk <- names(links[links_incident(links, rm)])
     # nolint end
 
     blockr_abort(

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -894,7 +894,7 @@ destroy_rm_blocks <- function(ids, rv, sess, args) {
 
   update_block_links(
     rv,
-    rm = links[links$from %in% ids | links$to %in% ids]
+    rm = links[links_incident(links, ids)]
   )
 
   for (id in ids) {
@@ -1659,7 +1659,7 @@ augment_board_update.board <- function(upd, board, ...,
     links <- board_links(board)
 
     mis_lnk <- setdiff(
-      names(links[links$from %in% rm | links$to %in% rm]),
+      names(links[links_incident(links, rm)]),
       upd$links$rm
     )
 

--- a/R/links-class.R
+++ b/R/links-class.R
@@ -299,6 +299,10 @@ links_assign <- function(...) {
   validate_links(vec_assign(...))
 }
 
+links_incident <- function(x, ids) {
+  x$from %in% ids | x$to %in% ids
+}
+
 #' @rdname new_link
 #' @export
 validate_links <- function(x) {

--- a/R/utils-serdes.R
+++ b/R/utils-serdes.R
@@ -254,9 +254,21 @@ blockr_ser.stacks <- function(x, ...) {
   )
 }
 
+#' @param on_error How to handle a block that cannot be deserialized -- its
+#' constructor (or the package providing it) is unavailable, its payload cannot
+#' be reconstructed, or the round-trip class check fails. `"abort"` (the
+#' default) propagates the error, while `"drop"` omits the offending block
+#' (emitting a warning) and continues; board deserialization then prunes any
+#' links and stacks that reference a dropped block, so a board referencing a
+#' since-retired or no-longer-installed block type still loads. Board
+#' deserialization resolves `on_error` once and threads it to the contained
+#' blocks. The default is sourced from `blockr_option("deser_on_error",
+#' "abort")`, letting a deployment opt into dropping via
+#' `options(blockr.deser_on_error = "drop")` or the `BLOCKR_DESER_ON_ERROR`
+#' environment variable.
 #' @rdname blockr_ser
 #' @export
-blockr_deser <- function(x, ...) {
+blockr_deser <- function(x, ..., on_error = NULL) {
   UseMethod("blockr_deser")
 }
 
@@ -307,21 +319,9 @@ blockr_deser.block <- function(x, data, ...) {
   do.call(ctor_fun(ctor), args)
 }
 
-#' @param on_error How to handle a block that cannot be deserialized -- its
-#' constructor (or the package providing it) is unavailable, its payload cannot
-#' be reconstructed, or the round-trip class check fails. `"abort"` (the
-#' default) propagates the error, while `"drop"` omits the offending block
-#' (emitting a warning) and continues; board deserialization then prunes any
-#' links and stacks that reference a dropped block, so a board referencing a
-#' since-retired or no-longer-installed block type still loads. Board
-#' deserialization resolves `on_error` once and threads it to the contained
-#' blocks. The default is sourced from `blockr_option("deser_on_error",
-#' "abort")`, letting a deployment opt into dropping via
-#' `options(blockr.deser_on_error = "drop")` or the `BLOCKR_DESER_ON_ERROR`
-#' environment variable.
 #' @rdname blockr_ser
 #' @export
-blockr_deser.blocks <- function(x, data, on_error = NULL, ...) {
+blockr_deser.blocks <- function(x, data, ..., on_error = NULL) {
 
   on_error <- resolve_deser_on_error(on_error)
 
@@ -360,7 +360,7 @@ resolve_deser_on_error <- function(on_error) {
 
 #' @rdname blockr_ser
 #' @export
-blockr_deser.board <- function(x, data, on_error = NULL, ...) {
+blockr_deser.board <- function(x, data, ..., on_error = NULL) {
 
   stopifnot(
     all(c("constructor", "payload") %in% names(data))
@@ -370,7 +370,7 @@ blockr_deser.board <- function(x, data, on_error = NULL, ...) {
 
   ctor <- blockr_deser(data[["constructor"]])
 
-  parts <- lapply(data[["payload"]], blockr_deser, on_error = on_error, ...)
+  parts <- lapply(data[["payload"]], blockr_deser, ..., on_error = on_error)
 
   if (identical(on_error, "drop")) {
     parts <- drop_block_refs(parts, data[["payload"]][["blocks"]])
@@ -404,7 +404,7 @@ drop_block_refs <- function(parts, blocks) {
 
   before <- length(lnk) + sum(lengths(stk))
 
-  parts[["links"]] <- lnk[!(lnk$from %in% dropped) & !(lnk$to %in% dropped)]
+  parts[["links"]] <- lnk[!links_incident(lnk, dropped)]
 
   stk <- lapply(stk, rm_stack_members, dropped)
   stk <- stk[lengths(stk) > 0L]

--- a/R/utils-serdes.R
+++ b/R/utils-serdes.R
@@ -307,26 +307,77 @@ blockr_deser.block <- function(x, data, ...) {
   do.call(ctor_fun(ctor), args)
 }
 
+#' @param on_error How to handle a block that cannot be deserialized -- its
+#' constructor (or the package providing it) is unavailable, its payload cannot
+#' be reconstructed, or the round-trip class check fails. `"abort"` (the
+#' default) propagates the error, while `"drop"` omits the offending block
+#' (emitting a warning) and continues; board deserialization then prunes any
+#' links and stacks that reference a dropped block, so a board referencing a
+#' since-retired or no-longer-installed block type still loads. Board
+#' deserialization resolves `on_error` once and threads it to the contained
+#' blocks. The default is sourced from `blockr_option("deser_on_error",
+#' "abort")`, letting a deployment opt into dropping via
+#' `options(blockr.deser_on_error = "drop")` or the `BLOCKR_DESER_ON_ERROR`
+#' environment variable.
 #' @rdname blockr_ser
 #' @export
-blockr_deser.blocks <- function(x, data, ...) {
-  as_blocks(
-    lapply(data[["payload"]], blockr_deser)
+blockr_deser.blocks <- function(x, data, on_error = NULL, ...) {
+
+  on_error <- resolve_deser_on_error(on_error)
+
+  payload <- data[["payload"]]
+
+  if (identical(on_error, "abort")) {
+    return(as_blocks(lapply(payload, blockr_deser)))
+  }
+
+  res <- map(deser_or_drop, payload, names(payload))
+  names(res) <- names(payload)
+
+  as_blocks(res[!lgl_ply(res, is.null)])
+}
+
+deser_or_drop <- function(x, id) {
+  tryCatch(
+    blockr_deser(x),
+    error = function(e) {
+      log_warn(
+        "Dropping block ", id, " during deserialization: ",
+        conditionMessage(e),
+        use_glue = FALSE
+      )
+      NULL
+    }
+  )
+}
+
+resolve_deser_on_error <- function(on_error) {
+  match.arg(
+    coal(on_error, blockr_option("deser_on_error", "abort")),
+    c("drop", "abort")
   )
 }
 
 #' @rdname blockr_ser
 #' @export
-blockr_deser.board <- function(x, data, ...) {
+blockr_deser.board <- function(x, data, on_error = NULL, ...) {
 
   stopifnot(
     all(c("constructor", "payload") %in% names(data))
   )
 
+  on_error <- resolve_deser_on_error(on_error)
+
   ctor <- blockr_deser(data[["constructor"]])
 
+  parts <- lapply(data[["payload"]], blockr_deser, on_error = on_error, ...)
+
+  if (identical(on_error, "drop")) {
+    parts <- drop_block_refs(parts, data[["payload"]][["blocks"]])
+  }
+
   args <- c(
-    lapply(data[["payload"]], blockr_deser),
+    parts,
     list(
       ctor = coal(ctor_name(ctor), ctor_fun(ctor)),
       pkg = ctor_pkg(ctor)
@@ -338,6 +389,37 @@ blockr_deser.board <- function(x, data, ...) {
   attr(res, "id") <- data[["id"]]
 
   res
+}
+
+drop_block_refs <- function(parts, blocks) {
+
+  dropped <- setdiff(names(blocks[["payload"]]), names(parts[["blocks"]]))
+
+  if (!length(dropped)) {
+    return(parts)
+  }
+
+  lnk <- parts[["links"]]
+  stk <- as.list(parts[["stacks"]])
+
+  before <- length(lnk) + sum(lengths(stk))
+
+  parts[["links"]] <- lnk[!(lnk$from %in% dropped) & !(lnk$to %in% dropped)]
+
+  stk <- lapply(stk, rm_stack_members, dropped)
+  stk <- stk[lengths(stk) > 0L]
+  parts[["stacks"]] <- as_stacks(stk)
+
+  if (length(parts[["links"]]) + sum(lengths(stk)) < before) {
+    log_warn("Pruned links and stacks referencing dropped blocks.")
+  }
+
+  parts
+}
+
+rm_stack_members <- function(x, rm) {
+  stack_blocks(x) <- setdiff(stack_blocks(x), rm)
+  x
 }
 
 #' @rdname blockr_ser

--- a/man/blockr_ser.Rd
+++ b/man/blockr_ser.Rd
@@ -51,15 +51,15 @@ blockr_ser(x, ...)
 
 \method{blockr_ser}{stacks}(x, ...)
 
-blockr_deser(x, ...)
+blockr_deser(x, ..., on_error = NULL)
 
 \method{blockr_deser}{list}(x, ...)
 
 \method{blockr_deser}{block}(x, data, ...)
 
-\method{blockr_deser}{blocks}(x, data, on_error = NULL, ...)
+\method{blockr_deser}{blocks}(x, data, ..., on_error = NULL)
 
-\method{blockr_deser}{board}(x, data, on_error = NULL, ...)
+\method{blockr_deser}{board}(x, data, ..., on_error = NULL)
 
 \method{blockr_deser}{link}(x, data, ...)
 
@@ -95,8 +95,6 @@ rather than aborting the save.}
 
 \item{board_id}{Board ID}
 
-\item{data}{List valued data (converted from JSON)}
-
 \item{on_error}{How to handle a block that cannot be deserialized -- its
 constructor (or the package providing it) is unavailable, its payload cannot
 be reconstructed, or the round-trip class check fails. \code{"abort"} (the
@@ -108,6 +106,8 @@ deserialization resolves \code{on_error} once and threads it to the contained
 blocks. The default is sourced from \code{blockr_option("deser_on_error", "abort")}, letting a deployment opt into dropping via
 \code{options(blockr.deser_on_error = "drop")} or the \code{BLOCKR_DESER_ON_ERROR}
 environment variable.}
+
+\item{data}{List valued data (converted from JSON)}
 }
 \value{
 Serialization helper function \code{blockr_ser()} returns lists, which

--- a/man/blockr_ser.Rd
+++ b/man/blockr_ser.Rd
@@ -57,9 +57,9 @@ blockr_deser(x, ...)
 
 \method{blockr_deser}{block}(x, data, ...)
 
-\method{blockr_deser}{blocks}(x, data, ...)
+\method{blockr_deser}{blocks}(x, data, on_error = NULL, ...)
 
-\method{blockr_deser}{board}(x, data, ...)
+\method{blockr_deser}{board}(x, data, on_error = NULL, ...)
 
 \method{blockr_deser}{link}(x, data, ...)
 
@@ -96,6 +96,18 @@ rather than aborting the save.}
 \item{board_id}{Board ID}
 
 \item{data}{List valued data (converted from JSON)}
+
+\item{on_error}{How to handle a block that cannot be deserialized -- its
+constructor (or the package providing it) is unavailable, its payload cannot
+be reconstructed, or the round-trip class check fails. \code{"abort"} (the
+default) propagates the error, while \code{"drop"} omits the offending block
+(emitting a warning) and continues; board deserialization then prunes any
+links and stacks that reference a dropped block, so a board referencing a
+since-retired or no-longer-installed block type still loads. Board
+deserialization resolves \code{on_error} once and threads it to the contained
+blocks. The default is sourced from \code{blockr_option("deser_on_error", "abort")}, letting a deployment opt into dropping via
+\code{options(blockr.deser_on_error = "drop")} or the \code{BLOCKR_DESER_ON_ERROR}
+environment variable.}
 }
 \value{
 Serialization helper function \code{blockr_ser()} returns lists, which

--- a/tests/testthat/test-utils-serdes.R
+++ b/tests/testthat/test-utils-serdes.R
@@ -239,3 +239,148 @@ test_that("a board with variadic links round-trips and still evaluates", {
     args = list(x = restored)
   )
 })
+
+test_that("blocks deser drops offending blocks when on_error is drop", {
+
+  blks <- c(a = new_dataset_block("iris"), b = new_subset_block())
+
+  class_err <- blockr_ser(blks)
+  class_err$payload$b$object <- c("foo_block", class_err$payload$b$object)
+
+  expect_error(
+    blockr_deser(class_err),
+    class = "block_deser_class_error"
+  )
+
+  expect_error(
+    blockr_deser(class_err, on_error = "abort"),
+    class = "block_deser_class_error"
+  )
+
+  kept <- expect_output(
+    blockr_deser(class_err, on_error = "drop"),
+    "Dropping block b"
+  )
+
+  expect_true(is_blocks(kept))
+  expect_identical(names(kept), "a")
+
+  miss_pkg <- blockr_ser(blks)
+  miss_pkg$payload$b$constructor$package <- "some_imaginary_pkg"
+
+  expect_error(
+    blockr_deser(miss_pkg),
+    class = "blockr_deser_missing_pkg"
+  )
+
+  dropped_pkg <- expect_output(
+    blockr_deser(miss_pkg, on_error = "drop"),
+    "Dropping block b"
+  )
+
+  expect_identical(names(dropped_pkg), "a")
+
+  expect_error(blockr_deser(class_err, on_error = "nonsense"))
+})
+
+test_that("board deser prunes links and stacks referencing dropped blocks", {
+
+  board <- new_board(
+    c(
+      a = new_dataset_block("iris"),
+      b = new_subset_block(),
+      c = new_subset_block()
+    ),
+    links = links(from = "a", to = "b"),
+    stacks = list(with_a = new_stack(c("a", "b")), only_c = new_stack("c"))
+  )
+
+  ser <- blockr_ser(board)
+
+  for (id in c("b", "c")) {
+    ser$payload$blocks$payload[[id]]$object <- c(
+      "foo_block", ser$payload$blocks$payload[[id]]$object
+    )
+  }
+
+  expect_error(
+    blockr_deser(ser),
+    class = "block_deser_class_error"
+  )
+
+  res <- expect_output(
+    blockr_deser(ser, on_error = "drop"),
+    "Dropping block b"
+  )
+
+  expect_true(is_board(res))
+  expect_identical(board_block_ids(res), "a")
+  expect_length(board_links(res), 0L)
+
+  # with_a keeps its surviving member; only_c empties out and is removed
+  expect_identical(board_stack_ids(res), "with_a")
+  expect_identical(stack_blocks(board_stacks(res)[["with_a"]]), "a")
+})
+
+test_that("deser_on_error default is sourced from a blockr_option", {
+
+  blks <- c(a = new_dataset_block("iris"), b = new_subset_block())
+  ser <- blockr_ser(blks)
+  ser$payload$b$object <- c("foo_block", ser$payload$b$object)
+
+  withr::with_envvar(
+    c(BLOCKR_DESER_ON_ERROR = NA),
+    withr::with_options(
+      list(blockr.deser_on_error = NULL),
+      expect_error(blockr_deser(ser), class = "block_deser_class_error")
+    )
+  )
+
+  withr::with_options(
+    list(blockr.deser_on_error = "drop"),
+    {
+      opt_res <- expect_output(blockr_deser(ser), "Dropping block b")
+      expect_identical(names(opt_res), "a")
+    }
+  )
+
+  withr::with_envvar(
+    c(BLOCKR_DESER_ON_ERROR = "drop"),
+    {
+      env_res <- expect_output(blockr_deser(ser), "Dropping block b")
+      expect_identical(names(env_res), "a")
+    }
+  )
+})
+
+test_that("board deser resolves the option and threads it to blocks", {
+
+  board <- new_board(
+    c(a = new_dataset_block("iris"), b = new_subset_block()),
+    links = links(from = "a", to = "b"),
+    stacks = list(with_a = new_stack(c("a", "b")))
+  )
+
+  ser <- blockr_ser(board)
+  ser$payload$blocks$payload$b$object <- c(
+    "foo_block", ser$payload$blocks$payload$b$object
+  )
+
+  withr::with_envvar(
+    c(BLOCKR_DESER_ON_ERROR = NA),
+    withr::with_options(
+      list(blockr.deser_on_error = NULL),
+      expect_error(blockr_deser(ser), class = "block_deser_class_error")
+    )
+  )
+
+  res <- withr::with_options(
+    list(blockr.deser_on_error = "drop"),
+    expect_output(blockr_deser(ser), "Dropping block b")
+  )
+
+  expect_true(is_board(res))
+  expect_identical(board_block_ids(res), "a")
+  expect_length(board_links(res), 0L)
+  expect_identical(stack_blocks(board_stacks(res)[["with_a"]]), "a")
+})


### PR DESCRIPTION
## Summary

- A single block that can't be deserialized -- its constructor or package is no longer available, its payload won't reconstruct, or the round-trip class check fails (`block_deser_class_error`) -- currently aborts the *entire* board restore. That is the recurring annoyance this issue describes, and specifically covers a board referencing a block *type* a package has since retired or consolidated.
- `blockr_deser()` for `blocks` gains an `on_error` argument, defaulting to `blockr_option("deser_on_error", "abort")`. `"abort"` is the current behaviour, unchanged; a deployment opts into `"drop"` via `options(blockr.deser_on_error = "drop")` or the `BLOCKR_DESER_ON_ERROR` environment variable.
- In `"drop"` mode each block deserializes behind a `tryCatch`; a block that fails any of the three modes is omitted (with a `log_warn` naming the block and the reason) and the rest of the board loads.
- Dropping a block cascades: `blockr_deser.board()` prunes the links and stacks that reference an *actually-dropped* block before `new_board()` validates, so the load doesn't simply re-abort with a dangling-reference error. `validate_board()` is left untouched -- a reference to a block that was never present (genuine corruption, not a drop) still aborts.
- Scope is blocks plus the link/stack cascade in core; extensions can adopt the same `on_error` protocol later.

Fixes #264
