### PR TITLE
Thread request query params to app UI/server builders

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,15 @@
   plugins -- which typical front-ends (e.g. blockr.dock) replace with their
   own UI -- so a bare core install no longer pulls it in. Install `DT`
   alongside if you use either (#129).
+* A board's `blockr_app_ui()` and `blockr_app_server()` methods now receive the
+  request's parsed URL query parameters as a `query` argument, at both the GET
+  and the websocket phase. A board subclass reads it to make the rendered UI and
+  the server URL-aware from one source -- for example opening on the view named
+  by `?view=` -- so the initial render and the server agree without a custom
+  loader. The default `board` methods ignore it. Breaking for front-ends: a
+  `blockr_app_ui()` / `blockr_app_server()` method that forwards its `...` into
+  the returned UI must add a `query` formal, or the threaded argument lands in
+  `...` and renders as stray content (#291).
 * Cleanup of a removed block, stack or view now uses shiny's public
   `session$destroy(id)` (requires shiny >= 1.14.0) rather than reaching into
   undocumented shiny internals to tear down a module's inputs, outputs and

--- a/R/board-loader.R
+++ b/R/board-loader.R
@@ -95,22 +95,22 @@ is_board_loader <- function(x) {
 
 reload_param <- "__blockr_reload__"
 
+resolve_query <- function(request, session) {
+
+  search <- if (is.null(session)) {
+    request[["QUERY_STRING"]]
+  } else {
+    isolate(session$clientData$url_search)
+  }
+
+  parseQueryString(coal(search, ""))
+}
+
 #' @rdname board_loader
 #' @export
 local_loader <- function() {
 
   store <- new.env(parent = emptyenv())
-
-  read_query <- function(request, session) {
-
-    search <- if (is.null(session)) {
-      request[["QUERY_STRING"]]
-    } else {
-      isolate(session$clientData$url_search)
-    }
-
-    parseQueryString(coal(search, ""))
-  }
 
   query_string <- function(query) {
 
@@ -126,7 +126,7 @@ local_loader <- function() {
 
   write_token <- function(session, token) {
 
-    query <- read_query(NULL, session)
+    query <- resolve_query(NULL, session)
     query[[reload_param]] <- token
 
     updateQueryString(query_string(query), mode = "replace", session = session)
@@ -134,7 +134,7 @@ local_loader <- function() {
 
   resolve <- function(request, session, default) {
 
-    token <- read_query(request, session)[[reload_param]]
+    token <- resolve_query(request, session)[[reload_param]]
 
     if (is.null(token)) {
       return(NULL)

--- a/R/utils-serve.R
+++ b/R/utils-serve.R
@@ -191,14 +191,19 @@ custom_options <- function(x) {
   }
 }
 
+#' @param query Parsed URL query parameters (a named list) for the incoming
+#' request, passed to `blockr_app_ui()` and `blockr_app_server()` at both the
+#' GET and the websocket phase. A board subclass method reads it to make the
+#' rendered UI and the server URL-aware -- for example picking an initial view
+#' from `query[["view"]]`; the default methods ignore it.
 #' @rdname serve
 #' @export
-blockr_app_ui <- function(id, x, ...) {
+blockr_app_ui <- function(id, x, ..., query = list()) {
   UseMethod("blockr_app_ui", x)
 }
 
 #' @export
-blockr_app_ui.board <- function(id, x, ...) {
+blockr_app_ui.board <- function(id, x, ..., query = list()) {
   bslib::page_fluid(
     theme = bslib::bs_theme(version = 5),
     board_ui(id, x, ...)
@@ -207,12 +212,12 @@ blockr_app_ui.board <- function(id, x, ...) {
 
 #' @rdname serve
 #' @export
-blockr_app_server <- function(id, x, ...) {
+blockr_app_server <- function(id, x, ..., query = list()) {
   UseMethod("blockr_app_server", x)
 }
 
 #' @export
-blockr_app_server.board <- function(id, x, ...) {
+blockr_app_server.board <- function(id, x, ..., query = list()) {
   board_server(id, x, ...)
 }
 
@@ -229,7 +234,15 @@ serve_board_ui <- function(id, default, loader, plugins, options, ...) {
 
     do.call(
       blockr_app_ui,
-      c(list(id, x, plugins = plugins(x), options = options(x)), args)
+      c(
+        list(
+          id, x,
+          query = resolve_query(request, NULL),
+          plugins = plugins(x),
+          options = options(x)
+        ),
+        args
+      )
     )
   }
 }
@@ -245,7 +258,15 @@ serve_board_srv <- function(id, default, loader, plugins, options, ...) {
 
     res <- do.call(
       blockr_app_server,
-      c(list(id, x, plugins = plugins(x), options = options(x)), args)
+      c(
+        list(
+          id, x,
+          query = resolve_query(session$request, session),
+          plugins = plugins(x),
+          options = options(x)
+        ),
+        args
+      )
     )
 
     board_refresh <- res[["board_refresh"]]

--- a/man/serve.Rd
+++ b/man/serve.Rd
@@ -34,9 +34,9 @@ blockr_app_options(x)
 
 custom_options(x)
 
-blockr_app_ui(id, x, ...)
+blockr_app_ui(id, x, ..., query = list())
 
-blockr_app_server(id, x, ...)
+blockr_app_server(id, x, ..., query = list())
 
 blockr_test_exports(x, rv, ...)
 }
@@ -55,6 +55,12 @@ blockr_test_exports(x, rv, ...)
 
 \item{loader}{A \code{\link[=board_loader]{board_loader()}} resolving the board to build for each
 request; defaults to \code{\link[=local_loader]{local_loader()}}, the in-process save/restore handoff}
+
+\item{query}{Parsed URL query parameters (a named list) for the incoming
+request, passed to \code{blockr_app_ui()} and \code{blockr_app_server()} at both the
+GET and the websocket phase. A board subclass method reads it to make the
+rendered UI and the server URL-aware -- for example picking an initial view
+from \code{query[["view"]]}; the default methods ignore it.}
 
 \item{rv}{Board \code{\link[shiny:reactiveValues]{shiny::reactiveValues()}}}
 }

--- a/tests/testthat/test-plugin-serdes.R
+++ b/tests/testthat/test-plugin-serdes.R
@@ -298,6 +298,66 @@ test_that("a user-changed block-backed board option survives save/restore", {
   )
 })
 
+test_that("resolve_query reads the query at both request phases", {
+
+  get <- resolve_query(list(QUERY_STRING = "view=sales&tab=2"), NULL)
+  expect_identical(get[["view"]], "sales")
+  expect_identical(get[["tab"]], "2")
+
+  ws <- resolve_query(NULL, list(clientData = list(url_search = "?view=sales")))
+  expect_identical(ws[["view"]], "sales")
+
+  expect_length(resolve_query(list(), NULL), 0L)
+  expect_length(
+    resolve_query(NULL, list(clientData = list(url_search = ""))),
+    0L
+  )
+})
+
+test_that("serve_board_ui threads the request query to blockr_app_ui", {
+
+  seen <- NULL
+
+  local_mocked_bindings(
+    blockr_app_ui = function(id, x, ..., query = list()) {
+      seen <<- query
+      NULL
+    }
+  )
+
+  ui <- serve_board_ui(
+    "app", new_board(), local_loader(), blockr_app_plugins, blockr_app_options
+  )
+  ui(list(QUERY_STRING = "view=sales&tab=2"))
+
+  expect_identical(seen[["view"]], "sales")
+  expect_identical(seen[["tab"]], "2")
+})
+
+test_that("serve_board_srv threads the session query to blockr_app_server", {
+
+  seen <- NULL
+
+  local_mocked_bindings(
+    resolve_query = function(request, session) {
+      if (is.null(session)) list() else list(view = "ops")
+    },
+    blockr_app_server = function(id, x, ..., query = list()) {
+      seen <<- query
+      list()
+    },
+    blockr_test_exports = function(x, rv, ...) invisible()
+  )
+
+  srv <- serve_board_srv(
+    "app", new_board(), local_loader(), blockr_app_plugins, blockr_app_options
+  )
+
+  testServer(srv, session$flushReact())
+
+  expect_identical(seen[["view"]], "ops")
+})
+
 test_that("preserve_board return validation", {
 
   with_mock_session(


### PR DESCRIPTION
## Summary

- A board *type* had no way to see the request's URL query at render time: `blockr_app_ui.<subclass>()` receives the resolved board but not the request. So blockr.dock's `?view=` fell back to a server-only shim, which leaves the GET-rendered navbar on the default view until the websocket switch corrects it.
- `serve()` now parses the request query once per phase — via `resolve_query()`, hoisted out of `local_loader()`'s closure so the loader and the serve builders share the same GET/WS split — and passes it as a `query` argument to `blockr_app_ui()` and `blockr_app_server()` at both phases. The generics and their default `board` methods take `query = list()` and the defaults ignore it.
- A board subclass reads `query` to make the initial render and the server URL-aware from one source (e.g. pre-setting the active view from `query[["view"]]` in both methods), so the two agree without a custom loader. No new exported generic — the only public change is the documented `query` argument (`NAMESPACE` is unchanged).

Breaking for front-ends: a `blockr_app_ui()` / `blockr_app_server()` method that forwards its `...` into the returned UI must add a `query` formal to absorb the new argument (or it renders as stray content). blockr.dock adapts in BristolMyersSquibb/blockr.dock#358, which the reverse-dependency check below pins so it lands as a coupled pair.

```deps
BristolMyersSquibb/blockr.dock#358
```

Fixes #291
