### PR TITLE
Qualify both data references in the scatter block expr

### DIFF
--- a/R/plot-scatter.R
+++ b/R/plot-scatter.R
@@ -61,7 +61,7 @@ new_scatter_block <- function(x = character(), y = character(), ...) {
           list(
             expr = reactive(
               bbquote(
-                plot(.(data)[[.(x)]], data[[.(y)]], xlab = .(x_col),
+                plot(.(data)[[.(x)]], .(data)[[.(y)]], xlab = .(x_col),
                      ylab = .(y_col)),
                 list(x = x_col(), y = y_col(), x_col = x_col(),
                      y_col = y_col())

--- a/tests/testthat/test-plot-scatter.R
+++ b/tests/testthat/test-plot-scatter.R
@@ -22,6 +22,14 @@ test_that("scetter plot block constructor", {
 
       expect_identical(session$returned$state$x(), "Sepal.Length")
       expect_identical(session$returned$state$y(), "Sepal.Width")
+
+      expect_identical(
+        session$returned$expr(),
+        quote(
+          plot(.(data)[["Sepal.Length"]], .(data)[["Sepal.Width"]],
+               xlab = "Sepal.Length", ylab = "Sepal.Width")
+        )
+      )
     },
     args = list(data = function() iris)
   )


### PR DESCRIPTION
The scatter block's expression marks only the x-axis data reference with `.()`; the y-axis one is a bare `data`:

https://github.com/BristolMyersSquibb/blockr.core/blob/main/R/plot-scatter.R#L64

```r
plot(.(data)[[.(x)]], data[[.(y)]], xlab = .(x_col), ylab = .(y_col))
```

`new_scatter_block()` is `expr_type = "bquoted"`, and only terms wrapped in `.()` are substituted — at runtime by `eval_impl()` (`R/block-server.R`), at export time by `wrap_expr()` (`R/utils-code.R`), which maps each input to the upstream block's variable name. The unmarked `data` therefore survives into exported code as a literal symbol bound to nothing.

### Reproducing

```r
board <- generate_plugin_args(
  new_board(
    blocks = c(
      a = new_dataset_block("iris"),
      b = new_scatter_block(x = "Sepal.Length", y = "Sepal.Width")
    ),
    links = links(from = "a", to = "b")
  )
)$board

cat(
  export_wrapped_code(
    isolate(lst_xtr_reval(board$blocks, "server", "expr")),
    isolate(board$board)
  )
)
```

Before:

```r
a <- local(datasets::iris)

b <- local(plot(a[["Sepal.Length"]], data[["Sepal.Width"]], xlab = "Sepal.Length",
    ylab = "Sepal.Width"))
```

Running that script fails — `object 'data' not found`, or `object of type 'closure' is not subsettable` when `utils::data` is reachable on the search path.

After:

```r
a <- local(datasets::iris)

b <- local(plot(a[["Sepal.Length"]], a[["Sepal.Width"]], xlab = "Sepal.Length",
    ylab = "Sepal.Width"))
```

which evaluates cleanly.

### Why it went unnoticed

In-app evaluation is unaffected: `eval_impl()` substitutes `.(data)` with the name `data` and evaluates in an environment where `data` is bound, so both the marked and the unmarked reference resolve to the same object. Only code export (and anything else consuming the marked expression) sees the difference.

### Changes

- `R/plot-scatter.R` — one character: `data[[.(y)]]` → `.(data)[[.(y)]]`.
- `tests/testthat/test-plot-scatter.R` — regression test pinning the generated expression, so both references stay marked. It fails on `main` and passes here.
