### PR TITLE
Extract a pure apply_board_update() reducer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # blockr.core 0.1.4
 
+* `apply_board_update()` is now a real reducer rather than a no-op: its
+  default `.board` method applies the core delta (block, link and stack
+  mutations) to the supplied board and returns it, and update validation
+  now checks that applying the delta yields a valid board instead of
+  re-deriving the merged references. Extensions overriding
+  `apply_board_update()` must compose with `NextMethod()` to pick up the
+  core apply before layering their own payload slots (as blockr.dock does
+  for views). Breaking for front-ends that override the apply generic
+  (#311).
 * Block result previews now dispatch through a *tabular display*: an S3
   object bundling the output container, render function, render trigger
   and board options for a single result class, kept in sync by living on

--- a/R/board-class.R
+++ b/R/board-class.R
@@ -357,8 +357,7 @@ rm_blocks.board <- function(x, rm, ..., session = get_session()) {
 #' of interest, this is available as `board_link_ids()`, which is short for
 #' `names(board_links(x))`. A (generic) convenience function for all kinds of
 #' updates to board links in one is available as `modify_board_links()`. With
-#' arguments `add`, `rm` and `mod`, links can be added, removed or modified in
-#' one go.
+#' arguments `add` and `rm`, links can be added or removed in one go.
 #'
 #' @rdname board_blocks
 #' @export
@@ -382,13 +381,13 @@ board_link_ids <- function(x) {
 }
 
 #' @param add Links/stacks to add
-#' @param mod Link/stacks to modify
+#' @param mod Stacks to modify
 #' @rdname board_blocks
 #' @export
-modify_board_links <- function(x, add = NULL, rm = NULL, mod = NULL, ...,
+modify_board_links <- function(x, add = NULL, rm = NULL, ...,
                                session = get_session()) {
 
-  if (!length(add) && !length(rm) && !length(mod)) {
+  if (!length(add) && !length(rm)) {
     return(x)
   }
 
@@ -396,8 +395,8 @@ modify_board_links <- function(x, add = NULL, rm = NULL, mod = NULL, ...,
 }
 
 #' @export
-modify_board_links.board <- function(x, add = NULL, rm = NULL, mod = NULL,
-                                     ..., session = get_session()) {
+modify_board_links.board <- function(x, add = NULL, rm = NULL, ...,
+                                     session = get_session()) {
 
   links <- board_links(x)
 
@@ -416,10 +415,6 @@ modify_board_links.board <- function(x, add = NULL, rm = NULL, mod = NULL,
   if (length(rm)) {
     stopifnot(is.character(rm), all(rm %in% names(links)))
     links <- links[!names(links) %in% rm]
-  }
-
-  if (length(mod)) {
-    links[names(mod)] <- mod
   }
 
   board_links(x) <- c(links, add)

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -292,18 +292,6 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
                 vis = vis
               )
 
-              new_board <- do.call(
-                apply_board_update,
-                c(
-                  list(rv$board, upd),
-                  dot_args,
-                  list(session = session)
-                )
-              )
-
-              stopifnot(is_board(new_board))
-              rv$board <- new_board
-
               record_update_outcome(TRUE, "apply")
             },
             error = function(e) {
@@ -889,14 +877,7 @@ apply_block_mod_delta <- function(blk_id, delta, rv) {
   invisible()
 }
 
-destroy_rm_blocks <- function(ids, rv, sess, args) {
-
-  links <- board_links(rv$board)
-
-  update_block_links(
-    rv,
-    rm = links[links_incident(links, ids)]
-  )
+destroy_rm_blocks <- function(ids, rv, sess) {
 
   for (id in ids) {
     sess$destroy(paste0("block_", id))
@@ -918,11 +899,6 @@ destroy_rm_blocks <- function(ids, rv, sess, args) {
       rm(list = id, envir = slots)
     }
   }
-
-  rv$board <- do.call(
-    rm_blocks,
-    c(list(rv$board, ids), args, list(session = sess))
-  )
 
   invisible()
 }
@@ -1205,14 +1181,20 @@ add_blocks_to_stacks <- function(rv, add, session) {
 #' fixups; an error thrown here aborts the update before apply runs.
 #'
 #' @section Apply:
-#' The default `.board` method returns the supplied board unchanged —
-#' the core apply path (block / link / stack mutation, block UI
-#' insertion / removal) is not routed through this generic. Subclass
-#' methods receive a plain `board` snapshot (no reactive surface) and
-#' return a `board`, which the final observer assigns back to
-#' `rv$board`. For piecemeal customization of the core apply path
-#' itself, override the relevant sub-generic
-#' ([modify_board_links()], [insert_block_ui()], etc.) instead.
+#' The default `.board` method applies the core delta to the supplied
+#' board and returns it: added blocks are appended, link and stack
+#' deltas are folded in through [modify_board_links()] /
+#' [modify_board_stacks()], and removed blocks are dropped last (once
+#' the earlier steps have freed them of every link and stack). Subclass
+#' methods compose with `NextMethod()` to layer their own payload slots
+#' on top of the core-updated board (blockr.dock, for instance,
+#' cascades view membership), so a single [apply_board_update()] call
+#' yields the full board for any subclass. The board handed in is a
+#' plain `board` snapshot with no reactive surface; the returned
+#' `board` is what the final observer assigns back to `rv$board`. The
+#' reactive side effects that mirror the delta — block UI insertion /
+#' removal, server construction / teardown, link and stack wiring — run
+#' around this single reduce.
 #'
 #' Errors thrown from either augment or apply are caught by the
 #' observer, reported via [notify()], and the reactive is reset so the
@@ -1362,10 +1344,6 @@ validate_board_update_structure <- function(payload, board) {
 
 has_comp <- function(comp, x) {
   comp %in% names(x) && length(x[[comp]])
-}
-
-has_comps <- function(comps, x, fun = `||`) {
-  Reduce(fun, lgl_ply(comps, has_comp, x))
 }
 
 validate_board_update_blocks <- function(x, board) {
@@ -1546,96 +1524,11 @@ merge_stack_mods <- function(board, mod) {
   as_stacks(Map(update_stack, board_stacks(board)[names(mod)], mod))
 }
 
-combine_update_blocks <- function(upd, board) {
-
-  all_blks <- board_blocks(board)
-
-  if (!has_comp("blocks", upd)) {
-    return(all_blks)
-  }
-
-  blk <- upd$blocks
-
-  if (has_comp("rm", blk)) {
-    all_blks <- all_blks[setdiff(names(all_blks), blk$rm)]
-  }
-
-  if (has_comp("add", blk)) {
-    all_blks <- c(all_blks, blk$add)
-  }
-
-  all_blks
-}
-
-combine_update_links <- function(upd, board) {
-
-  all_lnks <- board_links(board)
-
-  if (!has_comp("links", upd)) {
-    return(all_lnks)
-  }
-
-  lnk <- upd$links
-
-  if (has_comp("rm", lnk)) {
-    all_lnks <- all_lnks[setdiff(names(all_lnks), lnk$rm)]
-  }
-
-  if (has_comp("mod", lnk)) {
-    all_lnks <- c(
-      all_lnks[setdiff(names(all_lnks), names(lnk$mod))],
-      merge_link_mods(board, lnk$mod)
-    )
-  }
-
-  if (has_comp("add", lnk)) {
-    all_lnks <- c(all_lnks, lnk$add)
-  }
-
-  all_lnks
-}
-
-combine_update_stacks <- function(upd, board) {
-
-  all_stks <- board_stacks(board)
-
-  if (!has_comp("stacks", upd)) {
-    return(all_stks)
-  }
-
-  stk <- upd$stacks
-
-  if (has_comp("rm", stk)) {
-    all_stks <- all_stks[setdiff(names(all_stks), stk$rm)]
-  }
-
-  if (has_comp("mod", stk)) {
-    all_stks <- c(
-      all_stks[setdiff(names(all_stks), names(stk$mod))],
-      merge_stack_mods(board, stk$mod)
-    )
-  }
-
-  if (has_comp("add", stk)) {
-    all_stks <- c(all_stks, stk$add)
-  }
-
-  all_stks
-}
-
 validate_board_update_result <- function(payload, board) {
 
-  payload <- augment_board_update(payload, board)
-
-  blks <- combine_update_blocks(payload, board)
-
-  if (has_comps(c("add", "mod"), payload$links)) {
-    validate_board_blocks_links(blks, combine_update_links(payload, board))
-  }
-
-  if (has_comps(c("add", "mod"), payload$stacks)) {
-    validate_board_blocks_stacks(blks, combine_update_stacks(payload, board))
-  }
+  validate_board(
+    apply_board_update(board, augment_board_update(payload, board))
+  )
 
   invisible()
 }
@@ -1779,6 +1672,32 @@ apply_board_update <- function(board, upd, ...,
 #' @export
 apply_board_update.board <- function(board, upd, ...,
                                      session = get_session()) {
+
+  if (length(upd$blocks$add)) {
+    board_blocks(board) <- c(board_blocks(board), upd$blocks$add)
+  }
+
+  add <- upd$links$add
+  rm <- upd$links$rm
+
+  if (length(upd$links$mod)) {
+    add <- vec_c(add, merge_link_mods(board, upd$links$mod))
+    rm <- c(rm, names(upd$links$mod))
+  }
+
+  board <- modify_board_links(board, add, rm, ..., session = session)
+
+  board <- modify_board_stacks(
+    board, upd$stacks$add, upd$stacks$rm,
+    merge_stack_mods(board, upd$stacks$mod),
+    ...,
+    session = session
+  )
+
+  if (length(upd$blocks$rm)) {
+    board <- rm_blocks(board, upd$blocks$rm, ..., session = session)
+  }
+
   board
 }
 
@@ -1788,6 +1707,66 @@ apply_core_board_update <- function(rv, upd, session,
                                     dot_args = list()) {
 
   ns <- session$ns
+
+  lnk_add <- upd$links$add
+  lnk_rm <- upd$links$rm
+
+  if (length(upd$links$mod)) {
+    lnk_add <- vec_c(lnk_add, merge_link_mods(rv$board, upd$links$mod))
+    lnk_rm <- c(lnk_rm, names(upd$links$mod))
+  }
+
+  # Links into a block that is added or removed in this update are wired by
+  # construct_block() / dropped by destroy_rm_blocks(); the reactive link delta
+  # below only touches links between surviving blocks. Resolve it (and the stack
+  # mod deltas) against the pre-update board before the reduce rewrites it.
+  lifecycle_blocks <- c(names(upd$blocks$add), upd$blocks$rm)
+  between_survivors <- function(x) {
+    if (length(x)) x[!field(x, "to") %in% lifecycle_blocks] else x
+  }
+
+  cur_links <- board_links(rv$board)
+
+  lnk_add <- between_survivors(lnk_add)
+  lnk_rm <- between_survivors(cur_links[intersect(lnk_rm, names(cur_links))])
+
+  stk <- upd$stacks
+
+  if (length(stk$mod)) {
+    stk$mod <- merge_stack_mods(rv$board, stk$mod)
+  }
+
+  # Tear down removed blocks before the reduce drops them from the board: the
+  # remove_block_ui() method (e.g. blockr.dock's) asserts the block is still
+  # present and reads it to locate the live panel it detaches.
+  if (length(upd$blocks$rm)) {
+
+    log_debug("removing block{?s} {names(upd$blocks$rm)}")
+
+    do.call(
+      remove_block_ui,
+      c(
+        list(ns(NULL), rv$board, upd$blocks$rm),
+        dot_args,
+        list(
+          edit_ui = edit_block,
+          ctrl_ui = ctrl_block,
+          session = session
+        )
+      )
+    )
+
+    destroy_rm_blocks(upd$blocks$rm, rv, session)
+
+    rm_vis_slots(vis, upd$blocks$rm)
+  }
+
+  rv$board <- do.call(
+    apply_board_update,
+    c(list(rv$board, upd), dot_args, list(session = session))
+  )
+
+  stopifnot(is_board(rv$board))
 
   if (length(upd$blocks$add)) {
 
@@ -1807,8 +1786,6 @@ apply_core_board_update <- function(rv, upd, session,
         )
       )
     )
-
-    board_blocks(rv$board) <- c(board_blocks(rv$board), upd$blocks$add)
 
     construct_blocks(names(upd$blocks$add), rv, edit_block, ctrl_block,
                      edit_plugin_args, vis)
@@ -1830,87 +1807,20 @@ apply_core_board_update <- function(rv, upd, session,
     }
   }
 
-  if (length(upd$links$mod)) {
+  if (length(lnk_add) || length(lnk_rm)) {
 
-    upd$links$add <- vec_c(
-      upd$links$add,
-      merge_link_mods(rv$board, upd$links$mod)
-    )
-    upd$links$rm <- c(upd$links$rm, names(upd$links$mod))
-  }
-
-  if (length(upd$links$add) || length(upd$links$rm)) {
-
-    if (length(upd$links$add)) {
-      log_debug("adding link{?s} {names(upd$links$add)}")
+    if (length(lnk_add)) {
+      log_debug("adding link{?s} {names(lnk_add)}")
     }
 
-    if (length(upd$links$rm)) {
-      log_debug("removing link{?s} {names(upd$links$rm)}")
+    if (length(lnk_rm)) {
+      log_debug("removing link{?s} {names(lnk_rm)}")
     }
 
-    rm <- board_links(rv$board)[upd$links$rm]
-    update_block_links(rv, upd$links$add, rm)
-
-    rv$board <- do.call(
-      modify_board_links,
-      c(
-        list(rv$board, upd$links$add, upd$links$rm),
-        dot_args,
-        list(session = session)
-      )
-    )
+    update_block_links(rv, lnk_add, lnk_rm)
   }
 
-  if (length(upd$stacks$rm)) {
-    log_debug("removing stack{?s} {names(upd$stacks$rm)}")
-  }
-
-  if (length(upd$stacks$add)) {
-    log_debug("adding stack{?s} {names(upd$stacks$add)}")
-  }
-
-  if (length(upd$stacks$mod)) {
-
-    log_debug("modifying stack{?s} {names(upd$stacks$mod)}")
-
-    upd$stacks$mod <- merge_stack_mods(rv$board, upd$stacks$mod)
-  }
-
-  update_stack_blocks(
-    rv, upd$stacks, edit_stack, edit_plugin_args, session
-  )
-
-  rv$board <- do.call(
-    modify_board_stacks,
-    c(
-      list(rv$board, upd$stacks$add, upd$stacks$rm, upd$stacks$mod),
-      dot_args,
-      list(session = session)
-    )
-  )
-
-  if (length(upd$blocks$rm)) {
-
-    log_debug("removing block{?s} {names(upd$blocks$rm)}")
-
-    do.call(
-      remove_block_ui,
-      c(
-        list(ns(NULL), rv$board, upd$blocks$rm),
-        dot_args,
-        list(
-          edit_ui = edit_block,
-          ctrl_ui = ctrl_block,
-          session = session
-        )
-      )
-    )
-
-    destroy_rm_blocks(upd$blocks$rm, rv, session, dot_args)
-
-    rm_vis_slots(vis, upd$blocks$rm)
-  }
+  update_stack_blocks(rv, stk, edit_stack, edit_plugin_args, session)
 
   invisible()
 }

--- a/man/board_blocks.Rd
+++ b/man/board_blocks.Rd
@@ -34,14 +34,7 @@ board_links(x) <- value
 
 board_link_ids(x)
 
-modify_board_links(
-  x,
-  add = NULL,
-  rm = NULL,
-  mod = NULL,
-  ...,
-  session = get_session()
-)
+modify_board_links(x, add = NULL, rm = NULL, ..., session = get_session())
 
 board_stacks(x)
 
@@ -85,7 +78,7 @@ clear_board(x)
 
 \item{add}{Links/stacks to add}
 
-\item{mod}{Link/stacks to modify}
+\item{mod}{Stacks to modify}
 
 \item{blocks, stacks}{Sets of blocks/stacks}
 }
@@ -126,8 +119,7 @@ corresponding replacement function \verb{board_links<-()}. If only links IDs are
 of interest, this is available as \code{board_link_ids()}, which is short for
 \code{names(board_links(x))}. A (generic) convenience function for all kinds of
 updates to board links in one is available as \code{modify_board_links()}. With
-arguments \code{add}, \code{rm} and \code{mod}, links can be added, removed or modified in
-one go.
+arguments \code{add} and \code{rm}, links can be added or removed in one go.
 }
 
 \section{Stacks}{

--- a/man/board_update.Rd
+++ b/man/board_update.Rd
@@ -68,14 +68,20 @@ fixups; an error thrown here aborts the update before apply runs.
 
 \section{Apply}{
 
-The default \code{.board} method returns the supplied board unchanged —
-the core apply path (block / link / stack mutation, block UI
-insertion / removal) is not routed through this generic. Subclass
-methods receive a plain \code{board} snapshot (no reactive surface) and
-return a \code{board}, which the final observer assigns back to
-\code{rv$board}. For piecemeal customization of the core apply path
-itself, override the relevant sub-generic
-(\code{\link[=modify_board_links]{modify_board_links()}}, \code{\link[=insert_block_ui]{insert_block_ui()}}, etc.) instead.
+The default \code{.board} method applies the core delta to the supplied
+board and returns it: added blocks are appended, link and stack
+deltas are folded in through \code{\link[=modify_board_links]{modify_board_links()}} /
+\code{\link[=modify_board_stacks]{modify_board_stacks()}}, and removed blocks are dropped last (once
+the earlier steps have freed them of every link and stack). Subclass
+methods compose with \code{NextMethod()} to layer their own payload slots
+on top of the core-updated board (blockr.dock, for instance,
+cascades view membership), so a single \code{\link[=apply_board_update]{apply_board_update()}} call
+yields the full board for any subclass. The board handed in is a
+plain \code{board} snapshot with no reactive surface; the returned
+\code{board} is what the final observer assigns back to \code{rv$board}. The
+reactive side effects that mirror the delta — block UI insertion /
+removal, server construction / teardown, link and stack wiring — run
+around this single reduce.
 
 Errors thrown from either augment or apply are caught by the
 observer, reported via \code{\link[=notify]{notify()}}, and the reactive is reset so the

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -861,9 +861,11 @@ test_that("validate_board_update handles block-rm orphan cleanup (#177)", {
     links = list(mod = list(lnk1 = list(input = "data")))
   )
 
+  # Modifying a link that still points at the removed block leaves it referenced
+  # once the augment cascade drops it, so the apply's rm_blocks() guard rejects.
   expect_error(
     validate_board_update(payload_mod, brd),
-    class = "board_block_link_name_mismatch"
+    class = "invalid_removal_of_used_block"
   )
 })
 
@@ -900,27 +902,27 @@ test_that("validate_board_update cascades stack membership on rm (#308)", {
   )
 })
 
-test_that("validate_board_update stays within core references", {
+test_that("validate_board_update validates the applied board", {
 
   brd <- new_board(
     blocks = c(a = new_dataset_block("iris"), b = new_subset_block()),
     links = links(ab = new_link("a", "b"))
   )
 
-  # Core update validation checks only core references. Validating the whole
-  # board would fire a subclass validate_board method (e.g. dock view
-  # membership) on an intermediate the core update does not cascade.
-  seen <- FALSE
+  # Update validation applies the augmented delta to a scratch board and
+  # validates the result, so a subclass validate_board method (e.g. dock view
+  # membership) sees the fully-cascaded board rather than an intermediate.
+  seen <- NULL
   local_mocked_bindings(
     validate_board = function(x, ...) {
-      seen <<- TRUE
+      seen <<- board_block_ids(x)
       x
     }
   )
 
   validate_board_update(list(blocks = list(rm = "a")), brd)
 
-  expect_false(seen)
+  expect_identical(seen, "b")
 })
 
 test_that("board server utils", {
@@ -1097,8 +1099,12 @@ test_that("board_update lifecycle runs augment before apply and resets", {
 
       expect_true(any(call_log == "augment"))
       expect_true(any(call_log == "apply"))
+
+      # Validation now also runs apply_board_update (validate-by-apply), so
+      # augment and apply interleave; the first augment still precedes the first
+      # apply, and the applied board reflects the augmented payload (below).
       expect_lt(
-        max(which(call_log == "augment")),
+        min(which(call_log == "augment")),
         min(which(call_log == "apply"))
       )
 
@@ -1151,13 +1157,34 @@ test_that("apply_board_update splices board_server `...` as named args", {
   )
 })
 
-test_that("apply_board_update.board returns the supplied board unchanged", {
+test_that("apply_board_update.board applies the core delta", {
 
-  brd <- new_board()
+  brd <- new_board(
+    blocks = c(a = new_dataset_block("iris"), b = new_subset_block()),
+    links = links(ab = new_link("a", "b"))
+  )
+
   expect_identical(apply_board_update(brd, list()), brd)
+
+  added <- apply_board_update(
+    brd,
+    list(blocks = list(add = as_blocks(c(c = new_subset_block()))))
+  )
+
+  expect_identical(board_block_ids(added), c("a", "b", "c"))
+
+  # Block removal folds in the incident-link cascade produced by augment, so
+  # rm_blocks() sees the block already free of every link.
+  removed <- apply_board_update(
+    brd,
+    augment_board_update(list(blocks = list(rm = "a")), brd)
+  )
+
+  expect_identical(board_block_ids(removed), "b")
+  expect_length(board_link_ids(removed), 0L)
 })
 
-test_that("apply_board_update runs after core has settled rv state", {
+test_that("apply_board_update composes the core apply via NextMethod", {
 
   reset_ext_methods()
 
@@ -1166,8 +1193,9 @@ test_that("apply_board_update runs after core has settled rv state", {
   register_ext_method(
     "apply_board_update",
     function(board, upd, ...) {
+      board <- NextMethod()
       observed <<- board_block_ids(board)
-      NextMethod()
+      board
     }
   )
 
@@ -1183,6 +1211,7 @@ test_that("apply_board_update runs after core has settled rv state", {
       session$flushReact()
 
       expect_identical(observed, "a")
+      expect_identical(board_block_ids(rv$board), "a")
     },
     args = list(
       x = ext_board,
@@ -1271,8 +1300,10 @@ test_that("rejected board update records validate-phase failure each time", {
 
 test_that("apply-phase failure records apply outcome", {
 
+  # apply_board_update() now also runs during validation, so fail a reactive
+  # side effect that only the apply observer reaches.
   local_mocked_bindings(
-    apply_board_update = function(board, upd, ...) {
+    update_stack_blocks = function(...) {
       stop("apply boom")
     }
   )


### PR DESCRIPTION
## Summary

- `apply_board_update.board()` becomes a real reducer: it applies the core delta (add blocks, fold link `mod` into `add`+`rm`, `modify_board_links` / `modify_board_stacks`, then remove blocks last, once they are free of every link and stack) and returns the board. Subclasses compose via `NextMethod()`, so a single `apply_board_update()` call yields the full board for any subclass.
- Update validation now asks whether applying the delta yields a valid board — `validate_board(apply_board_update(board, augment_board_update(payload, board)))` — instead of re-deriving the merged references. The `combine_update_*` helpers, `has_comps()`, and the narrow membership check retire.
- `apply_core_board_update()` keeps only its reactive side effects, reordered around the single reduce (side effects that need the updated board run after it; link/stack delta resolutions are captured against the pre-update board before it).
- Retires `modify_board_links()`'s unused `mod` argument, which raised a vctrs out-of-bounds error on a `mod`+`rm` overlap.

## Breaking: extension authors

Overriding `apply_board_update()` previously received a board the reactive path had already core-applied and only layered subclass state on top. Now the default `.board` method *is* the core apply, so a subclass method must call `NextMethod()` to pick it up before applying its own payload slots. The blockr.dock adaptation is BristolMyersSquibb/blockr.dock#383; the revdep runs against it.

```deps
BristolMyersSquibb/blockr.dock#383
BristolMyersSquibb/blockr.assistant@core311-pin
```

Fixes #311
