### PR TITLE
Don't record empty-message conditions as block errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -70,6 +70,12 @@
   accumulator was empty, so the downstream link setup ran without its
   `to`/`input` arguments and aborted with `missing subscript`, rolling back
   the whole update; it now concatenates with `vec_c()` (#287).
+* A `req()` -- or any silent flow-control throw with an empty message --
+  evaluated while a block's conditions are captured is no longer recorded as
+  a block error, so a block that is merely not currently needed no longer
+  flashes a text-less red error band (and a false error count) in deployed
+  apps. Empty-message conditions are filtered by emptiness rather than class,
+  so a `validate(need(x, "msg"))` message still surfaces (#289).
 
 # blockr.core 0.1.3
 

--- a/R/utils-cnd.R
+++ b/R/utils-cnd.R
@@ -179,10 +179,22 @@ warn_handler <- function(cond, conds) {
 err_handler <- function(cond, conds, err_val = NULL) {
   stopifnot(is.environment(cond), is.character(conds))
   function(e) {
+
+    msg <- fmt_cnd_msg(e)
+
+    # Silent flow-control throws (req()) carry an empty message; recording one
+    # as an error paints a text-less red band. Gate on emptiness, not class:
+    # validate(need(x, "msg")) is also a shiny.silent.error and must surface.
+    if (all(!nzchar(msg))) {
+      return(err_val)
+    }
+
     if ("error" %in% conds) {
       cond$error <- list(as_blk_cnd(e))
     }
-    log_error(fmt_cnd_msg(e), use_glue = FALSE)
+
+    log_error(msg, use_glue = FALSE)
+
     err_val
   }
 }

--- a/tests/testthat/test-utils-cnd.R
+++ b/tests/testthat/test-utils-cnd.R
@@ -78,6 +78,49 @@ test_that("conditions", {
   expect_identical(cnd, as_blk_cnd(cnd))
 })
 
+test_that("empty-message flow-control throws are not recorded as errors", {
+
+  # A req() / silent flow-control throw carries an empty message and must not
+  # be recorded as an error (it would paint a text-less red band). The
+  # discriminator is emptiness, not class -- validate(need(x, "msg")) is the
+  # same shiny.silent.error class and must keep surfacing.
+  with_mock_session(
+    {
+      vals <- reactiveValues(test = NULL)
+
+      res <- withr::with_options(
+        list(blockr.show_conditions = c("warning", "error")),
+        capture_conditions(
+          req(FALSE),
+          rv = vals,
+          slot = "test",
+          error_val = NULL
+        )
+      )
+
+      expect_null(res)
+      expect_length(vals$test$error, 0L)
+
+      res <- withr::with_options(
+        list(blockr.show_conditions = c("warning", "error")),
+        capture_conditions(
+          validate(need(FALSE, "Column not found")),
+          rv = vals,
+          slot = "test",
+          error_val = NULL
+        )
+      )
+
+      expect_null(res)
+      expect_length(vals$test$error, 1L)
+      expect_identical(
+        cnd_message(vals$test$error[[1L]]),
+        "Column not found"
+      )
+    }
+  )
+})
+
 test_that("captured condition messages with braces do not glue-interpolate", {
 
   # tidyr::pivot_wider() emits duplicate-value warnings whose text contains


### PR DESCRIPTION
## Summary

- `input_reactive` gates a block on `req(block_needed(rv, to))`; when the block is not currently needed this throws a `shiny.silent.error` with an empty message. `err_handler` recorded *every* error unconditionally, so the flow-control `req()` landed in `cond$error` as a text-less condition — surfacing a red error band (icon only) and a false error count on blocks that are working fine. Only observable when a ctrl plugin reads `data()` for an upstream block on a non-visible view, but confusing in deployed apps.
- `err_handler` now drops a captured error whose message is empty, returning `err_val` without recording or logging it. The discriminator is emptiness, **not** class: `validate(need(x, "msg"))` is the same `shiny.silent.error` class and must keep surfacing (e.g. blockr.viz's "Column not found").
- Regression test captures both a `req(FALSE)` (no error recorded) and a `validate(need(FALSE, "msg"))` (error recorded, message preserved) through `capture_conditions`, proving the filter keys on emptiness rather than class.

Fixes #289