### PR TITLE
Surface a stale eval status for dormant blocks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -145,6 +145,13 @@
   `block_meta_*()` accessors report those defaults rather than a metadata read
   aborting -- so a cosmetic lookup can no longer take down a board whose
   registry has been curated (#299).
+* Blocks now carry a sixth eval status, `stale`. A dormant block (built but not
+  currently needed, so not evaluating) whose upstream has produced a new result
+  since it last evaluated reports `stale` rather than `dormant`, flagging that
+  its last-known result is out of date without forcing a re-evaluation. A
+  front-end can render it distinctly (e.g. a muted node badge); previously such
+  a block was indistinguishable from an up-to-date dormant one, so a break
+  introduced upstream stayed hidden until the block was visited (#310).
 
 # blockr.core 0.1.3
 

--- a/R/block-class.R
+++ b/R/block-class.R
@@ -111,7 +111,7 @@
 #' input (`state`) provided. Until then -- including while an upstream is itself
 #' still pending -- neither the validator nor the block expression run and no
 #' output is produced. See [block_server()] for the resulting eval status
-#' (`dormant` / `waiting` / `unset` / `failed` / `ready`).
+#' (`dormant` / `stale` / `waiting` / `unset` / `failed` / `ready`).
 #'
 #' Other conditions (messages and warnings) may be thrown as will be caught
 #' and displayed to the user but they will not interrupt evaluation. Errors

--- a/R/block-server.R
+++ b/R/block-server.R
@@ -17,14 +17,19 @@
 #' i.e. block user inputs and expression), and instantiation of the
 #' `edit_block` module (if passed from the parent scope).
 #'
-#' Each block carries an *eval status* -- one of `dormant`, `waiting`, `unset`,
-#' `failed` or `ready` -- which, together with its orthogonal front-end
+#' Each block carries an *eval status* -- one of `dormant`, `stale`, `waiting`,
+#' `unset`, `failed` or `ready` -- which, together with its orthogonal front-end
 #' visibility, determines its behaviour. The status separates the two input
 #' kinds (data
 #' inputs from links, user inputs from `state`) and a genuine failure:
 #' * `dormant` -- not *needed* (neither on screen nor feeding, transitively over
 #'   [board_links()], an on-screen block); inputs stay unfulfilled
 #'   ([shiny::req()] out) and nothing evaluates.
+#' * `stale` -- dormant, but an upstream has produced a new result since the
+#'   block last evaluated, so its last-known result is out of date. The block
+#'   is not re-evaluated while dormant; the status only reports that the cached
+#'   result no longer reflects its inputs, so a front-end can flag it (e.g. a
+#'   muted node badge) without forcing a recompute.
 #' * `waiting` -- needed, but a required *data* input is missing: unconnected,
 #'   below the required number of variadic `...args` inputs (one by default),
 #'   or fed by an upstream block that is not itself `ready` (see
@@ -291,6 +296,50 @@ block_server.block <- function(id, x, data = list(), block_id = id,
       # Last successful evaluation, for the unchanged-inputs skip below.
       last_eval <- new.env(parent = emptyenv())
 
+      # This block's own "are my inputs out of date" verdict, read by
+      # board_server in block_eval_status()'s dormant branch. Per upstream, so a
+      # dormant sibling doesn't mask a change; two cases per upstream:
+      #  * ready -- its result is safe to read; stale if it no longer matches,
+      #    by object identity, the result this block consumed from it
+      #    (`last_eval$consumed`, keyed by from-id, rebuilt each evaluation);
+      #  * dormant -- nothing to read (a dormant block's `result()` would
+      #    re-enter its guarded, req()-ing pipeline). It is either itself
+      #    `stale` (propagate) or fine.
+      input_stale <- reactive(
+        {
+          if (!isTRUE(last_eval$has)) {
+            return(FALSE)
+          }
+
+          srcs <- isolate(board$sources[[block_id]])
+
+          if (is.null(srcs)) {
+            return(FALSE)
+          }
+
+          for (from in unlst(reactiveValuesToList(srcs))) {
+
+            status <- reval_if(board$eval[[from]])
+
+            if (identical(status, "stale")) {
+              return(TRUE)
+            }
+
+            if (!identical(status, "ready")) {
+              next
+            }
+
+            cur <- upstream_result_now(from, board)
+
+            if (not_null(cur) && !same_ref(cur, last_eval$consumed[[from]])) {
+              return(TRUE)
+            }
+          }
+
+          FALSE
+        }
+      )
+
       res <- reactive(
         {
           if (!isTRUE(reval_if(gate)) || !isTRUE(data_valid()) ||
@@ -346,6 +395,22 @@ block_server.block <- function(id, x, data = list(), block_id = id,
           last_eval$data <- eval_data
           last_eval$trigger <- eval_trigger
           last_eval$result <- result
+
+          # Record what we just consumed from each upstream, keyed by from-id,
+          # for input_stale's dormant check. Rebuilt whole each evaluation, so a
+          # swapped-out or removed upstream leaves no lingering entry.
+          srcs <- isolate(board$sources[[block_id]])
+
+          froms <- character()
+
+          if (not_null(srcs)) {
+            froms <- unlst(reactiveValuesToList(srcs))
+          }
+
+          last_eval$consumed <- set_names(
+            isolate(lapply(froms, upstream_result_now, board)),
+            froms
+          )
 
           result
         },
@@ -421,6 +486,7 @@ block_server.block <- function(id, x, data = list(), block_id = id,
       c(
         list(
           result = res,
+          input_stale = input_stale,
           state_ready = state_ready,
           failed = failed,
           expr = lang,
@@ -520,6 +586,16 @@ same_ref <- function(x, y) {
 same_refs <- function(x, y) {
   identical(names(x), names(y)) &&
     identical(chr_ply(x, rlang::obj_address), chr_ply(y, rlang::obj_address))
+}
+
+# A (ready) upstream's current result. Only ever read once the caller has
+# confirmed the upstream is `ready`: a dormant block's `result()` would re-enter
+# its guarded pipeline and req() out.
+upstream_result_now <- function(from, rv) {
+
+  srv <- isolate(rv$blocks[[from]])[["server"]]
+
+  if (is.null(srv)) NULL else srv$result()
 }
 
 eval_impl <- function(x, expr, dat) {

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -805,6 +805,16 @@ input_ready <- function(from, rv) {
 block_eval_status <- function(rv, id, inputs_ready, srv) {
 
   if (!block_needed(rv, id)) {
+
+    # A dormant block reports `stale` on its own verdict (`input_stale`): a
+    # ready upstream's result no longer matches what it consumed, or a direct
+    # upstream is itself `stale` -- so a change flows through the whole
+    # downstream cone, one dependency hop at a time. Depending on the upstreams
+    # is what wakes this status (and the badge) without re-evaluating the block.
+    if (isTRUE(srv$input_stale())) {
+      return("stale")
+    }
+
     return("dormant")
   }
 

--- a/R/plugin-code.R
+++ b/R/plugin-code.R
@@ -96,7 +96,7 @@ code_export_state <- function(board) {
     return("pending")
   }
 
-  if (all(chr_ply(status, reval_if) %in% c("ready", "dormant"))) {
+  if (all(chr_ply(status, reval_if) %in% c("ready", "dormant", "stale"))) {
     return("ready")
   }
 

--- a/man/block_server.Rd
+++ b/man/block_server.Rd
@@ -95,8 +95,8 @@ of the block expression server (handling the block-specific functionality,
 i.e. block user inputs and expression), and instantiation of the
 \code{edit_block} module (if passed from the parent scope).
 
-Each block carries an \emph{eval status} -- one of \code{dormant}, \code{waiting}, \code{unset},
-\code{failed} or \code{ready} -- which, together with its orthogonal front-end
+Each block carries an \emph{eval status} -- one of \code{dormant}, \code{stale}, \code{waiting},
+\code{unset}, \code{failed} or \code{ready} -- which, together with its orthogonal front-end
 visibility, determines its behaviour. The status separates the two input
 kinds (data
 inputs from links, user inputs from \code{state}) and a genuine failure:
@@ -104,6 +104,11 @@ inputs from links, user inputs from \code{state}) and a genuine failure:
 \item \code{dormant} -- not \emph{needed} (neither on screen nor feeding, transitively over
 \code{\link[=board_links]{board_links()}}, an on-screen block); inputs stay unfulfilled
 (\code{\link[shiny:req]{shiny::req()}} out) and nothing evaluates.
+\item \code{stale} -- dormant, but an upstream has produced a new result since the
+block last evaluated, so its last-known result is out of date. The block
+is not re-evaluated while dormant; the status only reports that the cached
+result no longer reflects its inputs, so a front-end can flag it (e.g. a
+muted node badge) without forcing a recompute.
 \item \code{waiting} -- needed, but a required \emph{data} input is missing: unconnected,
 below the required number of variadic \code{...args} inputs (one by default),
 or fed by an upstream block that is not itself \code{ready} (see

--- a/man/new_block.Rd
+++ b/man/new_block.Rd
@@ -202,7 +202,7 @@ Ahead of validation, a block must have its inputs available: every required
 input (\code{state}) provided. Until then -- including while an upstream is itself
 still pending -- neither the validator nor the block expression run and no
 output is produced. See \code{\link[=block_server]{block_server()}} for the resulting eval status
-(\code{dormant} / \code{waiting} / \code{unset} / \code{failed} / \code{ready}).
+(\code{dormant} / \code{stale} / \code{waiting} / \code{unset} / \code{failed} / \code{ready}).
 
 Other conditions (messages and warnings) may be thrown as will be caught
 and displayed to the user but they will not interrupt evaluation. Errors

--- a/tests/testthat/test-visibility-gating.R
+++ b/tests/testthat/test-visibility-gating.R
@@ -415,6 +415,234 @@ test_that("a needed round trip with unchanged inputs does not re-evaluate", {
   )
 })
 
+test_that("a dormant block reports stale when an upstream re-evaluates", {
+
+  reset_probes()
+
+  withr::local_options(blockr.background_construction_delay = 0)
+
+  board <- new_board(
+    blocks = c(
+      s1 = with_id(probe_source(), "s1"),
+      s2 = with_id(probe_source_alt(), "s2"),
+      a = with_id(probe_passthrough(), "a"),
+      r = with_id(probe_passthrough(), "r")
+    ),
+    links = links(
+      sa = new_link("s1", "a", "data"),
+      ar = new_link("a", "r", "data")
+    )
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      expect_true(evaluated("a"))
+      expect_true(evaluated("r"))
+      expect_identical(rv$eval[["r"]](), "ready")
+
+      # Park r off-screen: it drops out of the eval set and goes dormant, while
+      # a stays required (its panel is still open).
+      vis$required[["r"]](FALSE)
+      session$flushReact()
+
+      expect_identical(rv$eval[["r"]](), "dormant")
+
+      # Re-route a from s1 to s2 (a different dataset): a re-evaluates to a new
+      # result, breaking r's cached input -- but r is dormant and never re-runs.
+      reset_probes()
+
+      board_update(
+        list(
+          links = list(
+            rm = "sa",
+            add = links(s2a = new_link("s2", "a", "data"))
+          )
+        )
+      )
+      session$flushReact()
+
+      expect_true(evaluated("a"))
+      expect_false(evaluated("r"))
+
+      # r's reported status now reflects that its last-known result is stale.
+      expect_identical(rv$eval[["r"]](), "stale")
+    },
+    args = list(
+      x = board,
+      plugins = list(),
+      callbacks = function(visibility, ...) {
+        require_blocks(visibility, "a", "r")
+        render_blocks(visibility, "a", "r")
+      }
+    )
+  )
+})
+
+test_that("a dormant block whose upstreams are unchanged stays dormant", {
+
+  reset_probes()
+
+  withr::local_options(blockr.background_construction_delay = 0)
+
+  board <- new_board(
+    blocks = c(
+      s = with_id(probe_source(), "s"),
+      a = with_id(probe_passthrough(), "a"),
+      r = with_id(probe_passthrough(), "r")
+    ),
+    links = links(
+      sa = new_link("s", "a", "data"),
+      ar = new_link("a", "r", "data")
+    )
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      expect_identical(rv$eval[["r"]](), "ready")
+
+      # Park the whole chain, as a view switch does: r and its upstream a both
+      # go dormant. a's last result survives dormancy, so r's cached input still
+      # matches and r is not stale.
+      vis$required[["a"]](FALSE)
+      vis$required[["r"]](FALSE)
+      session$flushReact()
+
+      expect_identical(rv$eval[["a"]](), "dormant")
+      expect_identical(rv$eval[["r"]](), "dormant")
+    },
+    args = list(
+      x = board,
+      plugins = list(),
+      callbacks = function(visibility, ...) {
+        require_blocks(visibility, "a", "r")
+        render_blocks(visibility, "a", "r")
+      }
+    )
+  )
+})
+
+test_that("staleness propagates to the whole dormant downstream cone", {
+
+  reset_probes()
+
+  withr::local_options(blockr.background_construction_delay = 0)
+
+  board <- new_board(
+    blocks = c(
+      s1 = with_id(probe_source(), "s1"),
+      s2 = with_id(probe_source_alt(), "s2"),
+      a = with_id(probe_passthrough(), "a"),
+      b = with_id(probe_passthrough(), "b"),
+      r = with_id(probe_passthrough(), "r")
+    ),
+    links = links(
+      s1a = new_link("s1", "a", "data"),
+      ab = new_link("a", "b", "data"),
+      br = new_link("b", "r", "data")
+    )
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      expect_identical(rv$eval[["r"]](), "ready")
+
+      # Park b and r off-screen; a stays required so it re-evaluates below.
+      vis$required[["b"]](FALSE)
+      vis$required[["r"]](FALSE)
+      session$flushReact()
+
+      expect_identical(rv$eval[["b"]](), "dormant")
+      expect_identical(rv$eval[["r"]](), "dormant")
+
+      # Re-route a to a new dataset: a re-evaluates. b (a's direct downstream)
+      # is stale from the changed input; r is stale transitively via b, even
+      # though b -- being dormant -- never re-evaluated.
+      board_update(
+        list(
+          links = list(
+            rm = "s1a",
+            add = links(s2a = new_link("s2", "a", "data"))
+          )
+        )
+      )
+      session$flushReact()
+
+      expect_identical(rv$eval[["b"]](), "stale")
+      expect_identical(rv$eval[["r"]](), "stale")
+    },
+    args = list(
+      x = board,
+      plugins = list(),
+      callbacks = function(visibility, ...) {
+        require_blocks(visibility, "a", "b", "r")
+        render_blocks(visibility, "a", "b", "r")
+      }
+    )
+  )
+})
+
+test_that("re-routing a dormant block's input marks it stale", {
+
+  reset_probes()
+
+  withr::local_options(blockr.background_construction_delay = 0)
+
+  board <- new_board(
+    blocks = c(
+      a = with_id(probe_source(), "a"),
+      b = with_id(probe_source_alt(), "b"),
+      r = with_id(probe_passthrough(), "r")
+    ),
+    links = links(ar = new_link("a", "r", "data"))
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      expect_identical(rv$eval[["r"]](), "ready")
+
+      # Park r; a and b stay required (both ready).
+      vis$required[["r"]](FALSE)
+      session$flushReact()
+
+      expect_identical(rv$eval[["r"]](), "dormant")
+
+      reset_probes()
+
+      # Swap r's input from a to b. r never re-evaluates, but its consumed input
+      # (a's result) is no longer what feeds it, so it is stale.
+      board_update(
+        list(
+          links = list(rm = "ar", add = links(br = new_link("b", "r", "data")))
+        )
+      )
+      session$flushReact()
+
+      expect_false(evaluated("r"))
+      expect_identical(rv$eval[["r"]](), "stale")
+    },
+    args = list(
+      x = board,
+      plugins = list(),
+      callbacks = function(visibility, ...) {
+        require_blocks(visibility, "a", "b", "r")
+        render_blocks(visibility, "a", "b", "r")
+      }
+    )
+  )
+})
+
 test_that("a view switch does not re-evaluate shared upstream left needed", {
 
   reset_probes()


### PR DESCRIPTION
## Summary

- Under deferred evaluation a dormant block does not re-run on an upstream change, so a break introduced upstream (e.g. editing a dataset block so a downstream `rbind` can no longer combine) stayed hidden — the block's node badge kept its non-error look until it was visited and re-entered the eval set. Only core has the dependency graph and eval provenance to tell that a dormant block is now stale, which is why the fix belongs here rather than in the badge layer.
- Adds a sixth eval status, `stale`: a dormant block whose input is out of date reports `stale` instead of `dormant`, without being re-evaluated.
- Each block owns its own verdict (`input_stale`), checked per upstream by object identity — no board-side bookkeeping and no extra published result. For each upstream: if it is `ready`, its result is safe to read and the block is stale when that result no longer matches what it consumed; if it is dormant, its result is *not* read (that would re-enter the dormant block's guarded, `req()`-ing pipeline), and it instead propagates via its status — a dormant upstream that is itself `stale` makes this block stale too, so a change flows through the whole downstream cone one dependency hop at a time. `block_eval_status()` reports `stale` in the dormant branch when the verdict holds. Depending on the upstreams' results/statuses is also what wakes the status (and the badge) on a change; parking a subtree off screen reads no results, so it doesn't false-positive.
- `code_export_state()` treats `stale` like `dormant`. The dock / dag node badges (BristolMyersSquibb/blockr.dock#314, BristolMyersSquibb/blockr.dag#145) can now render it as a muted / pending badge — a follow-up in those repos.

Fixes #310