### PR TITLE
Re-resolve a downstream input when its upstream builds later

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -69,6 +69,12 @@
   Each tick's pacing delay now begins once the just-built block has flushed
   rather than while its reactive graph is still flushing, so pending user input
   is serviced within one tick instead of behind the entire backlog (#276).
+* With a finite `background_construction_delay` (the default), a downstream
+  block's data input no longer latches at `NULL` when its input reactive runs
+  before the upstream is built. The input read the upstream server under
+  `isolate()` and never re-resolved once that server registered a moment
+  later; it now re-fires when the upstream is constructed, so the block picks
+  up its data instead of starving for the rest of the session (#298).
 * Captured block conditions are no longer glue-interpolated when logged, so a
   block whose warning or error text contains braces -- e.g. the `{summary_fun}`
   / `{data}` placeholders in `tidyr::pivot_wider()`'s duplicate-value warning --

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -939,7 +939,18 @@ upstream_result <- function(key, src_rv, rv, to) {
 
       from <- src_rv[[key]]
 
-      srv <- if (is.null(from)) NULL else isolate(rv$blocks[[from]])[["server"]]
+      srv <- if (is.null(from)) {
+        NULL
+      } else {
+        # Depend on the upstream's rv$eval slot -- installed when it is
+        # constructed -- so a downstream whose input runs before its upstream
+        # is registered re-resolves the server once that upstream appears,
+        # rather than latching the NULL it first saw. Mirrors input_ready();
+        # rv$blocks stays isolated to avoid a whole-container dependency that
+        # would re-fire every input on every block's construction.
+        rv$eval[[from]]
+        isolate(rv$blocks[[from]])[["server"]]
+      }
 
       if (is.null(srv)) NULL else srv$result()
     }

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -939,18 +939,19 @@ upstream_result <- function(key, src_rv, rv, to) {
 
       from <- src_rv[[key]]
 
-      srv <- if (is.null(from)) {
-        NULL
-      } else {
-        # Depend on the upstream's rv$eval slot -- installed when it is
-        # constructed -- so a downstream whose input runs before its upstream
-        # is registered re-resolves the server once that upstream appears,
-        # rather than latching the NULL it first saw. Mirrors input_ready();
-        # rv$blocks stays isolated to avoid a whole-container dependency that
-        # would re-fire every input on every block's construction.
-        rv$eval[[from]]
-        isolate(rv$blocks[[from]])[["server"]]
+      if (is.null(from)) {
+        return(NULL)
       }
+
+      # Depend on the upstream's rv$eval slot -- installed when it is
+      # constructed -- so a downstream whose input runs before its upstream
+      # is registered re-resolves the server once that upstream appears,
+      # rather than latching the NULL it first saw. Mirrors input_ready();
+      # rv$blocks stays isolated to avoid a whole-container dependency that
+      # would re-fire every input on every block's construction.
+      rv$eval[[from]]
+
+      srv <- isolate(rv$blocks[[from]])[["server"]]
 
       if (is.null(srv)) NULL else srv$result()
     }

--- a/tests/testthat/test-visibility-gating.R
+++ b/tests/testthat/test-visibility-gating.R
@@ -1029,3 +1029,54 @@ test_that("a zero background delay builds every block up front", {
     args = list(x = ordered_board(), plugins = list(), callbacks = visible_b)
   )
 })
+
+test_that("a downstream input recovers an upstream built after it ran", {
+
+  # Regression for the finite background_construction_delay race: an input
+  # reactive that runs before its upstream is registered in rv$blocks must
+  # re-resolve the server once that upstream is constructed, instead of latching
+  # the NULL it first saw. The wake rides the upstream's rv$eval slot, installed
+  # at its construction -- the same per-key signal input_ready() depends on.
+
+  latch_probe <- function(id) {
+    moduleServer(
+      id,
+      function(input, output, session) {
+
+        rv <- reactiveValues(blocks = list())
+        rv$eval <- reactiveValues()
+        rv$needed <- reactiveVal(TRUE)
+        rv$needed_slots <- new.env(parent = emptyenv())
+
+        src_rv <- reactiveValues()
+        src_rv[["data"]] <- "up"
+
+        input_res <- upstream_result("data", src_rv, rv, to = "down")
+
+        captured <- new.env(parent = emptyenv())
+        captured$val <- "unset"
+
+        observe(captured$val <- input_res())
+      }
+    )
+  }
+
+  testServer(
+    latch_probe,
+    {
+      session$flushReact()
+
+      expect_null(captured$val)
+
+      # Build the upstream, mirroring construct_block's install order: rebind
+      # rv$blocks, then install the eval slot through a local binding.
+      rv$blocks[["up"]] <- list(server = list(result = reactive("UPSTREAM")))
+      ev <- isolate(rv$eval)
+      ev[["up"]] <- reactive("ready")
+
+      session$flushReact()
+
+      expect_identical(captured$val, "UPSTREAM")
+    }
+  )
+})


### PR DESCRIPTION
## Summary

- A finite `background_construction_delay` (the default, `50`) could latch a downstream block's data input at `NULL` for the whole session. Under staggered construction a block's input reactive can run before its upstream is registered in `rv$blocks`, and `upstream_result()` read the upstream server under `isolate()`, so it never re-fired once that server registered a moment later. On the `blockr.cdex` board this starved the shared `cdisc` block and every downstream view.
- `upstream_result()` now takes a per-key dependency on the upstream's `rv$eval` slot — installed at the upstream's construction — so the input re-resolves the server when the upstream appears, instead of caching the first `NULL`. This mirrors `input_ready()`, which already depends on that slot to wake a downstream when its upstream's status installs.
- The wake rides `rv$eval[[from]]` rather than `rv$blocks[[from]]` because `rv$blocks` is a plain list with no per-key reactivity; `rv$blocks` stays isolated so the input does not re-fire on every block's construction (`delay = 0` / `Inf` were already immune, building each set in one topo-ordered pass).
- Regression test drives a downstream input that runs before its upstream is built, then installs the upstream mirroring `construct_block`'s order and asserts the input recovers — it fails on the unfixed code (latched `NULL`) and passes with the fix.

Fixes #298