### PR TITLE
Make manage_links / manage_stacks plugins opt-in

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,15 @@
   plugins -- which typical front-ends (e.g. blockr.dock) replace with their
   own UI -- so a bare core install no longer pulls it in. Install `DT`
   alongside if you use either (#129).
+* The default board plugin set (`board_plugins()`) no longer includes
+  the `manage_links` and `manage_stacks` editor plugins, which render
+  their tables through `DT`. Including them by default made a bare core
+  board fail with `there is no package called 'DT'` once `DT` became a
+  Suggest, breaking consumer test apps built on the default board. Add
+  them back with `c(board_plugins(x), manage_links(), manage_stacks())`
+  to restore interactive link and stack editing; both constructors now
+  raise a clear error when `DT` is missing. Breaking for front-ends that
+  relied on the core editors in the default board (#297).
 * A board's `blockr_app_ui()` and `blockr_app_server()` methods now receive the
   request's parsed URL query parameters as a `query` argument, at both the GET
   and the websocket phase. A board subclass reads it to make the rendered UI and

--- a/R/board-plugins.R
+++ b/R/board-plugins.R
@@ -28,7 +28,11 @@
 #' called for their side effects of throwing errors in case of validation
 #' failure. Inheritance checkers `is_plugin()`/`is_plugins()` return scalar
 #' logicals and finally, the convenience function `board_plugins()` returns a
-#' `plugins` object with all known plugins (or a selected subset thereof).
+#' `plugins` object with the default set of plugins (or a selected subset
+#' thereof). The `manage_links` and `manage_stacks` link/stack editors are not
+#' part of this default set (they require the suggested \pkg{DT} package); add
+#' them explicitly with `c(board_plugins(x), manage_links(), manage_stacks())`
+#' to restore interactive link and stack editing.
 #'
 #' @export
 new_plugin <- function(server, ui = NULL, validator = abort_not_null,
@@ -320,8 +324,6 @@ board_plugins.board <- function(x, which = NULL, ...) {
   plugins <- plugins(
     preserve_board(),
     manage_blocks(),
-    manage_links(),
-    manage_stacks(),
     notify_user(),
     generate_code(),
     edit_block(),

--- a/R/plugin-links.R
+++ b/R/plugin-links.R
@@ -5,6 +5,11 @@
 #' alternate version of this plugin. The default implementation provides a
 #' table-based UI, presented in a modal.
 #'
+#' This plugin is not part of the default set returned by [board_plugins()];
+#' add it explicitly (e.g. `c(board_plugins(x), manage_links())`) to enable
+#' interactive link editing. Its table UI requires the suggested \pkg{DT}
+#' package.
+#'
 #' Updates are mediated via the [shiny::reactiveVal()] object passed as
 #' `update`, where link updates are communicated as list entry `stacks` with
 #' components `add`, `rm` or `mod`, where
@@ -23,6 +28,16 @@
 #'
 #' @export
 manage_links <- function(server = manage_links_server, ui = manage_links_ui) {
+
+  if (!pkg_avail("DT")) {
+    blockr_abort(
+      "The `manage_links` plugin requires the \"DT\" package. Install it ",
+      "with `install.packages(\"DT\")` or omit `manage_links()` from the ",
+      "board plugins.",
+      class = "manage_links_no_dt"
+    )
+  }
+
   new_plugin(server, ui, class = "manage_links")
 }
 

--- a/R/plugin-stacks.R
+++ b/R/plugin-stacks.R
@@ -5,6 +5,11 @@
 #' alternate version of this plugin. The default implementation provides a
 #' table-based UI, presented in a modal.
 #'
+#' This plugin is not part of the default set returned by [board_plugins()];
+#' add it explicitly (e.g. `c(board_plugins(x), manage_stacks())`) to enable
+#' interactive stack editing. Its table UI requires the suggested \pkg{DT}
+#' package.
+#'
 #' Updates are mediated via the [shiny::reactiveVal()] object passed as
 #' `update`, where stack updates are communicated as list entry `stacks` with
 #' components `add`, `rm` or `mod`, where
@@ -24,6 +29,15 @@
 #' @export
 manage_stacks <- function(server = manage_stacks_server,
                           ui = manage_stacks_ui) {
+
+  if (!pkg_avail("DT")) {
+    blockr_abort(
+      "The `manage_stacks` plugin requires the \"DT\" package. Install it ",
+      "with `install.packages(\"DT\")` or omit `manage_stacks()` from the ",
+      "board plugins.",
+      class = "manage_stacks_no_dt"
+    )
+  }
 
   new_plugin(server, ui, class = "manage_stacks")
 }

--- a/inst/examples/board/empty/app.R
+++ b/inst/examples/board/empty/app.R
@@ -1,3 +1,7 @@
 library(blockr.core)
 
-serve(new_board(), "my_board")
+serve(
+  new_board(),
+  "my_board",
+  plugins = custom_plugins(list(manage_links(), manage_stacks()))
+)

--- a/inst/examples/board/stack/app.R
+++ b/inst/examples/board/stack/app.R
@@ -13,5 +13,6 @@ serve(
     ),
     stacks = list(ac = c("a", "c"))
   ),
-  "my_board"
+  "my_board",
+  plugins = custom_plugins(list(manage_links(), manage_stacks()))
 )

--- a/man/manage_links.Rd
+++ b/man/manage_links.Rd
@@ -36,6 +36,11 @@ alternate version of this plugin. The default implementation provides a
 table-based UI, presented in a modal.
 }
 \details{
+This plugin is not part of the default set returned by \code{\link[=board_plugins]{board_plugins()}};
+add it explicitly (e.g. \code{c(board_plugins(x), manage_links())}) to enable
+interactive link editing. Its table UI requires the suggested \pkg{DT}
+package.
+
 Updates are mediated via the \code{\link[shiny:reactiveVal]{shiny::reactiveVal()}} object passed as
 \code{update}, where link updates are communicated as list entry \code{stacks} with
 components \code{add}, \code{rm} or \code{mod}, where

--- a/man/manage_stacks.Rd
+++ b/man/manage_stacks.Rd
@@ -36,6 +36,11 @@ alternate version of this plugin. The default implementation provides a
 table-based UI, presented in a modal.
 }
 \details{
+This plugin is not part of the default set returned by \code{\link[=board_plugins]{board_plugins()}};
+add it explicitly (e.g. \code{c(board_plugins(x), manage_stacks())}) to enable
+interactive stack editing. Its table UI requires the suggested \pkg{DT}
+package.
+
 Updates are mediated via the \code{\link[shiny:reactiveVal]{shiny::reactiveVal()}} object passed as
 \code{update}, where stack updates are communicated as list entry \code{stacks} with
 components \code{add}, \code{rm} or \code{mod}, where

--- a/man/new_plugin.Rd
+++ b/man/new_plugin.Rd
@@ -60,7 +60,11 @@ validators \code{validate_plugin()}/\code{validate_plugins()}, which are typical
 called for their side effects of throwing errors in case of validation
 failure. Inheritance checkers \code{is_plugin()}/\code{is_plugins()} return scalar
 logicals and finally, the convenience function \code{board_plugins()} returns a
-\code{plugins} object with all known plugins (or a selected subset thereof).
+\code{plugins} object with the default set of plugins (or a selected subset
+thereof). The \code{manage_links} and \code{manage_stacks} link/stack editors are not
+part of this default set (they require the suggested \pkg{DT} package); add
+them explicitly with \code{c(board_plugins(x), manage_links(), manage_stacks())}
+to restore interactive link and stack editing.
 }
 \description{
 A core mechanism for extending or customizing UX aspects of the board module

--- a/tests/testthat/test-board-plugins.R
+++ b/tests/testthat/test-board-plugins.R
@@ -1,5 +1,7 @@
 test_that("plugins", {
 
+  skip_if_not_installed("DT")
+
   a <- preserve_board()
   b <- manage_blocks()
 

--- a/vignettes/extend-blockr.qmd
+++ b/vignettes/extend-blockr.qmd
@@ -95,6 +95,8 @@ The legacy board supports the following plugins :
 - `edit_block()`: Implements how a block attributes such as titles are processed and rendered.
 - `edit_stack()`: Implements how a stack attributes such as names are processed and rendered.
 
+Of these, `manage_links()` and `manage_stacks()` are not part of the default plugin set: their table editors rely on the suggested DT package, so a bare board omits them. Add them back when serving with `plugins = custom_plugins(list(manage_links(), manage_stacks()))`, as the bundled example apps do.
+
 ### Override a plugin's server and ui functions
 
 We will work from an example, we want to modify the `manage_blocks()` plugin to use the `scoutbaR` package to search for blocks to add.


### PR DESCRIPTION
## Summary

- `manage_links()` / `manage_stacks()` (the link/stack table editors) are no longer part of the default `board_plugins()`. They render through `DT`, so shipping them by default made the default board — and any consumer test app built on it — require `DT` at runtime even though `DT` is only a Suggest. Once `DT` moved to Suggests (#292), `blockr.dm` and `blockr.dplyr` CI began failing with `there is no package called 'DT'`.
- #297's root-cause section is stale: the *default `block_ui`* stopped using `DT` in #292 (previews now render through `minimal_display`). The real dependency was these board editors — so the fix makes them opt-in rather than moving `DT` back to Imports, which would undo #292's decoupling. Full correction posted on the issue.
- Both constructors now guard on `DT` and raise an actionable error when it's absent, instead of a cryptic `loadNamespace` failure.
- The bundled `board/empty` and `board/stack` example apps re-add the editors via `custom_plugins()`, preserving the shinytest2 e2e coverage.

Front-ends that override `board_plugins` (`blockr.dock`, `blockr.ui`) are unaffected — they already exclude these editors. `blockr.dm` / `blockr.dplyr` can drop their `DT`-in-Suggests stopgap once this lands.

### Migration

A board that relied on the default link/stack editors must opt back in:

| Before | After |
| --- | --- |
| `serve(board)` | `serve(board, plugins = custom_plugins(list(manage_links(), manage_stacks())))` |

Fixes #297