### PR TITLE
Force live/nm in freeze_state_view() so state views stop aliasing

### DIFF
--- a/R/block-server.R
+++ b/R/block-server.R
@@ -678,6 +678,15 @@ freeze_exposed_state <- function(state, x, frozen, sess) {
 
 freeze_state_view <- function(live, nm, frozen, snapshot, sess) {
 
+  # `live` and `nm` MUST be forced here. The caller passes them from a
+  # `for (nm in views)` loop, and reactive() defers its body: without these
+  # forces the promises are only resolved on the first read, in the caller's
+  # frame, where the loop has long since finished -- so every view would bind
+  # to the LAST element of `views`. That aliased all of a block's state fields
+  # onto one value, which is what serialize_board() then wrote out.
+  force(live)
+  force(nm)
+
   reactive(
     if (frozen()) snapshot()[[nm]] else reval_if(live),
     domain = sess

--- a/R/block-server.R
+++ b/R/block-server.R
@@ -651,7 +651,7 @@ freeze_exposed_state <- function(state, x, frozen, sess) {
   }
 
   ctrl <- intersect(fn_names, external_ctrl_vars(x))
-  views <- setdiff(fn_names, ctrl)
+  readonly <- setdiff(fn_names, ctrl)
 
   live <- state[fn_names]
 
@@ -669,21 +669,21 @@ freeze_exposed_state <- function(state, x, frozen, sess) {
     hold_ctrl_state(live[ctrl], frozen, snapshot, sess)
   }
 
-  for (nm in views) {
-    state[[nm]] <- freeze_state_view(live[[nm]], nm, frozen, snapshot, sess)
+  for (nm in readonly) {
+    state[[nm]] <- freeze_readonly_field(live[[nm]], nm, frozen, snapshot, sess)
   }
 
   state
 }
 
-freeze_state_view <- function(live, nm, frozen, snapshot, sess) {
+freeze_readonly_field <- function(live, nm, frozen, snapshot, sess) {
 
   # `live` and `nm` MUST be forced here. The caller passes them from a
-  # `for (nm in views)` loop, and reactive() defers its body: without these
+  # `for (nm in readonly)` loop, and reactive() defers its body: without these
   # forces the promises are only resolved on the first read, in the caller's
-  # frame, where the loop has long since finished -- so every view would bind
-  # to the LAST element of `views`. That aliased all of a block's state fields
-  # onto one value, which is what serialize_board() then wrote out.
+  # frame, where the loop has long since finished -- so every field would bind
+  # to the LAST element of `readonly`. That aliased all of a block's state
+  # fields onto one value, which is what serialize_board() then wrote out.
   force(live)
   force(nm)
 

--- a/tests/testthat/test-input-freeze.R
+++ b/tests/testthat/test-input-freeze.R
@@ -33,6 +33,66 @@ new_state_probe <- function(v = "published") {
   )
 }
 
+new_multi_state_probe <- function(first = FALSE, second = FALSE) {
+  new_transform_block(
+    function(id, data) {
+      moduleServer(
+        id,
+        function(input, output, session) {
+          first_rv <- reactiveVal(first)
+          second_rv <- reactiveVal(second)
+          observeEvent(input$first, first_rv(input$first))
+          observeEvent(input$second, second_rv(input$second))
+          list(
+            expr = reactive(quote(identity(data))),
+            state = list(first = first_rv, second = second_rv)
+          )
+        }
+      )
+    },
+    function(id) shiny::tagList(),
+    class = "multi_state_probe",
+    block_metadata = FALSE
+  )
+}
+
+test_that("each exposed state view tracks its own value", {
+
+  # Regression: freeze_state_view() took `live`/`nm` as promises that reactive()
+  # only forced on first read, by which time the caller's `for (nm in views)`
+  # loop had finished -- so every view bound to the LAST one. Every state field
+  # then reported the last field's value, and that is what got serialized.
+
+  blk <- new_multi_state_probe()
+
+  testServer(
+    get_s3_method("block_server", blk),
+    {
+      session$flushReact()
+
+      scope <- session$makeScope("expr")
+
+      scope$setInputs(first = TRUE)
+      session$flushReact()
+
+      expect_true(reval_if(session$returned$state$first))
+      expect_false(reval_if(session$returned$state$second))
+
+      scope$setInputs(first = FALSE, second = TRUE)
+      session$flushReact()
+
+      expect_false(reval_if(session$returned$state$first))
+      expect_true(reval_if(session$returned$state$second))
+    },
+    args = list(
+      x = blk,
+      data = list(data = reactiveVal(datasets::BOD)),
+      block_id = "p",
+      visibility = make_vis("p")
+    )
+  )
+})
+
 test_that("the board exposes a per-block frozen channel", {
 
   board <- new_board(blocks = c(a = new_dataset_block("iris")))

--- a/tests/testthat/test-input-freeze.R
+++ b/tests/testthat/test-input-freeze.R
@@ -56,12 +56,13 @@ new_multi_state_probe <- function(first = FALSE, second = FALSE) {
   )
 }
 
-test_that("each exposed state view tracks its own value", {
+test_that("each exposed read-only state field tracks its own value", {
 
-  # Regression: freeze_state_view() took `live`/`nm` as promises that reactive()
-  # only forced on first read, by which time the caller's `for (nm in views)`
-  # loop had finished -- so every view bound to the LAST one. Every state field
-  # then reported the last field's value, and that is what got serialized.
+  # Regression: freeze_readonly_field() took `live`/`nm` as promises that
+  # reactive() only forced on first read, by which time the caller's
+  # `for (nm in readonly)` loop had finished -- so every field bound to the
+  # LAST one. Every state field then reported the last field's value, and that
+  # is what got serialized.
 
   blk <- new_multi_state_probe()
 


### PR DESCRIPTION
Fixes #285. Root cause, MRE and verification in the issue.

`reactive()` defers its body, so the `live` / `nm` promises passed from the `for (nm in views)` loop were only resolved on first read — after the loop had finished — binding every state view to the last field. `force()` on both resolves them in the right frame.

- `R/block-server.R`: `force(live)` / `force(nm)` at the top of `freeze_state_view()`.
- `tests/testthat/test-input-freeze.R`: regression test asserting each exposed view tracks its own value. Fails on both assertions without the fix.

Verified: test-input-freeze 26 passed / 0 failed with the fix (2 failures on unfixed main). Also green: block-server (73), board-server (131), plugin-serdes (45), utils-serdes (23). The fix has additionally been confirmed to resolve the issue in production.