### PR TITLE
Add `evaluate` and `require` board update requests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -170,15 +170,18 @@
   front-end can render it distinctly (e.g. a muted node badge); previously such
   a block was indistinguishable from an up-to-date dormant one, so a break
   introduced upstream stayed hidden until the block was visited (#310).
-* Callbacks registered with `board_server()` now receive an `evaluate` channel
-  alongside `update`. Writing block IDs to it joins those blocks, and their
-  upstream closure, to the eval set until they have run and published a current
-  result and current conditions, after which they drop back out and core resets
-  the channel. It brings a dormant block up to date without making it visible:
-  previously the only lever was the front-end's `required` channel, which
-  extensions never receive and which latches the block into the eval set, so a
-  consumer had no way to tell whether a change it had just made broke an
-  off-screen block (#318).
+* Board updates gain two request components, `evaluate` and `require`, for
+  evaluating a dormant block without making it visible. Both name blocks that
+  are joined, with their upstream closure, to the eval set so they publish a
+  current result and current conditions; core drops an `evaluate` request once
+  the block has run, while a `require` claim (`list(add =, rm =)`) is held until
+  released. Previously the only lever was the front-end's `required` channel,
+  which extensions never receive and which latches the block into the eval set,
+  so a consumer had no way to tell whether a change it had just made broke an
+  off-screen block. Since they carry no state change, request components are
+  also the one part of a payload a locked board still accepts, and a payload
+  rejected for being locked now records an outcome in `board$last_update`
+  instead of being dropped silently (#318).
 
 # blockr.core 0.1.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -170,6 +170,15 @@
   front-end can render it distinctly (e.g. a muted node badge); previously such
   a block was indistinguishable from an up-to-date dormant one, so a break
   introduced upstream stayed hidden until the block was visited (#310).
+* Callbacks registered with `board_server()` now receive an `evaluate` channel
+  alongside `update`. Writing block IDs to it joins those blocks, and their
+  upstream closure, to the eval set until they have run and published a current
+  result and current conditions, after which they drop back out and core resets
+  the channel. It brings a dormant block up to date without making it visible:
+  previously the only lever was the front-end's `required` channel, which
+  extensions never receive and which latches the block into the eval set, so a
+  consumer had no way to tell whether a change it had just made broke an
+  off-screen block (#318).
 
 # blockr.core 0.1.3
 

--- a/R/block-server.R
+++ b/R/block-server.R
@@ -29,7 +29,8 @@
 #'   block last evaluated, so its last-known result is out of date. The block
 #'   is not re-evaluated while dormant; the status only reports that the cached
 #'   result no longer reflects its inputs, so a front-end can flag it (e.g. a
-#'   muted node badge) without forcing a recompute.
+#'   muted node badge) without forcing a recompute. A consumer that needs the
+#'   block current asks for it through [board_server()]'s `evaluate` channel.
 #' * `waiting` -- needed, but a required *data* input is missing: unconnected,
 #'   below the required number of variadic `...args` inputs (one by default),
 #'   or fed by an upstream block that is not itself `ready` (see
@@ -305,40 +306,47 @@ block_server.block <- function(id, x, data = list(), block_id = id,
       #  * dormant -- nothing to read (a dormant block's `result()` would
       #    re-enter its guarded, req()-ing pipeline). It is either itself
       #    `stale` (propagate) or fine.
-      input_stale <- reactive(
-        {
-          if (!isTRUE(last_eval$has)) {
-            return(FALSE)
-          }
+      # A plain function rather than a reactive: `last_eval` is written while
+      # the block is needed and this verdict is read while it is not, and no
+      # reactive source has to change in between -- a re-evaluation triggered by
+      # the block itself (an evaluation request, or the block being put back on
+      # screen) refreshes `consumed` silently. A reactive would answer that from
+      # its cache and keep reporting stale on a block it had just brought
+      # current. Its reads register with the status reactive that calls it, so
+      # the verdict is recomputed exactly when the status is.
+      input_stale <- function() {
 
-          srcs <- isolate(board$sources[[block_id]])
-
-          if (is.null(srcs)) {
-            return(FALSE)
-          }
-
-          for (from in unlst(reactiveValuesToList(srcs))) {
-
-            status <- reval_if(board$eval[[from]])
-
-            if (identical(status, "stale")) {
-              return(TRUE)
-            }
-
-            if (!identical(status, "ready")) {
-              next
-            }
-
-            cur <- upstream_result_now(from, board)
-
-            if (not_null(cur) && !same_ref(cur, last_eval$consumed[[from]])) {
-              return(TRUE)
-            }
-          }
-
-          FALSE
+        if (!isTRUE(last_eval$has)) {
+          return(FALSE)
         }
-      )
+
+        srcs <- isolate(board$sources[[block_id]])
+
+        if (is.null(srcs)) {
+          return(FALSE)
+        }
+
+        for (from in unlst(reactiveValuesToList(srcs))) {
+
+          status <- reval_if(board$eval[[from]])
+
+          if (identical(status, "stale")) {
+            return(TRUE)
+          }
+
+          if (!identical(status, "ready")) {
+            next
+          }
+
+          cur <- upstream_result_now(from, board)
+
+          if (not_null(cur) && !same_ref(cur, last_eval$consumed[[from]])) {
+            return(TRUE)
+          }
+        }
+
+        FALSE
+      }
 
       res <- reactive(
         {

--- a/R/block-server.R
+++ b/R/block-server.R
@@ -30,7 +30,7 @@
 #'   is not re-evaluated while dormant; the status only reports that the cached
 #'   result no longer reflects its inputs, so a front-end can flag it (e.g. a
 #'   muted node badge) without forcing a recompute. A consumer that needs the
-#'   block current asks for it through [board_server()]'s `evaluate` channel.
+#'   block current asks for it with a [board_update()] `evaluate` request.
 #' * `waiting` -- needed, but a required *data* input is missing: unconnected,
 #'   below the required number of variadic `...args` inputs (one by default),
 #'   or fed by an upstream block that is not itself `ready` (see

--- a/R/block-server.R
+++ b/R/block-server.R
@@ -128,6 +128,9 @@ block_server <- function(id, x, data = list(), ...) {
 #' inputs are all connected to ready upstream blocks (supplied by
 #' [board_server()]; defaults to always-ready when a block server is run
 #' standalone)
+#' @param needed Reactive flag signaling whether the block is currently in the
+#' eval set (supplied by [board_server()]; defaults to always-needed when a
+#' block server is run standalone)
 #' @param visibility Front-end channel bundle -- a list with three channels,
 #' `required`, `visible` and `frozen`, each an environment of per-block
 #' `reactiveVal`s, supplied by [board_server()] to gate rendering and to
@@ -140,6 +143,7 @@ block_server.block <- function(id, x, data = list(), block_id = id,
                                board = reactiveValues(),
                                update = reactiveVal(),
                                inputs_ready = reactive(TRUE),
+                               needed = reactive(TRUE),
                                visibility = NULL, ...) {
 
   dot_args <- list(...)
@@ -306,47 +310,50 @@ block_server.block <- function(id, x, data = list(), block_id = id,
       #  * dormant -- nothing to read (a dormant block's `result()` would
       #    re-enter its guarded, req()-ing pipeline). It is either itself
       #    `stale` (propagate) or fine.
-      # A plain function rather than a reactive: `last_eval` is written while
-      # the block is needed and this verdict is read while it is not, and no
-      # reactive source has to change in between -- a re-evaluation triggered by
-      # the block itself (an evaluation request, or the block being put back on
-      # screen) refreshes `consumed` silently. A reactive would answer that from
-      # its cache and keep reporting stale on a block it had just brought
-      # current. Its reads register with the status reactive that calls it, so
-      # the verdict is recomputed exactly when the status is.
-      input_stale <- function() {
-
-        if (!isTRUE(last_eval$has)) {
-          return(FALSE)
-        }
-
-        srcs <- isolate(board$sources[[block_id]])
-
-        if (is.null(srcs)) {
-          return(FALSE)
-        }
-
-        for (from in unlst(reactiveValuesToList(srcs))) {
-
-          status <- reval_if(board$eval[[from]])
-
-          if (identical(status, "stale")) {
-            return(TRUE)
+      input_stale <- reactive(
+        {
+          # Only meaningful while the block is dormant: a needed block
+          # evaluates, so it is current by definition. The dependency is also
+          # what makes a fresh verdict due -- `last_eval` is a plain
+          # environment, so the re-evaluation that refreshes `consumed`
+          # invalidates nothing, and dropping back out of the eval set is
+          # exactly when the comparison has to be redone.
+          if (isTRUE(needed())) {
+            return(FALSE)
           }
 
-          if (!identical(status, "ready")) {
-            next
+          if (!isTRUE(last_eval$has)) {
+            return(FALSE)
           }
 
-          cur <- upstream_result_now(from, board)
+          srcs <- isolate(board$sources[[block_id]])
 
-          if (not_null(cur) && !same_ref(cur, last_eval$consumed[[from]])) {
-            return(TRUE)
+          if (is.null(srcs)) {
+            return(FALSE)
           }
+
+          for (from in unlst(reactiveValuesToList(srcs))) {
+
+            status <- reval_if(board$eval[[from]])
+
+            if (identical(status, "stale")) {
+              return(TRUE)
+            }
+
+            if (!identical(status, "ready")) {
+              next
+            }
+
+            cur <- upstream_result_now(from, board)
+
+            if (not_null(cur) && !same_ref(cur, last_eval$consumed[[from]])) {
+              return(TRUE)
+            }
+          }
+
+          FALSE
         }
-
-        FALSE
-      }
+      )
 
       res <- reactive(
         {

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -18,6 +18,26 @@
 #' for fine-grained updates — rather than walking nested condition state. The
 #' default [notify_user()] plugin renders its toasts from this source.
 #'
+#' @section Evaluation requests:
+#' Deferred evaluation leaves a block that nothing currently needs holding its
+#' last run — not only its result, but the conditions it reports. Callbacks
+#' receive an `evaluate` channel alongside `update` (a [shiny::reactiveVal()])
+#' for bringing such a block up to date without putting it on screen. Write the
+#' IDs of the blocks to evaluate and core joins them, together with their
+#' upstream closure over [board_links()] (without which they cannot produce a
+#' result), to the eval set for as long as it takes them to run: each publishes
+#' a current result and current conditions, then drops back out and reports
+#' `dormant` again. The channel is orthogonal to the `required` visibility
+#' channel, so a request neither competes with the front-end's gating nor
+#' leaves a block latched into the eval set, and nothing about what is on
+#' screen changes.
+#'
+#' Core resets the reactive to `NULL` once every requested block has run — or
+#' has reported why it cannot, such as an unconnected data input or a user
+#' input that was never set. That reset is what tells a caller the conditions
+#' it now reads are current. Requesting a block that is already in the eval set
+#' does nothing, and IDs that do not resolve to a board block are dropped.
+#'
 #' @param x Board
 #' @param id Parent namespace
 #' @param ... Generic consistency
@@ -43,7 +63,9 @@ board_server <- function(id, x, ...) {
 #' leaving `NA` until it is first built); the board reads both to gate
 #' construction, evaluation and rendering. Set
 #' `visibility$frozen[[id]](TRUE)` to freeze a block's inputs (for example when
-#' its controls are hidden), so a forged input can no longer steer it.
+#' its controls are hidden), so a forged input can no longer steer it. A
+#' callback also receives the `update` and `evaluate` channels (see
+#' [board_update] and the Evaluation requests section).
 #' @param callback_location Location of callback invocation (before or after
 #' plugins)
 #' @rdname board_server
@@ -117,12 +139,25 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
       # changed.
       rv$needed_slots <- new.env(parent = emptyenv())
 
+      # The `evaluate` channel handed to callbacks: block IDs written here join
+      # the needed set below (with their upstream closure, without which they
+      # cannot produce a result) until the observer further down finds them
+      # evaluated and resets the channel, dropping them back out.
+      board_evaluate <- reactiveVal()
+
+      eval_requested <- reactive(
+        eval_request_blocks(board_evaluate(), rv$board)
+      )
+
       observe(
         {
           cur <- if (!gating_active(vis$required)) {
             TRUE
           } else {
-            upstream_blocks(required_now(vis$required), rv$board)
+            union(
+              upstream_blocks(required_now(vis$required), rv$board),
+              eval_requested()
+            )
           }
 
           old <- isolate(rv$needed())
@@ -141,6 +176,24 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
           # whose membership actually flipped invalidate their readers.
           for (id in board_block_ids(rv$board)) {
             set_needed_slot(rv, id, isTRUE(cur) || id %in% cur)
+          }
+        }
+      )
+
+      observe(
+        {
+          if (!length(board_evaluate())) {
+            return(invisible())
+          }
+
+          # Reading a block's status is what pulls its evaluation: the status
+          # consults `failed()`, which reads the block result, and an input that
+          # is not ready reads its upstream's status in turn, so the pull
+          # cascades up the chain. A block that is not built yet, or not in the
+          # eval set yet, holds the request open -- either read invalidates this
+          # observer once it changes.
+          if (!any(lgl_ply(eval_requested(), block_awaits_eval, rv))) {
+            board_evaluate(NULL)
           }
         }
       )
@@ -169,7 +222,11 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
 
       cb_args <- c(
         rv_ro,
-        list(update = board_update, visibility = vis),
+        list(
+          update = board_update,
+          evaluate = board_evaluate,
+          visibility = vis
+        ),
         dot_args,
         list(session = session)
       )
@@ -746,6 +803,29 @@ valid_visible <- function(x) {
 
 valid_frozen <- function(x) {
   is.logical(x) && length(x) == 1L && !is.na(x)
+}
+
+eval_request_blocks <- function(ids, board) {
+
+  if (!length(ids)) {
+    return(character())
+  }
+
+  known <- intersect(ids, board_block_ids(board))
+  unknown <- setdiff(ids, known)
+
+  if (length(unknown)) {
+    log_warn("ignoring evaluation request for unknown block{?s} {unknown}")
+  }
+
+  upstream_blocks(known, board)
+}
+
+block_awaits_eval <- function(id, rv) {
+
+  status <- reval_if(rv$eval[[id]])
+
+  is.null(status) || status %in% c("dormant", "stale")
 }
 
 needed_block_ids <- function(rv, required) {

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -20,23 +20,23 @@
 #'
 #' @section Evaluation requests:
 #' Deferred evaluation leaves a block that nothing currently needs holding its
-#' last run — not only its result, but the conditions it reports. Callbacks
-#' receive an `evaluate` channel alongside `update` (a [shiny::reactiveVal()])
-#' for bringing such a block up to date without putting it on screen. Write the
-#' IDs of the blocks to evaluate and core joins them, together with their
-#' upstream closure over [board_links()] (without which they cannot produce a
-#' result), to the eval set for as long as it takes them to run: each publishes
-#' a current result and current conditions, then drops back out and reports
-#' `dormant` again. The channel is orthogonal to the `required` visibility
-#' channel, so a request neither competes with the front-end's gating nor
-#' leaves a block latched into the eval set, and nothing about what is on
-#' screen changes.
+#' last run — not only its result, but the conditions it reports. Anything that
+#' can reach the [board_update()] channel can ask for such a block to be brought
+#' up to date, without putting it on screen, through the `evaluate` and
+#' `require` payload components. Both name blocks, and core joins them, together
+#' with their upstream closure over [board_links()] (without which they cannot
+#' produce a result), to the eval set. They differ only in who lets go: an
+#' `evaluate` request is a one-off that core drops once the block has run, while
+#' a `require` claim is held until the requester removes it.
 #'
-#' Core resets the reactive to `NULL` once every requested block has run — or
-#' has reported why it cannot, such as an unconnected data input or a user
-#' input that was never set. That reset is what tells a caller the conditions
-#' it now reads are current. Requesting a block that is already in the eval set
-#' does nothing, and IDs that do not resolve to a board block are dropped.
+#' Requests are orthogonal to the `required` visibility channel, so neither
+#' competes with the front-end's gating, and nothing about what is on screen
+#' changes. Because they carry no state change, they are also the one part of a
+#' payload a locked board still accepts.
+#'
+#' Core drops a one-off request once the block has run — or has reported why it
+#' cannot, such as an unconnected data input or a user input that was never set.
+#' Requesting a block that is already in the eval set does nothing.
 #'
 #' @param x Board
 #' @param id Parent namespace
@@ -64,8 +64,8 @@ board_server <- function(id, x, ...) {
 #' construction, evaluation and rendering. Set
 #' `visibility$frozen[[id]](TRUE)` to freeze a block's inputs (for example when
 #' its controls are hidden), so a forged input can no longer steer it. A
-#' callback also receives the `update` and `evaluate` channels (see
-#' [board_update] and the Evaluation requests section).
+#' callback also receives the `update` channel (see [board_update]), through
+#' which it can request block evaluation (see the Evaluation requests section).
 #' @param callback_location Location of callback invocation (before or after
 #' plugins)
 #' @rdname board_server
@@ -139,24 +139,22 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
       # changed.
       rv$needed_slots <- new.env(parent = emptyenv())
 
-      # The `evaluate` channel handed to callbacks: block IDs written here join
-      # the needed set below (with their upstream closure, without which they
-      # cannot produce a result) until the observer further down finds them
-      # evaluated and resets the channel, dropping them back out.
-      board_evaluate <- reactiveVal()
-
-      eval_requested <- reactive(
-        eval_request_blocks(board_evaluate(), rv$board)
-      )
+      # The two request sets fed by the `evaluate` and `require` board update
+      # components. Both join the needed set below; they differ in who lets go.
+      # Core drops an `evaluating` entry once that block has had its evaluation
+      # pass (see the observer below), while a `required_blocks` entry stays
+      # until its requester removes it.
+      rv$evaluating <- reactiveVal(character())
+      rv$required_blocks <- reactiveVal(character())
 
       observe(
         {
           cur <- if (!gating_active(vis$required)) {
             TRUE
           } else {
-            union(
-              upstream_blocks(required_now(vis$required), rv$board),
-              eval_requested()
+            upstream_blocks(
+              union(required_now(vis$required), requested_blocks(rv)),
+              rv$board
             )
           }
 
@@ -182,7 +180,9 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
 
       observe(
         {
-          if (!length(board_evaluate())) {
+          pending <- rv$evaluating()
+
+          if (!length(pending)) {
             return(invisible())
           }
 
@@ -190,10 +190,12 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
           # consults `failed()`, which reads the block result, and an input that
           # is not ready reads its upstream's status in turn, so the pull
           # cascades up the chain. A block that is not built yet, or not in the
-          # eval set yet, holds the request open -- either read invalidates this
-          # observer once it changes.
-          if (!any(lgl_ply(eval_requested(), block_awaits_eval, rv))) {
-            board_evaluate(NULL)
+          # eval set yet, stays pending -- either read invalidates this observer
+          # once it changes.
+          keep <- pending[lgl_ply(pending, eval_pending, rv)]
+
+          if (length(keep) < length(pending)) {
+            rv$evaluating(keep)
           }
         }
       )
@@ -222,11 +224,7 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
 
       cb_args <- c(
         rv_ro,
-        list(
-          update = board_update,
-          evaluate = board_evaluate,
-          visibility = vis
-        ),
+        list(update = board_update, visibility = vis),
         dot_args,
         list(session = session)
       )
@@ -301,9 +299,15 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
 
           tryCatch(
             {
-              if (is_board_locked(rv$board)) {
+              # A lock stops the board being edited, not evaluated: a payload of
+              # request components alone carries no state change and goes
+              # through. One that carries any is dropped whole, rather than
+              # applied in part.
+              if (is_board_locked(rv$board) &&
+                    !all(names(upd) %in% update_request_components())) {
 
                 log_debug("rejecting board update on locked board")
+                record_update_outcome(FALSE, "validate", "Board is locked.")
                 board_update(NULL)
 
               } else {
@@ -805,27 +809,25 @@ valid_frozen <- function(x) {
   is.logical(x) && length(x) == 1L && !is.na(x)
 }
 
-eval_request_blocks <- function(ids, board) {
-
-  if (!length(ids)) {
-    return(character())
-  }
-
-  known <- intersect(ids, board_block_ids(board))
-  unknown <- setdiff(ids, known)
-
-  if (length(unknown)) {
-    log_warn("ignoring evaluation request for unknown block{?s} {unknown}")
-  }
-
-  upstream_blocks(known, board)
+requested_blocks <- function(rv) {
+  union(rv$evaluating(), rv$required_blocks())
 }
 
-block_awaits_eval <- function(id, rv) {
+# A block owes an evaluation pass while anything it needs for a result -- itself
+# or an upstream -- is unbuilt or still out of the eval set.
+eval_pending <- function(id, rv) {
+  any(lgl_ply(upstream_blocks(id, rv$board), block_deferred, rv))
+}
+
+block_deferred <- function(id, rv) {
 
   status <- reval_if(rv$eval[[id]])
 
   is.null(status) || status %in% c("dormant", "stale")
+}
+
+update_request_components <- function() {
+  c("evaluate", "require")
 }
 
 needed_block_ids <- function(rv, required) {
@@ -989,6 +991,9 @@ destroy_rm_blocks <- function(ids, rv, sess) {
       rm(list = id, envir = slots)
     }
   }
+
+  rv$evaluating(setdiff(isolate(rv$evaluating()), ids))
+  rv$required_blocks(setdiff(isolate(rv$required_blocks()), ids))
 
   invisible()
 }
@@ -1240,8 +1245,9 @@ add_blocks_to_stacks <- function(rv, add, session) {
 
 #' Board update
 #'
-#' Inside [board_server()] every state change flows through one
-#' `board_update` reactive. Core registers two observers framing the
+#' Inside [board_server()] every state change, and every request a
+#' consumer makes of the board, flows through one `board_update`
+#' reactive. Core registers two observers framing the
 #' change: an initial one that validates the payload and runs
 #' [augment_board_update()] for auto-fixups, and a final one that runs
 #' [apply_board_update()] and resets the reactive. Plugins or
@@ -1263,6 +1269,22 @@ add_blocks_to_stacks <- function(rv, add, session) {
 #' that link endpoints and stack members resolve in the post-update
 #' merged view. Unknown top-level keys are passed through, so subclass
 #' payload slots reach subclass augment / apply methods.
+#'
+#' @section Request components:
+#' Two components carry a request rather than a state change:
+#' `evaluate`, a character vector of block IDs to evaluate once, and
+#' `require`, a list with `add` / `rm` character vectors claiming and
+#' releasing blocks that are to stay evaluated. Both put the named
+#' blocks (and their upstream closure) into the eval set without
+#' touching what the front-end shows — see the Evaluation requests
+#' section of [board_server()] — and both resolve their IDs against
+#' the post-update block set, so a payload may add a block and ask for
+#' it in one go. They are applied after the state delta, so a payload
+#' that edits a block and evaluates it sees the edit.
+#'
+#' A locked board (see [is_board_locked()]) still accepts a payload of
+#' request components alone; one that also carries a state change is
+#' dropped whole rather than applied in part.
 #'
 #' @section Augment:
 #' The default `.board` method inserts implied link removals and stack
@@ -1427,6 +1449,90 @@ validate_board_update_structure <- function(payload, board) {
 
   if ("stacks" %in% names(payload)) {
     validate_board_update_stacks(payload$stacks, board)
+  }
+
+  # Both request components name blocks, and a payload may add the very block it
+  # asks for, so they resolve against the post-update block set.
+  if (any(update_request_components() %in% names(payload))) {
+
+    ids <- updated_block_ids(payload, board)
+
+    if ("evaluate" %in% names(payload)) {
+      validate_board_update_evaluate(payload$evaluate, ids)
+    }
+
+    if ("require" %in% names(payload)) {
+      validate_board_update_require(payload$require, ids)
+    }
+  }
+
+  invisible()
+}
+
+updated_block_ids <- function(payload, board) {
+
+  ids <- board_block_ids(board)
+
+  if (!"blocks" %in% names(payload)) {
+    return(ids)
+  }
+
+  union(setdiff(ids, payload$blocks$rm), names(payload$blocks$add))
+}
+
+validate_board_update_evaluate <- function(x, ids) {
+
+  if (!is.character(x)) {
+    blockr_abort(
+      "Expecting a board update `evaluate` component to be specified as a ",
+      "character vector.",
+      class = "board_update_evaluate_type_invalid"
+    )
+  }
+
+  unknown <- setdiff(x, ids)
+
+  if (length(unknown)) {
+    blockr_abort(
+      "Requested evaluation of unknown block{?s} {unknown}.",
+      class = "board_update_evaluate_unknown_id"
+    )
+  }
+
+  invisible()
+}
+
+validate_board_update_require <- function(x, ids) {
+
+  exp_cmp <- c("rm", "add")
+
+  if (!is.list(x) || length(names(x)) != length(x) ||
+        !all(names(x) %in% exp_cmp)) {
+    blockr_abort(
+      "Expecting a board update `require` component to consist of components ",
+      "{exp_cmp}.",
+      class = "board_update_require_components_invalid"
+    )
+  }
+
+  for (cmp in intersect(exp_cmp, names(x))) {
+
+    if (!(is.null(x[[cmp]]) || is.character(x[[cmp]]))) {
+      blockr_abort(
+        "Expecting a board update `require` {cmp} component be specified as a ",
+        "character vector (or NULL).",
+        class = "board_update_require_component_invalid"
+      )
+    }
+  }
+
+  unknown <- setdiff(c(x$add, x$rm), ids)
+
+  if (length(unknown)) {
+    blockr_abort(
+      "Requested evaluation of unknown block{?s} {unknown}.",
+      class = "board_update_require_unknown_id"
+    )
   }
 
   invisible()
@@ -1911,6 +2017,30 @@ apply_core_board_update <- function(rv, upd, session,
   }
 
   update_stack_blocks(rv, stk, edit_stack, edit_plugin_args, session)
+
+  # Last, so that a payload which edits a block and asks for it in one go
+  # evaluates the edit rather than what it replaced.
+  apply_eval_requests(rv, upd)
+
+  invisible()
+}
+
+apply_eval_requests <- function(rv, upd) {
+
+  if (length(upd$require$rm)) {
+    log_debug("releasing block{?s} {upd$require$rm}")
+    rv$required_blocks(setdiff(isolate(rv$required_blocks()), upd$require$rm))
+  }
+
+  if (length(upd$require$add)) {
+    log_debug("requiring block{?s} {upd$require$add}")
+    rv$required_blocks(union(isolate(rv$required_blocks()), upd$require$add))
+  }
+
+  if (length(upd$evaluate)) {
+    log_debug("requesting evaluation of block{?s} {upd$evaluate}")
+    rv$evaluating(union(isolate(rv$evaluating()), upd$evaluate))
+  }
 
   invisible()
 }

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -527,13 +527,14 @@ construct_block <- function(id, rv, mod_ed, mod_ct, args, vis) {
   update_block_links(rv, links[links$to == id])
 
   inputs_ready <- reactive(block_inputs_ready(src_rv, blk, rv))
+  needed <- reactive(block_needed(rv, id))
 
   srv <- do.call(
     block_server,
     c(
       list(paste0("block_", id), blk, rv$inputs[[id]], id, mod_ed, mod_ct),
       args,
-      list(inputs_ready = inputs_ready, visibility = vis)
+      list(inputs_ready = inputs_ready, needed = needed, visibility = vis)
     )
   )
 

--- a/man/block_server.Rd
+++ b/man/block_server.Rd
@@ -108,7 +108,8 @@ inputs from links, user inputs from \code{state}) and a genuine failure:
 block last evaluated, so its last-known result is out of date. The block
 is not re-evaluated while dormant; the status only reports that the cached
 result no longer reflects its inputs, so a front-end can flag it (e.g. a
-muted node badge) without forcing a recompute.
+muted node badge) without forcing a recompute. A consumer that needs the
+block current asks for it through \code{\link[=board_server]{board_server()}}'s \code{evaluate} channel.
 \item \code{waiting} -- needed, but a required \emph{data} input is missing: unconnected,
 below the required number of variadic \code{...args} inputs (one by default),
 or fed by an upstream block that is not itself \code{ready} (see

--- a/man/block_server.Rd
+++ b/man/block_server.Rd
@@ -109,7 +109,7 @@ block last evaluated, so its last-known result is out of date. The block
 is not re-evaluated while dormant; the status only reports that the cached
 result no longer reflects its inputs, so a front-end can flag it (e.g. a
 muted node badge) without forcing a recompute. A consumer that needs the
-block current asks for it through \code{\link[=board_server]{board_server()}}'s \code{evaluate} channel.
+block current asks for it with a \code{\link[=board_update]{board_update()}} \code{evaluate} request.
 \item \code{waiting} -- needed, but a required \emph{data} input is missing: unconnected,
 below the required number of variadic \code{...args} inputs (one by default),
 or fed by an upstream block that is not itself \code{ready} (see

--- a/man/block_server.Rd
+++ b/man/block_server.Rd
@@ -28,6 +28,7 @@ block_server(id, x, data = list(), ...)
   board = reactiveValues(),
   update = reactiveVal(),
   inputs_ready = reactive(TRUE),
+  needed = reactive(TRUE),
   visibility = NULL,
   ...
 )
@@ -63,6 +64,10 @@ block_render_trigger(x, session = get_session())
 inputs are all connected to ready upstream blocks (supplied by
 \code{\link[=board_server]{board_server()}}; defaults to always-ready when a block server is run
 standalone)}
+
+\item{needed}{Reactive flag signaling whether the block is currently in the
+eval set (supplied by \code{\link[=board_server]{board_server()}}; defaults to always-needed when a
+block server is run standalone)}
 
 \item{visibility}{Front-end channel bundle -- a list with three channels,
 \code{required}, \code{visible} and \code{frozen}, each an environment of per-block

--- a/man/board_server.Rd
+++ b/man/board_server.Rd
@@ -39,7 +39,9 @@ with \code{visibility$visible[[id]](TRUE)} (or \code{FALSE} once built but off s
 leaving \code{NA} until it is first built); the board reads both to gate
 construction, evaluation and rendering. Set
 \code{visibility$frozen[[id]](TRUE)} to freeze a block's inputs (for example when
-its controls are hidden), so a forged input can no longer steer it.}
+its controls are hidden), so a forged input can no longer steer it. A
+callback also receives the \code{update} and \code{evaluate} channels (see
+\link{board_update} and the Evaluation requests section).}
 
 \item{callback_location}{Location of callback invocation (before or after
 plugins)}
@@ -67,5 +69,27 @@ per-block \code{server$conditions} reactives (see \code{\link[=block_server]{blo
 consumer reads a single reactive — the whole board, or one block's frame
 for fine-grained updates — rather than walking nested condition state. The
 default \code{\link[=notify_user]{notify_user()}} plugin renders its toasts from this source.
+}
+
+\section{Evaluation requests}{
+
+Deferred evaluation leaves a block that nothing currently needs holding its
+last run — not only its result, but the conditions it reports. Callbacks
+receive an \code{evaluate} channel alongside \code{update} (a \code{\link[shiny:reactiveVal]{shiny::reactiveVal()}})
+for bringing such a block up to date without putting it on screen. Write the
+IDs of the blocks to evaluate and core joins them, together with their
+upstream closure over \code{\link[=board_links]{board_links()}} (without which they cannot produce a
+result), to the eval set for as long as it takes them to run: each publishes
+a current result and current conditions, then drops back out and reports
+\code{dormant} again. The channel is orthogonal to the \code{required} visibility
+channel, so a request neither competes with the front-end's gating nor
+leaves a block latched into the eval set, and nothing about what is on
+screen changes.
+
+Core resets the reactive to \code{NULL} once every requested block has run — or
+has reported why it cannot, such as an unconnected data input or a user
+input that was never set. That reset is what tells a caller the conditions
+it now reads are current. Requesting a block that is already in the eval set
+does nothing, and IDs that do not resolve to a board block are dropped.
 }
 

--- a/man/board_server.Rd
+++ b/man/board_server.Rd
@@ -40,8 +40,8 @@ leaving \code{NA} until it is first built); the board reads both to gate
 construction, evaluation and rendering. Set
 \code{visibility$frozen[[id]](TRUE)} to freeze a block's inputs (for example when
 its controls are hidden), so a forged input can no longer steer it. A
-callback also receives the \code{update} and \code{evaluate} channels (see
-\link{board_update} and the Evaluation requests section).}
+callback also receives the \code{update} channel (see \link{board_update}), through
+which it can request block evaluation (see the Evaluation requests section).}
 
 \item{callback_location}{Location of callback invocation (before or after
 plugins)}
@@ -74,22 +74,22 @@ default \code{\link[=notify_user]{notify_user()}} plugin renders its toasts from
 \section{Evaluation requests}{
 
 Deferred evaluation leaves a block that nothing currently needs holding its
-last run — not only its result, but the conditions it reports. Callbacks
-receive an \code{evaluate} channel alongside \code{update} (a \code{\link[shiny:reactiveVal]{shiny::reactiveVal()}})
-for bringing such a block up to date without putting it on screen. Write the
-IDs of the blocks to evaluate and core joins them, together with their
-upstream closure over \code{\link[=board_links]{board_links()}} (without which they cannot produce a
-result), to the eval set for as long as it takes them to run: each publishes
-a current result and current conditions, then drops back out and reports
-\code{dormant} again. The channel is orthogonal to the \code{required} visibility
-channel, so a request neither competes with the front-end's gating nor
-leaves a block latched into the eval set, and nothing about what is on
-screen changes.
+last run — not only its result, but the conditions it reports. Anything that
+can reach the \code{\link[=board_update]{board_update()}} channel can ask for such a block to be brought
+up to date, without putting it on screen, through the \code{evaluate} and
+\code{require} payload components. Both name blocks, and core joins them, together
+with their upstream closure over \code{\link[=board_links]{board_links()}} (without which they cannot
+produce a result), to the eval set. They differ only in who lets go: an
+\code{evaluate} request is a one-off that core drops once the block has run, while
+a \code{require} claim is held until the requester removes it.
 
-Core resets the reactive to \code{NULL} once every requested block has run — or
-has reported why it cannot, such as an unconnected data input or a user
-input that was never set. That reset is what tells a caller the conditions
-it now reads are current. Requesting a block that is already in the eval set
-does nothing, and IDs that do not resolve to a board block are dropped.
+Requests are orthogonal to the \code{required} visibility channel, so neither
+competes with the front-end's gating, and nothing about what is on screen
+changes. Because they carry no state change, they are also the one part of a
+payload a locked board still accepts.
+
+Core drops a one-off request once the block has run — or has reported why it
+cannot, such as an unconnected data input or a user input that was never set.
+Requesting a block that is already in the eval set does nothing.
 }
 

--- a/man/board_update.Rd
+++ b/man/board_update.Rd
@@ -31,8 +31,9 @@ the (possibly extended) payload. \code{\link[=apply_board_update]{apply_board_up
 \code{board}.
 }
 \description{
-Inside \code{\link[=board_server]{board_server()}} every state change flows through one
-\code{board_update} reactive. Core registers two observers framing the
+Inside \code{\link[=board_server]{board_server()}} every state change, and every request a
+consumer makes of the board, flows through one \code{board_update}
+reactive. Core registers two observers framing the
 change: an initial one that validates the payload and runs
 \code{\link[=augment_board_update]{augment_board_update()}} for auto-fixups, and a final one that runs
 \code{\link[=apply_board_update]{apply_board_update()}} and resets the reactive. Plugins or
@@ -56,6 +57,24 @@ The default \code{.board} method runs a structural check on the payload
 that link endpoints and stack members resolve in the post-update
 merged view. Unknown top-level keys are passed through, so subclass
 payload slots reach subclass augment / apply methods.
+}
+
+\section{Request components}{
+
+Two components carry a request rather than a state change:
+\code{evaluate}, a character vector of block IDs to evaluate once, and
+\code{require}, a list with \code{add} / \code{rm} character vectors claiming and
+releasing blocks that are to stay evaluated. Both put the named
+blocks (and their upstream closure) into the eval set without
+touching what the front-end shows — see the Evaluation requests
+section of \code{\link[=board_server]{board_server()}} — and both resolve their IDs against
+the post-update block set, so a payload may add a block and ask for
+it in one go. They are applied after the state delta, so a payload
+that edits a block and evaluates it sees the edit.
+
+A locked board (see \code{\link[=is_board_locked]{is_board_locked()}}) still accepts a payload of
+request components alone; one that also carries a state change is
+dropped whole rather than applied in part.
 }
 
 \section{Augment}{

--- a/tests/testthat/test-board-lock.R
+++ b/tests/testthat/test-board-lock.R
@@ -42,6 +42,63 @@ test_that("a locked board drops structural board updates", {
   )
 })
 
+test_that("a locked board records the outcome of what it dropped", {
+
+  withr::local_options(blockr.locked = TRUE)
+
+  board <- new_board()
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      board_update(
+        list(blocks = list(add = as_blocks(new_dataset_block())))
+      )
+
+      session$flushReact()
+
+      expect_false(rv$last_update$ok)
+      expect_identical(rv$last_update$phase, "validate")
+    },
+    args = list(x = board, plugins = list(manage_blocks()))
+  )
+})
+
+test_that("a locked board still accepts evaluation requests", {
+
+  withr::local_options(blockr.locked = TRUE)
+
+  board <- new_board(blocks = c(a = new_dataset_block("BOD")))
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      # A request carries no state change, so the lock does not apply to it.
+      board_update(list(require = list(add = "a")))
+      session$flushReact()
+
+      expect_setequal(rv$required_blocks(), "a")
+      expect_true(rv$last_update$ok)
+
+      # Mixed with one that does, the payload is dropped whole.
+      board_update(
+        list(
+          blocks = list(add = as_blocks(list(b = new_dataset_block("BOD")))),
+          require = list(rm = "a")
+        )
+      )
+      session$flushReact()
+
+      expect_false(rv$last_update$ok)
+      expect_length(board_blocks(rv$board), 1L)
+      expect_setequal(rv$required_blocks(), "a")
+    },
+    args = list(x = board, plugins = list())
+  )
+})
+
 test_that("an unlocked board applies structural board updates", {
 
   board <- new_board()

--- a/tests/testthat/test-visibility-gating.R
+++ b/tests/testthat/test-visibility-gating.R
@@ -91,24 +91,27 @@ probe_passthrough <- function() {
   )
 }
 
-# A block whose own expression is driven from outside the board, standing in
-# for a block edited while it sits off screen (the board update path writes the
-# same state reactiveVals).
-probe_select <- function(col) {
+# Externally controllable, so a board update `mod` delta can edit its
+# expression -- standing in for a consumer editing a block that sits off screen.
+probe_select <- function(col = "demand") {
   new_transform_block(
     function(id, data) {
       moduleServer(
         id,
         function(input, output, session) {
+
+          sel <- reactiveVal(col)
+
           list(
-            expr = reactive(bquote(subset(data, select = .(as.name(col()))))),
-            state = list(col = col)
+            expr = reactive(bquote(subset(data, select = .(as.name(sel()))))),
+            state = list(col = sel)
           )
         }
       )
     },
     function(id) shiny::tagList(),
     class = "probe_block",
+    external_ctrl = TRUE,
     block_metadata = FALSE
   )
 }
@@ -743,7 +746,7 @@ test_that("an evaluation request brings a stale block current", {
 
   withr::local_options(blockr.background_construction_delay = 0)
 
-  eval_channel <- NULL
+  upd_channel <- NULL
 
   board <- new_board(
     blocks = c(
@@ -785,7 +788,7 @@ test_that("an evaluation request brings a stale block current", {
 
       reset_probes()
 
-      eval_channel("r")
+      upd_channel(list(evaluate = "r"))
       session$flushReact()
 
       # The request pulls in a, the unevaluated upstream r needs for a result,
@@ -797,7 +800,7 @@ test_that("an evaluation request brings a stale block current", {
       expect_identical(rv$eval[["r"]](), "dormant")
 
       # The request is spent, and nothing about what is on screen changed.
-      expect_null(eval_channel())
+      expect_length(rv$evaluating(), 0L)
 
       expect_false(vis$required[["r"]]())
       expect_false(vis$visible[["r"]]())
@@ -806,8 +809,8 @@ test_that("an evaluation request brings a stale block current", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visibility, evaluate, ...) {
-        eval_channel <<- evaluate
+      callbacks = function(visibility, update, ...) {
+        upd_channel <<- update
         require_blocks(visibility, "s1", "s2", "a", "r")
         render_blocks(visibility, "s1", "s2", "a", "r")
       }
@@ -815,21 +818,27 @@ test_that("an evaluation request brings a stale block current", {
   )
 })
 
+select_board <- function() {
+  new_board(
+    blocks = c(
+      s = with_id(probe_source(), "s"),
+      r = with_id(probe_select(), "r")
+    ),
+    links = links(sr = new_link("s", "r", "data"))
+  )
+}
+
+edit_col <- function(value) {
+  list(blocks = list(mod = list(r = list(col = value))))
+}
+
 test_that("an evaluation request evaluates a block edited while dormant", {
 
   reset_probes()
 
   withr::local_options(blockr.background_construction_delay = 0)
 
-  col <- reactiveVal("demand")
-
-  board <- new_board(
-    blocks = c(
-      s = with_id(probe_source(), "s"),
-      r = with_id(probe_select(col), "r")
-    ),
-    links = links(sr = new_link("s", "r", "data"))
-  )
+  board <- select_board()
 
   testServer(
     get_s3_method("board_server", board),
@@ -848,14 +857,14 @@ test_that("an evaluation request evaluates a block edited while dormant", {
 
       # Break r by editing r itself. Nothing upstream changed, so it is not
       # stale, and its conditions still report the last (clean) run.
-      col("nope")
+      board_update(edit_col("nope"))
       session$flushReact()
 
       expect_false(evaluated("r"))
       expect_identical(rv$eval[["r"]](), "dormant")
       expect_equal(nrow(block_conditions(rv, "r", "error")), 0L)
 
-      board_evaluate("r")
+      board_update(list(evaluate = "r"))
       session$flushReact()
 
       # The request runs r off screen: the error it now raises is reported,
@@ -864,8 +873,52 @@ test_that("an evaluation request evaluates a block edited while dormant", {
       expect_equal(nrow(block_conditions(rv, "r", "error")), 1L)
 
       expect_identical(rv$eval[["r"]](), "dormant")
-      expect_null(board_evaluate())
+      expect_length(rv$evaluating(), 0L)
       expect_false(rendered("r"))
+    },
+    args = list(
+      x = board,
+      plugins = list(),
+      callbacks = function(visibility, ...) {
+        require_blocks(visibility, "s", "r")
+        render_blocks(visibility, "s", "r")
+      }
+    )
+  )
+})
+
+test_that("an edit and a request in one payload evaluate the edit", {
+
+  reset_probes()
+
+  withr::local_options(blockr.background_construction_delay = 0)
+
+  board <- select_board()
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      park_blocks(vis, "r")
+      session$flushReact()
+
+      reset_probes()
+
+      # Requests apply after the state delta, so the block evaluates what the
+      # same payload just made of it, not what it replaced.
+      board_update(c(edit_col("nope"), list(evaluate = "r")))
+      session$flushReact()
+
+      expect_true(evaluated("r"))
+      expect_equal(nrow(block_conditions(rv, "r", "error")), 1L)
+
+      # Repairing it the same way clears the report again.
+      board_update(c(edit_col("Time"), list(evaluate = "r")))
+      session$flushReact()
+
+      expect_equal(nrow(block_conditions(rv, "r", "error")), 0L)
+      expect_identical(rv$eval[["r"]](), "dormant")
     },
     args = list(
       x = board,
@@ -907,7 +960,7 @@ test_that("an evaluation request builds the blocks it needs", {
 
       # An unbuilt block holds the request open until it has been built and has
       # run, rather than the request being spent on a block that cannot report.
-      board_evaluate("r")
+      board_update(list(evaluate = "r"))
       session$flushReact()
 
       expect_true(constructed("a"))
@@ -915,7 +968,7 @@ test_that("an evaluation request builds the blocks it needs", {
 
       expect_true(evaluated("r"))
       expect_identical(rv$eval[["r"]](), "dormant")
-      expect_null(board_evaluate())
+      expect_length(rv$evaluating(), 0L)
     },
     args = list(
       x = board,
@@ -928,7 +981,105 @@ test_that("an evaluation request builds the blocks it needs", {
   )
 })
 
-test_that("an evaluation request for an unknown block is dropped", {
+test_that("a required claim holds a block until it is released", {
+
+  reset_probes()
+
+  withr::local_options(blockr.background_construction_delay = 0)
+
+  board <- new_board(
+    blocks = c(
+      s = with_id(probe_source(), "s"),
+      r = with_id(probe_passthrough(), "r")
+    ),
+    links = links(sr = new_link("s", "r", "data"))
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      park_blocks(vis, "r")
+      session$flushReact()
+
+      expect_identical(rv$eval[["r"]](), "dormant")
+
+      reset_probes()
+
+      # A claim, unlike a one-off request, survives evaluation.
+      board_update(list(require = list(add = "r")))
+      session$flushReact()
+
+      expect_identical(rv$eval[["r"]](), "ready")
+
+      for (i in 1:3) session$flushReact()
+
+      expect_identical(rv$eval[["r"]](), "ready")
+      expect_setequal(rv$required_blocks(), "r")
+
+      # Releasing it hands the block back to the front-end's gating, which
+      # parked it.
+      board_update(list(require = list(rm = "r")))
+      session$flushReact()
+
+      expect_identical(rv$eval[["r"]](), "dormant")
+      expect_length(rv$required_blocks(), 0L)
+      expect_false(rendered("r"))
+    },
+    args = list(
+      x = board,
+      plugins = list(),
+      callbacks = function(visibility, ...) {
+        require_blocks(visibility, "s", "r")
+        render_blocks(visibility, "s", "r")
+      }
+    )
+  )
+})
+
+test_that("a request for a block added in the same payload is honoured", {
+
+  reset_probes()
+
+  withr::local_options(blockr.background_construction_delay = 0)
+
+  board <- new_board(
+    blocks = c(s = with_id(probe_source(), "s")),
+    links = links()
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      new <- as_blocks(list(r = with_id(probe_passthrough(), "r")))
+
+      board_update(
+        list(
+          blocks = list(add = new),
+          links = list(add = links(sr = new_link("s", "r", "data"))),
+          evaluate = "r"
+        )
+      )
+      session$flushReact()
+
+      expect_true(evaluated("r"))
+      expect_length(rv$evaluating(), 0L)
+    },
+    args = list(
+      x = board,
+      plugins = list(),
+      callbacks = function(visibility, ...) {
+        require_blocks(visibility, "s")
+        render_blocks(visibility, "s")
+      }
+    )
+  )
+})
+
+test_that("a request naming an unknown block is rejected", {
 
   reset_probes()
 
@@ -944,10 +1095,19 @@ test_that("an evaluation request for an unknown block is dropped", {
     {
       session$flushReact()
 
-      board_evaluate("nope")
+      board_update(list(evaluate = "nope"))
       session$flushReact()
 
-      expect_null(board_evaluate())
+      expect_false(rv$last_update$ok)
+      expect_identical(rv$last_update$phase, "validate")
+      expect_length(rv$evaluating(), 0L)
+
+      board_update(list(require = list(add = "nope")))
+      session$flushReact()
+
+      expect_false(rv$last_update$ok)
+      expect_length(rv$required_blocks(), 0L)
+
       expect_setequal(rv$needed(), "a")
     },
     args = list(

--- a/tests/testthat/test-visibility-gating.R
+++ b/tests/testthat/test-visibility-gating.R
@@ -91,6 +91,28 @@ probe_passthrough <- function() {
   )
 }
 
+# A block whose own expression is driven from outside the board, standing in
+# for a block edited while it sits off screen (the board update path writes the
+# same state reactiveVals).
+probe_select <- function(col) {
+  new_transform_block(
+    function(id, data) {
+      moduleServer(
+        id,
+        function(input, output, session) {
+          list(
+            expr = reactive(bquote(subset(data, select = .(as.name(col()))))),
+            state = list(col = col)
+          )
+        }
+      )
+    },
+    function(id) shiny::tagList(),
+    class = "probe_block",
+    block_metadata = FALSE
+  )
+}
+
 probe_data_observer <- function() {
   new_transform_block(
     function(id, data) {
@@ -182,6 +204,21 @@ render_blocks <- function(vis, ...) {
   }
 
   invisible()
+}
+
+park_blocks <- function(vis, ...) {
+
+  for (id in c(...)) {
+    vis$required[[id]](FALSE)
+    vis$visible[[id]](FALSE)
+  }
+
+  invisible()
+}
+
+block_conditions <- function(rv, id, severity) {
+  cnd <- rv$conditions()
+  cnd[cnd$block == id & cnd$severity == severity, ]
 }
 
 test_that("with no producer every block is visible", {
@@ -638,6 +675,287 @@ test_that("re-routing a dormant block's input marks it stale", {
       callbacks = function(visibility, ...) {
         require_blocks(visibility, "a", "b", "r")
         render_blocks(visibility, "a", "b", "r")
+      }
+    )
+  )
+})
+
+test_that("a stale block that re-evaluates is dormant when parked again", {
+
+  reset_probes()
+
+  withr::local_options(blockr.background_construction_delay = 0)
+
+  board <- new_board(
+    blocks = c(
+      a = with_id(probe_source(), "a"),
+      b = with_id(probe_source_alt(), "b"),
+      r = with_id(probe_passthrough(), "r")
+    ),
+    links = links(ar = new_link("a", "r", "data"))
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      vis$required[["r"]](FALSE)
+      session$flushReact()
+
+      board_update(
+        list(
+          links = list(rm = "ar", add = links(br = new_link("b", "r", "data")))
+        )
+      )
+      session$flushReact()
+
+      expect_identical(rv$eval[["r"]](), "stale")
+
+      # Put r back on screen: it evaluates against its new input and is current
+      # again, so parking it a second time leaves it dormant. Neither b's result
+      # nor its status changed in between, so the verdict has to be recomputed
+      # off r's own last evaluation.
+      require_blocks(vis, "r")
+      session$flushReact()
+
+      expect_identical(rv$eval[["r"]](), "ready")
+
+      vis$required[["r"]](FALSE)
+      session$flushReact()
+
+      expect_identical(rv$eval[["r"]](), "dormant")
+    },
+    args = list(
+      x = board,
+      plugins = list(),
+      callbacks = function(visibility, ...) {
+        require_blocks(visibility, "a", "b", "r")
+        render_blocks(visibility, "a", "b", "r")
+      }
+    )
+  )
+})
+
+test_that("an evaluation request brings a stale block current", {
+
+  reset_probes()
+
+  withr::local_options(blockr.background_construction_delay = 0)
+
+  eval_channel <- NULL
+
+  board <- new_board(
+    blocks = c(
+      s1 = with_id(probe_source(), "s1"),
+      s2 = with_id(probe_source_alt(), "s2"),
+      a = with_id(probe_passthrough(), "a"),
+      r = with_id(probe_passthrough(), "r")
+    ),
+    links = links(
+      s1a = new_link("s1", "a", "data"),
+      ar = new_link("a", "r", "data")
+    )
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      expect_identical(rv$eval[["r"]](), "ready")
+
+      # Park the whole a -> r chain off screen, then re-route a to a different
+      # dataset: neither re-evaluates, both report the break as stale.
+      park_blocks(vis, "a", "r")
+      session$flushReact()
+
+      board_update(
+        list(
+          links = list(
+            rm = "s1a",
+            add = links(s2a = new_link("s2", "a", "data"))
+          )
+        )
+      )
+      session$flushReact()
+
+      expect_identical(rv$eval[["a"]](), "stale")
+      expect_identical(rv$eval[["r"]](), "stale")
+
+      reset_probes()
+
+      eval_channel("r")
+      session$flushReact()
+
+      # The request pulls in a, the unevaluated upstream r needs for a result,
+      # and both are current afterwards -- reported as dormant, not stale.
+      expect_true(evaluated("a"))
+      expect_true(evaluated("r"))
+
+      expect_identical(rv$eval[["a"]](), "dormant")
+      expect_identical(rv$eval[["r"]](), "dormant")
+
+      # The request is spent, and nothing about what is on screen changed.
+      expect_null(eval_channel())
+
+      expect_false(vis$required[["r"]]())
+      expect_false(vis$visible[["r"]]())
+      expect_false(rendered("r"))
+    },
+    args = list(
+      x = board,
+      plugins = list(),
+      callbacks = function(visibility, evaluate, ...) {
+        eval_channel <<- evaluate
+        require_blocks(visibility, "s1", "s2", "a", "r")
+        render_blocks(visibility, "s1", "s2", "a", "r")
+      }
+    )
+  )
+})
+
+test_that("an evaluation request evaluates a block edited while dormant", {
+
+  reset_probes()
+
+  withr::local_options(blockr.background_construction_delay = 0)
+
+  col <- reactiveVal("demand")
+
+  board <- new_board(
+    blocks = c(
+      s = with_id(probe_source(), "s"),
+      r = with_id(probe_select(col), "r")
+    ),
+    links = links(sr = new_link("s", "r", "data"))
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      expect_identical(rv$eval[["r"]](), "ready")
+      expect_equal(nrow(block_conditions(rv, "r", "error")), 0L)
+
+      park_blocks(vis, "r")
+      session$flushReact()
+
+      expect_identical(rv$eval[["r"]](), "dormant")
+
+      reset_probes()
+
+      # Break r by editing r itself. Nothing upstream changed, so it is not
+      # stale, and its conditions still report the last (clean) run.
+      col("nope")
+      session$flushReact()
+
+      expect_false(evaluated("r"))
+      expect_identical(rv$eval[["r"]](), "dormant")
+      expect_equal(nrow(block_conditions(rv, "r", "error")), 0L)
+
+      board_evaluate("r")
+      session$flushReact()
+
+      # The request runs r off screen: the error it now raises is reported,
+      # and r drops back out of the eval set.
+      expect_true(evaluated("r"))
+      expect_equal(nrow(block_conditions(rv, "r", "error")), 1L)
+
+      expect_identical(rv$eval[["r"]](), "dormant")
+      expect_null(board_evaluate())
+      expect_false(rendered("r"))
+    },
+    args = list(
+      x = board,
+      plugins = list(),
+      callbacks = function(visibility, ...) {
+        require_blocks(visibility, "s", "r")
+        render_blocks(visibility, "s", "r")
+      }
+    )
+  )
+})
+
+test_that("an evaluation request builds the blocks it needs", {
+
+  reset_probes()
+
+  withr::local_options(blockr.background_construction_delay = Inf)
+
+  board <- new_board(
+    blocks = c(
+      s = with_id(probe_source(), "s"),
+      a = with_id(probe_passthrough(), "a"),
+      r = with_id(probe_passthrough(), "r")
+    ),
+    links = links(
+      sa = new_link("s", "a", "data"),
+      ar = new_link("a", "r", "data")
+    )
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      expect_true(constructed("s"))
+      expect_false(constructed("a"))
+      expect_false(constructed("r"))
+
+      # An unbuilt block holds the request open until it has been built and has
+      # run, rather than the request being spent on a block that cannot report.
+      board_evaluate("r")
+      session$flushReact()
+
+      expect_true(constructed("a"))
+      expect_true(constructed("r"))
+
+      expect_true(evaluated("r"))
+      expect_identical(rv$eval[["r"]](), "dormant")
+      expect_null(board_evaluate())
+    },
+    args = list(
+      x = board,
+      plugins = list(),
+      callbacks = function(visibility, ...) {
+        require_blocks(visibility, "s")
+        render_blocks(visibility, "s")
+      }
+    )
+  )
+})
+
+test_that("an evaluation request for an unknown block is dropped", {
+
+  reset_probes()
+
+  withr::local_options(blockr.background_construction_delay = 0)
+
+  board <- new_board(
+    blocks = c(a = with_id(probe_source(), "a")),
+    links = links()
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      board_evaluate("nope")
+      session$flushReact()
+
+      expect_null(board_evaluate())
+      expect_setequal(rv$needed(), "a")
+    },
+    args = list(
+      x = board,
+      plugins = list(),
+      callbacks = function(visibility, ...) {
+        require_blocks(visibility, "a")
+        render_blocks(visibility, "a")
       }
     )
   )


### PR DESCRIPTION
## Summary

- Board updates gain two request components for evaluating a dormant block without making it visible. Both name blocks, which core joins — with their upstream closure, without which they cannot produce a result — to the eval set, so they publish a current result and current conditions. They differ only in who lets go: `evaluate = ids` is a one-off that core drops once the block has run, while `require = list(add = ids, rm = ids)` is a claim held until the requester releases it. Deferred evaluation otherwise leaves an off-screen block's conditions as out of date as its result, and the one lever that brings it current is the front-end's `required` channel — which extensions never receive, and which latches the block into the eval set.
- Requests are applied after the state delta, so one payload can edit a block and ask for it: `update(list(blocks = list(mod = ...), evaluate = "b"))` evaluates the edit rather than what it replaced. Delivering them any other way loses that ordering, since the apply observer runs at `priority = -Inf` and a separate pull would fire first.
- Reading a block's status is what pulls its evaluation — the status consults `failed()`, which reads the result, and an unready input reads its upstream's status in turn — so a one-off stays pending while anything it needs is unbuilt or still deferred. A block that cannot evaluate, through an unconnected data input or a user input that was never set, reports that status rather than holding the request open forever.
- Requests carry no state change, so a locked board accepts a payload of them alone; one that also carries a state change is dropped whole rather than applied in part, and now records an outcome in `board$last_update` instead of vanishing with only a log line.
- The `input_stale` verdict was answering from its reactive cache, which had to be fixed for a request to land. It derives from the non-reactive `last_eval`, so a re-evaluation that leaves the upstreams untouched refreshes `consumed` silently and the block goes on reporting `stale` after it has been brought current. That is reachable from the front-end alone — park a block whose input was re-routed, put it back on screen, park it again — and has its own regression test. It is now a plain function called from the status reactive, so its reads register there and the verdict is recomputed exactly when the status is.

Nothing new has to be threaded anywhere: consumers, plugins and blockr.dock all have the update channel already, so blockr.assistant can adopt this as-is.

Follow-ups, not in this PR: `require_all_blocks()` in the code-export plugin overwrites the front-end's `required[[id]](FALSE)` and never releases, so one "Show code" turns a lazy board eager for the rest of the session — filed as #320, and the fix is to move it onto `require`.

Fixes #318