### PR TITLE
Make visible a logical channel so is_visible tests isTRUE

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,15 @@
   through per-block `reactiveVal` channels it receives as `visibility` --
   `required` (which blocks are needed) and `visible` (which are on screen) --
   in place of the single `visible` write-channel. Breaking for front-ends.
+* The `visible` channel is now logical, mirroring `required`: a front-end
+  writes `TRUE` once a block is painted, `FALSE` once it is built but off
+  screen, and leaves `NA` until it is first built (it previously carried the
+  rendered view id, or `NA_character_` off screen). The extra state lets a
+  front-end distinguish "never built" from "built, off screen" on this one
+  channel, so it no longer has to reset the slot to unbuilt when a card
+  leaves the screen -- which would erase the "was built" fact the render gate
+  needs. `is_visible()` is accordingly `isTRUE()` rather than `!is.na()`.
+  Breaking for front-ends that wrote a view id (#306).
 * The `visibility` bundle carries a third channel, `frozen`, letting a
   front-end freeze a block's inputs server-side: setting
   `visibility$frozen[[id]](TRUE)` -- for example for a locked board that shows

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -38,9 +38,10 @@ board_server <- function(id, x, ...) {
 #' `required`, `visible` and `frozen`, each an environment of per-block
 #' `reactiveVal`s (core keeps one per board block as blocks are added and
 #' removed). Declare a block needed with `visibility$required[[id]](TRUE)` (or
-#' `FALSE` for built but dormant) and report the view it is rendered into with
-#' `visibility$visible[[id]](view)` (or `NA_character_` for off screen); the
-#' board reads both to gate construction, evaluation and rendering. Set
+#' `FALSE` for built but dormant) and report whether it is currently painted
+#' with `visibility$visible[[id]](TRUE)` (or `FALSE` once built but off screen,
+#' leaving `NA` until it is first built); the board reads both to gate
+#' construction, evaluation and rendering. Set
 #' `visibility$frozen[[id]](TRUE)` to freeze a block's inputs (for example when
 #' its controls are hidden), so a forged input can no longer steer it.
 #' @param callback_location Location of callback invocation (before or after
@@ -653,7 +654,7 @@ add_vis_slots <- function(vis, ids) {
 
   for (id in ids) {
     vis$required[[id]] <- reactiveVal(NA)
-    vis$visible[[id]] <- reactiveVal(NA_character_)
+    vis$visible[[id]] <- reactiveVal(NA)
     vis$frozen[[id]] <- reactiveVal(FALSE)
   }
 
@@ -700,7 +701,7 @@ slot_needed <- function(id, required) {
 }
 
 is_visible <- function(x) {
-  !is.na(x)
+  isTRUE(x)
 }
 
 block_visible <- function(id, vis) {
@@ -729,7 +730,7 @@ validate_vis <- function(vis) {
   for (id in ls(vis$visible)) {
     if (!valid_visible(vis$visible[[id]]())) {
       blockr_abort(
-        "visible[[{id}]] must be a non-empty string or NA_character_",
+        "visible[[{id}]] must be TRUE, FALSE or NA",
         class = "invalid_visible"
       )
     }
@@ -752,7 +753,7 @@ valid_required <- function(x) {
 }
 
 valid_visible <- function(x) {
-  is.character(x) && length(x) == 1L && (is.na(x) || nzchar(x))
+  is.logical(x) && length(x) == 1L
 }
 
 valid_frozen <- function(x) {

--- a/man/board_server.Rd
+++ b/man/board_server.Rd
@@ -34,9 +34,10 @@ additional observers. Each receives a \code{visibility} list with three channels
 \code{required}, \code{visible} and \code{frozen}, each an environment of per-block
 \code{reactiveVal}s (core keeps one per board block as blocks are added and
 removed). Declare a block needed with \code{visibility$required[[id]](TRUE)} (or
-\code{FALSE} for built but dormant) and report the view it is rendered into with
-\code{visibility$visible[[id]](view)} (or \code{NA_character_} for off screen); the
-board reads both to gate construction, evaluation and rendering. Set
+\code{FALSE} for built but dormant) and report whether it is currently painted
+with \code{visibility$visible[[id]](TRUE)} (or \code{FALSE} once built but off screen,
+leaving \code{NA} until it is first built); the board reads both to gate
+construction, evaluation and rendering. Set
 \code{visibility$frozen[[id]](TRUE)} to freeze a block's inputs (for example when
 its controls are hidden), so a forged input can no longer steer it.}
 

--- a/tests/testthat/test-plugin-code.R
+++ b/tests/testthat/test-plugin-code.R
@@ -211,7 +211,7 @@ test_that("show code requires the whole board, gating export on config", {
       {
         for (id in c("a", "b")) {
           vis$required[[id]](TRUE)
-          vis$visible[[id]]("main")
+          vis$visible[[id]](TRUE)
         }
         session$flushReact()
 

--- a/tests/testthat/test-visibility-gating.R
+++ b/tests/testthat/test-visibility-gating.R
@@ -178,7 +178,7 @@ require_blocks <- function(vis, ...) {
 render_blocks <- function(vis, ...) {
 
   for (id in c(...)) {
-    vis$visible[[id]]("main")
+    vis$visible[[id]](TRUE)
   }
 
   invisible()
@@ -886,10 +886,11 @@ test_that("an infinite background delay never arms the scheduler", {
   )
 })
 
-test_that("is_visible is a non-NA check on the slot value", {
+test_that("is_visible is an isTRUE check on the slot value", {
 
-  expect_true(is_visible("main"))
-  expect_false(is_visible(NA_character_))
+  expect_true(is_visible(TRUE))
+  expect_false(is_visible(FALSE))
+  expect_false(is_visible(NA))
 })
 
 test_that("channel validators enforce the required and visible contracts", {
@@ -900,11 +901,12 @@ test_that("channel validators enforce the required and visible contracts", {
   expect_false(valid_required("x"))
   expect_false(valid_required(NA_character_))
 
-  expect_true(valid_visible("main"))
-  expect_true(valid_visible(NA_character_))
-  expect_false(valid_visible(""))
-  expect_false(valid_visible(NA))
-  expect_false(valid_visible(c("a", "b")))
+  expect_true(valid_visible(TRUE))
+  expect_true(valid_visible(FALSE))
+  expect_true(valid_visible(NA))
+  expect_false(valid_visible("main"))
+  expect_false(valid_visible(NA_character_))
+  expect_false(valid_visible(c(TRUE, FALSE)))
 })
 
 test_that("validate_vis hard-errors on an off-contract slot", {
@@ -920,7 +922,7 @@ test_that("validate_vis hard-errors on an off-contract slot", {
     expect_error(validate_vis(vis), class = "invalid_required")
 
     vis$required[["a"]](TRUE)
-    vis$visible[["a"]]("")
+    vis$visible[["a"]]("main")
     expect_error(validate_vis(vis), class = "invalid_visible")
   })
 })
@@ -963,12 +965,12 @@ test_that("required_fulfilled holds only when every required block is shown", {
     add_vis_slots(vis, c("a", "b"))
     vis$required[["a"]](TRUE)
     vis$required[["b"]](TRUE)
-    vis$visible[["a"]]("main")
-    vis$visible[["b"]]("main")
+    vis$visible[["a"]](TRUE)
+    vis$visible[["b"]](TRUE)
 
     expect_true(required_fulfilled(vis))
 
-    vis$visible[["b"]](NA_character_)
+    vis$visible[["b"]](FALSE)
     expect_false(required_fulfilled(vis))
 
     empty <- list(


### PR DESCRIPTION
## Summary

- `visible` (the fulfillment channel of the `visibility` bundle) becomes a scalar logical `NA` / `FALSE` / `TRUE`, mirroring `required`. `is_visible()` is now `isTRUE()` rather than `!is.na()`, and `valid_visible()` enforces `is.logical(x) && length(x) == 1L`.
- The old `character` encoding (view-id / `NA_character_`) spent both representable states on painted-vs-not, so a front-end could not tell "never built this block's UI" from "built it, currently off screen". But the render gate forces the off-screen reset — leave `visible` set and it keeps rendering the card off screen — and resetting to `NA_character_` erased the "was built" fact. The logical channel carries that missing middle state: `!is.na(visible)` is the build ledger, `isTRUE(visible)` the render gate, on one channel.
- The stored view-id was never consumed (core reads only `is_visible()`, and no front-end reads the value), so collapsing the string to a logical loses nothing.

## Migration for front-ends

| state | before | after |
| --- | --- | --- |
| painted into a view | `visibility$visible[[id]](view_id)` | `visibility$visible[[id]](TRUE)` |
| built but off screen | `visibility$visible[[id]](NA_character_)` | `visibility$visible[[id]](FALSE)` |
| never built | leave `NA_character_` | leave `NA` |

Breaking for blockr.dock, which writes into `visible`. The coupled dock-side adaptation is carried by blockr.dock#378: it switches those writes to logicals (`TRUE` painted / `FALSE` built-but-off-screen) and can then fold its build ledger onto `!is.na(visible)` in place of the separate `visibility$built` axis. Core's own checks don't build dock, so this PR is green on its own; the `deps` block below points the merge-queue revdep at dock#378. The dock-consuming intermediates (dag / assistant) pull dock through a bare remote, so before merge they'll also need dock#378 pinned in via throwaway branches, exactly as the #273 / #274 rollout required.

```deps
BristolMyersSquibb/blockr.dock#378
BristolMyersSquibb/blockr.dag@core306-pin
BristolMyersSquibb/blockr.assistant@core306-pin
```

Fixes #306

