### PR TITLE
Preserve links class in links$mod update so it applies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -63,6 +63,13 @@
   `options(blockr.deser_on_error = "drop")` or the `BLOCKR_DESER_ON_ERROR`
   environment variable. Links and stacks referencing a dropped block are
   pruned so the surrounding board still loads (#264).
+* A `links$mod` board update that changes a link to a different value (for
+  example switching a `merge_block`'s input from `x` to `y`) now applies
+  instead of being silently discarded. Folding the modified link into the
+  `add` accumulator with base `c()` dropped the `links` class when the
+  accumulator was empty, so the downstream link setup ran without its
+  `to`/`input` arguments and aborted with `missing subscript`, rolling back
+  the whole update; it now concatenates with `vec_c()` (#287).
 
 # blockr.core 0.1.3
 

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -1791,7 +1791,7 @@ apply_core_board_update <- function(rv, upd, session,
     cur_lnks <- board_links(rv$board)[names(upd$links$mod)]
     merged <- as_links(Map(update_link, cur_lnks, upd$links$mod))
 
-    upd$links$add <- c(upd$links$add, merged)
+    upd$links$add <- vec_c(upd$links$add, merged)
     upd$links$rm <- c(upd$links$rm, names(upd$links$mod))
   }
 

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -452,6 +452,35 @@ test_that("links$mod accepts partial-args deltas via update_link", {
   )
 })
 
+test_that("links$mod applies a value-changing delta (keeps links class)", {
+
+  board <- new_board(
+    blocks = c(a = new_dataset_block("iris"), m = new_merge_block()),
+    links = links(l1 = new_link("a", "m", "x"))
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      board_update(
+        list(links = list(mod = list(l1 = list(input = "y"))))
+      )
+
+      session$flushReact()
+
+      lnks <- board_links(rv$board)
+
+      expect_identical(names(lnks), "l1")
+      expect_identical(lnks$input, "y")
+      expect_identical(lnks$from, "a")
+      expect_identical(lnks$to, "m")
+    },
+    args = list(x = board)
+  )
+})
+
 test_that("stacks$mod merges deltas onto current stack via update_stack", {
 
   board <- new_board(


### PR DESCRIPTION
## Summary

- A `links$mod` board update that changes a link to a *different* value was silently discarded: the board stayed unchanged and `apply_board_update failed: missing subscript` was logged. Most visible when switching a finite multi-input target's slot (e.g. a `merge_block`'s input from `x` to `y`) — the link stayed on the old port with no user-facing error.
- Root cause: the `links$mod` branch folded the merged link into the `add` accumulator with base `c()`. For a pure-mod update the accumulator is `NULL`, and `c(NULL, <links>)` dispatches on the `NULL` first arg to base `c()`, stripping the `links` class to a plain `list`. `update_block_links()` then no longer spreads the record's fields, so `setup_link()` is called without its `to`/`input` arguments and aborts with `missing subscript`; the `tryCatch` around the apply logs a warning and discards the whole update.
- Fix: concatenate with `vec_c()` instead, which keeps the `links` class (and names and order), so a value-changing `links$mod` delta applies. The `rm` sibling stays `c()` — it concatenates a character vector of ids, not a `links` object.
- Added a regression test that switches a `merge_block`'s input `x` → `y`; it fails on the old `c()` (input stays `"x"`) and passes with `vec_c()` (`"y"`). The pre-existing `links$mod` test modded `input` to the value it already had, so an unchanged value couldn't distinguish a working apply from the discarded one.

Fixes #287