### PR TITLE
Gate code export on the built block set, not eval status

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,12 @@
   export ("Show code") then marks every block required, so the exported
   script covers the whole board; an off-screen block that is not fully
   configured holds the export back instead of emitting broken code (#269).
+* Code export gates on the set of blocks that actually carry an expression,
+  not on eval status alone, so a board with unbuilt blocks can no longer emit
+  a script that assigns to a variable named `NA`. "Show code" always opens the
+  modal, which reports "Preparing code..." while the board materializes and a
+  not-ready note when a block is left unconfigured, rather than silently
+  producing nothing (#300).
 * `blockr_ser()` accepts a partial block-state snapshot: a board block omitted
   from `blocks` (or mapped to `NULL`) serializes from its constructor scope
   instead of aborting with `length(blocks) == length(x)`. Saving a board under

--- a/R/plugin-code.R
+++ b/R/plugin-code.R
@@ -38,16 +38,20 @@ generate_code_server <- function(id, board, visibility = NULL, ...) {
     id,
     function(input, output, session) {
 
-      code <- reactive(
-        if (isTRUE(code_export_ready(board))) {
-          export_wrapped_code(
-            lst_xtr_reval(board$blocks, "server", "expr"),
-            board$board
-          )
+      output$code_out <- renderUI(
+        {
+          state <- code_export_state(board)
+
+          script <- if (identical(state, "ready")) {
+            export_wrapped_code(
+              lst_xtr_reval(board$blocks, "server", "expr"),
+              board$board
+            )
+          }
+
+          code_modal_body(state, script)
         }
       )
-
-      output$code_out <- renderUI(code_modal_body(code()))
 
       observeEvent(
         input$code_mod,
@@ -83,34 +87,45 @@ generate_code_ui <- function(id, board) {
   )
 }
 
-code_export_ready <- function(board) {
+code_export_state <- function(board) {
 
+  ids <- board_block_ids(board$board)
   status <- reactiveValuesToList(board$eval)
 
-  if (!setequal(names(status), board_block_ids(board$board))) {
-    return(FALSE)
+  if (!setequal(names(board$blocks), ids) || !setequal(names(status), ids)) {
+    return("pending")
   }
 
-  all(chr_ply(status, reval_if) %in% c("ready", "dormant"))
+  if (all(chr_ply(status, reval_if) %in% c("ready", "dormant"))) {
+    return("ready")
+  }
+
+  "blocked"
 }
 
-code_modal_body <- function(script) {
+code_modal_body <- function(state, script = NULL) {
 
-  if (is.null(script)) {
+  if (identical(state, "ready")) {
     return(
       div(
-        class = "text-muted",
-        paste(
-          "The board is not ready. Finish configuring all blocks",
-          "before exporting code."
-        )
+        class = "text-decoration-none position-relative",
+        pre(paste0(script, collapse = "\n"))
       )
     )
   }
 
+  if (identical(state, "pending")) {
+    return(
+      div(class = "text-muted", "Preparing code...")
+    )
+  }
+
   div(
-    class = "text-decoration-none position-relative",
-    pre(paste0(script, collapse = "\n"))
+    class = "text-muted",
+    paste(
+      "The board is not ready. Finish configuring all blocks",
+      "before exporting code."
+    )
   )
 }
 
@@ -121,7 +136,12 @@ require_all_blocks <- function(board, visibility) {
   }
 
   for (id in board_block_ids(board$board)) {
-    visibility$required[[id]](TRUE)
+
+    slot <- visibility$required[[id]]
+
+    if (not_null(slot)) {
+      slot(TRUE)
+    }
   }
 
   invisible()

--- a/tests/testthat/test-plugin-code.R
+++ b/tests/testthat/test-plugin-code.R
@@ -16,31 +16,9 @@ test_that("generate code", {
   testServer(
     generate_code_server,
     {
-      res <- code()
+      expect_identical(code_export_state(board), "ready")
 
-      expect_type(res, "character")
-      expect_length(res, 1L)
-
-      session$setInputs(code_mod = 1)
-    },
-    args = generate_plugin_args(board)
-  )
-})
-
-test_that("code export is gated on all blocks being ready", {
-
-  board <- new_board(
-    blocks = c(
-      a = new_dataset_block("BOD"),
-      c = new_merge_block(by = "Time")
-    )
-  )
-
-  testServer(
-    generate_code_server,
-    {
-      expect_false(code_export_ready(board))
-      expect_null(code())
+      expect_match(as.character(output$code_out), "merge", all = FALSE)
 
       session$setInputs(code_mod = 1)
     },
@@ -48,7 +26,7 @@ test_that("code export is gated on all blocks being ready", {
   )
 })
 
-test_that("code_export_ready settles on ready or dormant", {
+test_that("export would emit `NA` for an eval-complete but unbuilt board", {
 
   reactiveConsole(TRUE)
   on.exit(reactiveConsole(FALSE))
@@ -57,43 +35,88 @@ test_that("code_export_ready settles on ready or dormant", {
     blocks = c(a = new_dataset_block("BOD"), b = new_dataset_block("BOD"))
   )
 
-  make_rv <- function(...) {
-    list(eval = do.call(reactiveValues, list(...)), board = board)
+  # Only `a` carries an expression: `b` is reported ready but was never built.
+  # Handing this partial set to the exporter indexes `b` out of the block list
+  # and assigns to a variable literally named `NA` -- the junk this fix guards
+  # against.
+  junk <- export_wrapped_code(list(a = quote(datasets::BOD)), board)
+
+  expect_true(grepl("`NA` <-", junk, fixed = TRUE))
+
+  # code_export_state gates on the built set, so the plugin never reaches the
+  # exporter with `b` missing: it reports pending instead of exporting junk.
+  ro <- list(
+    eval = reactiveValues(a = reactive("ready"), b = reactive("ready")),
+    blocks = list(a = list(server = list(expr = reactive(quote(1))))),
+    board = board
+  )
+
+  expect_identical(code_export_state(ro), "pending")
+})
+
+test_that("code_export_state distinguishes ready, blocked and pending", {
+
+  reactiveConsole(TRUE)
+  on.exit(reactiveConsole(FALSE))
+
+  board <- new_board(
+    blocks = c(a = new_dataset_block("BOD"), b = new_dataset_block("BOD"))
+  )
+
+  make_ro <- function(...) {
+    status <- list(...)
+    list(
+      eval = do.call(reactiveValues, status),
+      blocks = set_names(vector("list", length(status)), names(status)),
+      board = board
+    )
   }
 
-  expect_true(
-    code_export_ready(make_rv(a = reactive("ready"), b = reactive("ready")))
+  expect_identical(
+    code_export_state(make_ro(a = reactive("ready"), b = reactive("ready"))),
+    "ready"
   )
-  expect_true(
-    code_export_ready(make_rv(a = reactive("ready"), b = reactive("dormant")))
-  )
-
-  expect_false(
-    code_export_ready(make_rv(a = reactive("ready"), b = reactive("waiting")))
-  )
-  expect_false(
-    code_export_ready(make_rv(a = reactive("ready"), b = reactive("unset")))
-  )
-  expect_false(
-    code_export_ready(make_rv(a = reactive("ready"), b = reactive("failed")))
+  expect_identical(
+    code_export_state(make_ro(a = reactive("ready"), b = reactive("dormant"))),
+    "ready"
   )
 
-  expect_false(
-    code_export_ready(make_rv(a = reactive("ready")))
+  expect_identical(
+    code_export_state(make_ro(a = reactive("ready"), b = reactive("waiting"))),
+    "blocked"
+  )
+  expect_identical(
+    code_export_state(make_ro(a = reactive("ready"), b = reactive("unset"))),
+    "blocked"
+  )
+  expect_identical(
+    code_export_state(make_ro(a = reactive("ready"), b = reactive("failed"))),
+    "blocked"
+  )
+
+  # a block still missing from the built set is pending, not blocked
+  expect_identical(
+    code_export_state(make_ro(a = reactive("ready"))),
+    "pending"
   )
 })
 
-test_that("code modal body shows script or a not-ready note", {
+test_that("code modal body shows a script, a preparing or a not-ready note", {
 
-  note <- code_modal_body(NULL)
+  ready <- code_modal_body("ready", "y <- 1")
 
-  expect_s3_class(note, "shiny.tag")
-  expect_match(as.character(note), "not ready")
+  expect_match(as.character(ready), "<pre>")
+  expect_match(as.character(ready), "y &lt;- 1")
 
-  body <- code_modal_body("y <- 1")
+  pending <- code_modal_body("pending")
 
-  expect_match(as.character(body), "<pre>")
-  expect_match(as.character(body), "y &lt;- 1")
+  expect_s3_class(pending, "shiny.tag")
+  expect_match(as.character(pending), "Preparing")
+
+  blocked <- code_modal_body("blocked")
+
+  expect_s3_class(blocked, "shiny.tag")
+  expect_match(as.character(blocked), "not ready")
 })
 
 test_that("require_all_blocks marks every block required on a gated board", {
@@ -144,6 +167,28 @@ test_that("require_all_blocks is a no-op when ungated or standalone", {
   expect_null(require_all_blocks(board, NULL))
 })
 
+test_that("require_all_blocks tolerates a block without a vis slot", {
+
+  reactiveConsole(TRUE)
+  on.exit(reactiveConsole(FALSE))
+
+  board <- list(
+    board = new_board(
+      blocks = c(a = new_dataset_block("BOD"), b = new_dataset_block("BOD"))
+    )
+  )
+
+  vis <- list(
+    required = new.env(parent = emptyenv()),
+    visible = new.env(parent = emptyenv())
+  )
+  add_vis_slots(vis, "a")
+  vis$required[["a"]](FALSE)
+
+  expect_no_error(require_all_blocks(board, vis))
+  expect_true(vis$required[["a"]]())
+})
+
 test_that("show code requires the whole board, gating export on config", {
 
   drive <- function(m) {
@@ -170,16 +215,24 @@ test_that("show code requires the whole board, gating export on config", {
         }
         session$flushReact()
 
-        built <- "m" %in% names(reactiveValuesToList(rv$eval))
+        ro <- list(eval = rv$eval, blocks = rv$blocks, board = rv$board)
+
+        pending <- code_export_state(ro)
+        pending_body <- as.character(code_modal_body(pending))
 
         require_all_blocks(list(board = rv$board), vis)
         session$flushReact()
 
+        ro <- list(eval = rv$eval, blocks = rv$blocks, board = rv$board)
+
         out <<- list(
-          built = built,
+          pending = pending,
+          pending_body = pending_body,
+          state = code_export_state(ro),
           status = reval_if(rv$eval[["m"]]),
-          ready = isTRUE(
-            code_export_ready(list(eval = rv$eval, board = rv$board))
+          script = export_wrapped_code(
+            lst_xtr_reval(rv$blocks, "server", "expr"),
+            rv$board
           )
         )
       },
@@ -191,14 +244,22 @@ test_that("show code requires the whole board, gating export on config", {
 
   configured <- drive(new_merge_block(by = "Time"))
 
-  expect_false(configured$built)
-  expect_identical(configured$status, "ready")
-  expect_true(configured$ready)
+  # before "Show code", `m` is unbuilt: pending, and never junk
+  expect_identical(configured$pending, "pending")
+  expect_false(grepl("`NA` <-", configured$pending_body, fixed = TRUE))
 
+  # after "Show code", the whole board is built and exports cleanly
+  expect_identical(configured$state, "ready")
+  expect_identical(configured$status, "ready")
+  expect_match(configured$script, "merge")
+  expect_false(grepl("`NA` <-", configured$script, fixed = TRUE))
+
+  # an unconfigured off-screen block holds the export back rather than
+  # exporting broken code
   unconfigured <- drive(new_merge_block())
 
+  expect_identical(unconfigured$state, "blocked")
   expect_identical(unconfigured$status, "unset")
-  expect_false(unconfigured$ready)
 })
 
 test_that("dummy add/rm block ui test", {


### PR DESCRIPTION
## Summary

Follow-up to #269. Under `background_construction_delay = Inf`, "Show code" either emitted a line assigning to a variable named `NA` for each unbuilt block, or opened no modal at all.

- The exporter reads each block's expression from `board$blocks` (the built servers), but the gate (`code_export_ready`) checked only `board$eval` status. When those disagree — an eval slot present for a block that was never built — the exporter indexes the missing id out of the block list and emits `` `NA` <- ... ``. The gate is now `code_export_state()`, keyed on the set of blocks that actually carry an expression, so a partial board reports pending / not-ready instead of exporting junk.
- `require_all_blocks()` called `visibility$required[[id]](TRUE)` unconditionally; a block without a visibility slot made that `NULL(TRUE)`, erroring the observer before `showModal()` ran — the "nothing at all" case. It now skips absent slots, so the modal always opens.
- The modal now has three states: the script when ready, "Preparing code..." while blocks materialize after the click, and the existing not-ready note when a block is left unconfigured.

Note on the `NA` divergence: in core alone, `board$eval` and `board$blocks` are written together in `construct_block()` and can't drift, so I couldn't reproduce the exact eval-complete/blocks-partial state a full board hits (it surfaces through the dock + deferred-restore timing). Gating on `board$blocks` — the exporter's real precondition — closes it regardless of how the drift arises, rather than pinning one repro.

Fixes #300