### PR TITLE
Degrade metadata-less blocks to defaults instead of aborting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -123,6 +123,13 @@
   and forward to the new ones, so existing
   `register_block(arguments = new_block_args(...))` call sites keep working;
   migrate them to the `arg_spec` family (#295).
+* A block constructed for a class with no registry entry is now imputed a
+  class-derived default metadata record at construction (name from the class,
+  default category and icon) instead of being left without one. It still warns,
+  but the block is then self-describing: `block_metadata()` and the
+  `block_meta_*()` accessors report those defaults rather than a metadata read
+  aborting -- so a cosmetic lookup can no longer take down a board whose
+  registry has been curated (#299).
 
 # blockr.core 0.1.3
 

--- a/R/block-class.R
+++ b/R/block-class.R
@@ -220,10 +220,13 @@ new_block <- function(server, ui, class, ctor = sys.parent(), ctor_pkg = NULL,
       block_metadata <- c(list(id = uid), block_metadata)
 
     } else if (!isFALSE(block_metadata)) {
+
       blockr_warn(
-        "No block metadata available for block {class[1L]}.",
+        "No registry entry for block {class[1L]}; using default metadata.",
         class = "missing_block_metadata"
       )
+
+      block_metadata <- block_default_metadata(class)
     }
   }
 

--- a/R/block-meta.R
+++ b/R/block-meta.R
@@ -10,7 +10,9 @@
 #' (`block_meta_name()`, `block_meta_guidance()`, ...) returning that attribute
 #' for a single block. Missing fields are filled with display defaults in the
 #' data.frame; the getters instead return the stored value (or `NA` / an empty
-#' value).
+#' value). A block constructed for a class with no registry entry carries a
+#' class-derived default record, imputed at construction, so accessors degrade
+#' to those defaults rather than signalling a missing record.
 #'
 #' @param x A `block`, a `blocks` collection, a `block_registry_entry` or a
 #'   registry ID
@@ -52,7 +54,12 @@ block_metadata.default <- function(x, fields = "all", ...) {
 }
 
 block_default_name <- function(x) {
-  gsub("_", " ", class(x)[1L])
+
+  if (is_block(x)) {
+    x <- class(x)
+  }
+
+  gsub("_", " ", x[1L])
 }
 
 block_metadata_fields <- function() {
@@ -93,15 +100,13 @@ catalog_column <- function(field, records, default_names) {
     field,
     id = scalar_column(records, "id", NA_character_),
     name = name_column(records, default_names),
-    description = scalar_column(
-      records, "description", "No description available."
-    ),
+    description = scalar_column(records, "description", default_description()),
     details = scalar_column(records, "details", NA_character_),
     link = scalar_column(records, "link", NA_character_),
     guidance = scalar_column(records, "guidance", NA_character_),
     category = scalar_column(records, "category", default_category()),
     icon = icon_column(records),
-    package = scalar_column(records, "package", "local"),
+    package = scalar_column(records, "package", default_package()),
     keywords = lapply(records, meta_default, "keywords", character()),
     arguments = lapply(records, meta_default, "arguments", new_arg_specs()),
     examples = lapply(records, record_examples)
@@ -145,6 +150,26 @@ block_record_fields <- function() {
   c(registry_metadata_fields, "examples")
 }
 
+block_default_metadata <- function(class) {
+
+  category <- default_category()
+
+  list(
+    id = NA_character_,
+    name = block_default_name(class),
+    description = default_description(),
+    details = NA_character_,
+    link = NA_character_,
+    guidance = NA_character_,
+    keywords = character(),
+    category = category,
+    icon = default_icon(category),
+    arguments = new_arg_specs(),
+    package = default_package(),
+    examples = list()
+  )
+}
+
 block_metadata_record <- function(x, ...) {
   UseMethod("block_metadata_record")
 }
@@ -154,14 +179,11 @@ block_metadata_record.block <- function(x, ...) {
 
   record <- attr(x, "block_metadata")
 
-  if (!is.list(record)) {
-    blockr_abort(
-      "Block {class(x)[1L]} carries no metadata.",
-      class = "missing_block_metadata"
-    )
+  if (is.list(record)) {
+    record
+  } else {
+    block_default_metadata(class(x))
   }
-
-  record
 }
 
 #' @export

--- a/R/block-registry.R
+++ b/R/block-registry.R
@@ -233,6 +233,10 @@ default_icon <- function(category = default_category()) {
 #' @export
 default_category <- function() "uncategorized"
 
+default_description <- function() "No description available."
+
+default_package <- function() "local"
+
 bsicon_icons <- function() {
   get("icon_info", envir = asNamespace("bsicons"), mode = "list")$name
 }
@@ -429,7 +433,9 @@ registry_metadata <- function(blocks = list_blocks(), fields = "all") {
   if ("package" %in% fields) {
     res <- c(
       res,
-      list(package = chr_ply(lapply(reg, attr, "package"), coal, "local"))
+      list(
+        package = chr_ply(lapply(reg, attr, "package"), coal, default_package())
+      )
     )
   }
 

--- a/man/block_metadata.Rd
+++ b/man/block_metadata.Rd
@@ -68,5 +68,7 @@ columns. Each attribute additionally has a dedicated getter
 (\code{block_meta_name()}, \code{block_meta_guidance()}, ...) returning that attribute
 for a single block. Missing fields are filled with display defaults in the
 data.frame; the getters instead return the stored value (or \code{NA} / an empty
-value).
+value). A block constructed for a class with no registry entry carries a
+class-derived default record, imputed at construction, so accessors degrade
+to those defaults rather than signalling a missing record.
 }

--- a/tests/testthat/test-block-meta.R
+++ b/tests/testthat/test-block-meta.R
@@ -197,3 +197,76 @@ test_that("block_metadata tabulates catalog fields with list-columns", {
   blk <- new_head_block()
   expect_identical(block_metadata(blk)$id, "head_block")
 })
+
+test_that("an unregistered block is imputed a class-derived default record", {
+
+  new_orphan_block <- function(block_metadata = NULL) {
+    new_transform_block(
+      function(id, data) {
+        moduleServer(
+          id,
+          function(input, output, session) {
+            list(
+              expr = reactive(quote(identity(data))),
+              state = list()
+            )
+          }
+        )
+      },
+      function(id) {
+        tagList()
+      },
+      block_metadata = block_metadata,
+      class = "ut_orphan_block"
+    )
+  }
+
+  expect_warning(
+    blk <- new_orphan_block(),
+    class = "missing_block_metadata"
+  )
+
+  expect_true(is.list(attr(blk, "block_metadata")))
+  expect_identical(
+    block_metadata_record(blk),
+    block_default_metadata(class(blk))
+  )
+  expect_named(
+    block_metadata_record(blk),
+    c("id", "name", "description", "details", "link", "guidance", "keywords",
+      "category", "icon", "arguments", "package", "examples")
+  )
+
+  meta <- block_metadata(blk)
+
+  expect_s3_class(meta, "data.frame")
+  expect_identical(nrow(meta), 1L)
+  expect_identical(meta$id, NA_character_)
+  expect_identical(meta$name, "ut orphan block")
+  expect_identical(meta$description, default_description())
+  expect_false(is.na(meta$icon))
+
+  expect_identical(block_meta_id(blk), NA_character_)
+  expect_identical(block_meta_name(blk), "ut orphan block")
+  expect_identical(block_meta_description(blk), default_description())
+  expect_identical(block_meta_category(blk), default_category())
+  expect_identical(block_meta_icon(blk), default_icon())
+  expect_identical(block_meta_keywords(blk), character())
+  expect_identical(block_meta_arguments(blk), new_arg_specs())
+
+  mixed <- suppressWarnings(
+    block_metadata(
+      blocks(good = new_dataset_block(), orphan = new_orphan_block())
+    )
+  )
+
+  expect_identical(nrow(mixed), 2L)
+  expect_identical(rownames(mixed), c("good", "orphan"))
+  expect_false(anyNA(mixed$icon))
+  expect_identical(mixed["orphan", "description"], default_description())
+
+  bare <- new_orphan_block(block_metadata = FALSE)
+
+  expect_false(is.list(attr(bare, "block_metadata")))
+  expect_identical(block_meta_name(bare), "ut orphan block")
+})


### PR DESCRIPTION
## Summary

- A block constructed while its class is absent from the registry carries no `block_metadata` attribute. Every metadata consumer funnels through `block_metadata_record.block()`, which `blockr_abort()`ed on the missing attribute — so a cosmetic lookup (the reported case: a `blockr.dag` node icon) took down the whole `board_server`, leaving a blank dock with the error only in the container log.
- Fix the single choke point: `block_metadata_record.block()` now returns an empty record (`list()`) instead of aborting. Every downstream consumer already fills display defaults for missing fields (`icon_column`, `name_column`, `scalar_meta`), so a metadata-less block now tabulates with defaults — identical to a block built with `block_metadata = list()`, which already worked.
- This is the issue's direction 2 (non-fatal consumption). I avoided direction 1 (abort at construction: it would break legitimately constructing an unregistered block, and still crash any board that does) and direction 3 (warn on unregister: a band-aid). Construction still warns, so the early signal is preserved.
- Adds a regression test, verified failing against the unfixed code: a metadata-less block, both alone and mixed into a `blocks()` collection, now tabulates with defaults instead of aborting.

Fixes #299
