### PR TITLE
Sweep leaked Chrome temp dirs unconditionally on CI after a settle

### DIFF
--- a/tests/testthat/setup-chrome-ci.R
+++ b/tests/testthat/setup-chrome-ci.R
@@ -16,25 +16,42 @@ withr::local_options(
 # gate fails on. `app$stop()` only ends the shinytest2 session; the shared
 # browser stays alive until R exits, so its scratch is never reclaimed. At the
 # end of the suite, close the browser (a clean shutdown reclaims its scratch),
-# then sweep anything that still leaked -- but only what this run created, so a
-# shared `$TMPDIR` on a developer machine keeps its other dirs.
+# then sweep anything that still leaked.
+#
+# On CI the sweep is unconditional. Closing the browser waits for its main
+# process, but a Chrome helper (crashpad, zygote) can drop a fresh scratch dir
+# a moment later -- past a snapshot taken here -- so settle first, then remove
+# every match. A throwaway runner has no unrelated dirs to protect. Locally,
+# keep the conservative `setdiff(before)` so a shared `$TMPDIR` retains its own.
 local({
 
   pat <- "^(com\\.google\\.Chrome|org\\.chromium\\.Chromium)"
   tmp_parent <- dirname(tempdir())
   before <- list.files(tmp_parent, pattern = pat)
+  on_ci <- nzchar(Sys.getenv("CI"))
 
   withr::defer(
     {
-      if (isTRUE(chromote::has_default_chromote_object())) {
+      had_browser <- isTRUE(chromote::has_default_chromote_object())
+
+      if (had_browser) {
         try(chromote::default_chromote_object()$close(), silent = TRUE)
       }
 
+      if (on_ci) {
+
+        if (had_browser) {
+          Sys.sleep(2)
+        }
+
+        leaked <- list.files(tmp_parent, pattern = pat)
+
+      } else {
+        leaked <- setdiff(list.files(tmp_parent, pattern = pat), before)
+      }
+
       unlink(
-        file.path(
-          tmp_parent,
-          setdiff(list.files(tmp_parent, pattern = pat), before)
-        ),
+        file.path(tmp_parent, leaked),
         recursive = TRUE,
         force = TRUE
       )


### PR DESCRIPTION
## Summary

- The suite-teardown sweep in `setup-chrome-ci.R` snapshots the `com.google.Chrome.*` / `org.chromium.Chromium.*` dirs once and unlinks only those absent at setup (`setdiff(before)`). A Chrome helper process can drop a fresh scratch dir a moment after the browser's main process is reaped — past that snapshot — so it survives the sweep, and `R CMD check`'s detritus NOTE then ejects the PR from the merge queue. That is the residual race reported here (observed on #307's `merge_group`), not the pre-#233 case a rebase fixes.
- On CI, close the browser, settle briefly so a straggler finishes, then unlink **every** matching dir. A throwaway runner has no unrelated dirs to protect, so dropping the `setdiff(before)` guard is safe and removes the reliance on a single well-timed snapshot. Gated on `nzchar(Sys.getenv("CI"))`; locally the conservative sweep is unchanged, so a shared `$TMPDIR` keeps its other dirs.
- On the issue's "close every live chromote session" idea: `shinytest2`'s `AppDriver` opens its session via `chromote::default_chromote_object()$new_session()`, so every session is a tab under the one default object. Closing that object — already done, and `close(wait = TRUE)` waits for the main process — covers them all; there is no second session to enumerate. The residual leak is a helper outliving the reaped main process, which the settle + unconditional sweep handles directly.

Fixes #312