### PR TITLE
Build the board for code export instead of evaluating it

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,20 @@
   request joins neither the eval set nor the front-end's `required` channel, so
   it cannot turn a lazily evaluating board into an eagerly evaluating one
   (#333).
+* Showing the generated code no longer writes the front-end's `required`
+  channel. A block parked with `required[[id]](FALSE)` was overwritten and
+  never restored, so a single "Show code" turned a lazily evaluating board
+  into an eagerly evaluating one for the rest of the session, with nothing
+  left to release it. The export asks for construction alone through the
+  `construct` board update component, since the script is assembled from
+  block expressions and needs its blocks built rather than run: a board that
+  defers its off-screen blocks now stays deferred while the code is shown.
+  Export is held back by what a block reports about itself -- user inputs
+  that were never set, or an error from its last run -- rather than by eval
+  status, and the modal offers a one-off evaluation so that a block which has
+  never run can report either way. The `generate_code` plugin server takes
+  `update` in place of `visibility`, which is breaking for a front-end that
+  supplies its own `generate_code_server()` (#320).
 * `apply_board_update()` is now a real reducer rather than a no-op: its
   default `.board` method applies the core delta (block, link and stack
   mutations) to the supplied board and returns it, and update validation
@@ -89,7 +103,7 @@
   unfreezing resumes normal input handling (#231).
 * `background_construction_delay` now accepts `Inf`, skipping the background
   construction pass so a block is built only once it becomes required. Code
-  export ("Show code") then marks every block required, so the exported
+  export ("Show code") then claims every block on the board, so the exported
   script covers the whole board; an off-screen block that is not fully
   configured holds the export back instead of emitting broken code (#269).
 * Code export gates on the set of blocks that actually carry an expression,

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -445,7 +445,7 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
 
       call_plugin_server(
         "generate_code",
-        server_args = c(read_plugin_args, list(visibility = vis)),
+        server_args = edit_plugin_args,
         plugins = plugins
       )
 

--- a/R/plugin-code.R
+++ b/R/plugin-code.R
@@ -7,6 +7,18 @@
 #' by offering a download button, by providing this functionality as a
 #' `generate_code` module.
 #'
+#' Opening the modal asks for every block on the board to be built, through the
+#' `construct` board update component (see the "Evaluation requests" section of
+#' [board_server()]), because the script is assembled from block expressions and
+#' an unbuilt block carries none. Nothing is evaluated: a board that defers its
+#' off-screen blocks stays deferred, and the front-end's gating is untouched.
+#'
+#' Export is held back while a block is not fully configured, or while one
+#' reports an error from its last run — either would put code into the script
+#' that does not reproduce the board. A block that has never run reports
+#' neither, so the modal offers to evaluate the board, which is a one-off that
+#' leaves the blocks dormant again but has them report what they found.
+#'
 #' @param server,ui Server/UI for the plugin module
 #'
 #' @return A plugin container inheriting from `generate_code` is returned by
@@ -23,17 +35,12 @@ generate_code <- function(server = generate_code_server,
 
 #' @param id Namespace ID
 #' @param board Reactive values object
-#' @param visibility Visibility channel bundle (supplied by [board_server()]).
-#' On a gated board, "Show code" marks every block `required`, so the exported
-#' script covers the whole board and not only what is on screen; an off-screen
-#' block that is not fully configured then holds the export back rather than
-#' emitting broken code. `NULL` (the standalone default) leaves the board
-#' untouched.
+#' @param update Reactive value object to initiate board updates
 #' @param ... Extra arguments passed from parent scope
 #'
 #' @rdname generate_code
 #' @export
-generate_code_server <- function(id, board, visibility = NULL, ...) {
+generate_code_server <- function(id, board, update, ...) {
   moduleServer(
     id,
     function(input, output, session) {
@@ -56,18 +63,15 @@ generate_code_server <- function(id, board, visibility = NULL, ...) {
       observeEvent(
         input$code_mod,
         {
-          require_all_blocks(board, visibility)
+          update(list(construct = board_block_ids(board$board)))
 
-          showModal(
-            modalDialog(
-              title = "Generated code",
-              uiOutput(session$ns("code_out")),
-              easyClose = TRUE,
-              footer = NULL,
-              size = "l"
-            )
-          )
+          showModal(code_modal(session$ns))
         }
+      )
+
+      observeEvent(
+        input$code_eval,
+        update(list(evaluate = board_block_ids(board$board)))
       )
 
       NULL
@@ -87,20 +91,43 @@ generate_code_ui <- function(id, board) {
   )
 }
 
+code_modal <- function(ns) {
+  modalDialog(
+    title = "Generated code",
+    uiOutput(ns("code_out")),
+    easyClose = TRUE,
+    footer = tagList(
+      actionButton(ns("code_eval"), "Evaluate blocks", class = "btn-secondary"),
+      modalButton("Close")
+    ),
+    size = "l"
+  )
+}
+
 code_export_state <- function(board) {
 
   ids <- board_block_ids(board$board)
-  status <- reactiveValuesToList(board$eval)
 
-  if (!setequal(names(board$blocks), ids) || !setequal(names(status), ids)) {
+  if (!setequal(names(board$blocks), ids)) {
     return("pending")
   }
 
-  if (all(chr_ply(status, reval_if) %in% c("ready", "dormant", "stale"))) {
-    return("ready")
+  ready <- lgl_ply(board$blocks, block_state_ready)
+
+  if (!all(ready) || nrow(export_block_errors(board)) > 0L) {
+    return("blocked")
   }
 
-  "blocked"
+  "ready"
+}
+
+block_state_ready <- function(blk) {
+  isTRUE(reval_if(blk$server$state_ready))
+}
+
+export_block_errors <- function(board) {
+  cnd <- reval_if(board$conditions)
+  cnd[cnd$severity == "error", ]
 }
 
 code_modal_body <- function(state, script = NULL) {
@@ -123,26 +150,8 @@ code_modal_body <- function(state, script = NULL) {
   div(
     class = "text-muted",
     paste(
-      "The board is not ready. Finish configuring all blocks",
-      "before exporting code."
+      "The board is not ready. Finish configuring all blocks, and fix any",
+      "block reporting an error, before exporting code."
     )
   )
-}
-
-require_all_blocks <- function(board, visibility) {
-
-  if (is.null(visibility) || !gating_active(visibility$required)) {
-    return(invisible())
-  }
-
-  for (id in board_block_ids(board$board)) {
-
-    slot <- visibility$required[[id]]
-
-    if (not_null(slot)) {
-      slot(TRUE)
-    }
-  }
-
-  invisible()
 }

--- a/inst/examples/board/code/app.R
+++ b/inst/examples/board/code/app.R
@@ -1,0 +1,25 @@
+library(blockr.core)
+
+options(blockr.background_construction_delay = Inf)
+
+serve(
+  new_board(
+    blocks = c(
+      a = new_dataset_block("BOD"),
+      b = new_dataset_block("ChickWeight")
+    )
+  ),
+  "my_board",
+  callbacks = function(board, visibility, ...) {
+
+    visibility$required[["a"]](TRUE)
+    visibility$visible[["a"]](TRUE)
+
+    shiny::exportTestValues(
+      built = names(board$blocks),
+      status_b = reval_if(board$eval[["b"]])
+    )
+
+    NULL
+  }
+)

--- a/man/generate_code.Rd
+++ b/man/generate_code.Rd
@@ -8,7 +8,7 @@
 \usage{
 generate_code(server = generate_code_server, ui = generate_code_ui)
 
-generate_code_server(id, board, visibility = NULL, ...)
+generate_code_server(id, board, update, ...)
 
 generate_code_ui(id, board)
 }
@@ -19,12 +19,7 @@ generate_code_ui(id, board)
 
 \item{board}{Reactive values object}
 
-\item{visibility}{Visibility channel bundle (supplied by \code{\link[=board_server]{board_server()}}).
-On a gated board, "Show code" marks every block \code{required}, so the exported
-script covers the whole board and not only what is on screen; an off-screen
-block that is not fully configured then holds the export back rather than
-emitting broken code. \code{NULL} (the standalone default) leaves the board
-untouched.}
+\item{update}{Reactive value object to initiate board updates}
 
 \item{...}{Extra arguments passed from parent scope}
 }
@@ -41,4 +36,17 @@ code snippet are conceivable and currently implemented, we have a modal
 with copy-to-clipboard functionality. This is readily extensible, for example
 by offering a download button, by providing this functionality as a
 \code{generate_code} module.
+}
+\details{
+Opening the modal asks for every block on the board to be built, through the
+\code{construct} board update component (see the "Evaluation requests" section of
+\code{\link[=board_server]{board_server()}}), because the script is assembled from block expressions and
+an unbuilt block carries none. Nothing is evaluated: a board that defers its
+off-screen blocks stays deferred, and the front-end's gating is untouched.
+
+Export is held back while a block is not fully configured, or while one
+reports an error from its last run — either would put code into the script
+that does not reproduce the board. A block that has never run reports
+neither, so the modal offers to evaluate the board, which is a one-off that
+leaves the blocks dormant again but has them report what they found.
 }

--- a/tests/testthat/test-plugin-code.R
+++ b/tests/testthat/test-plugin-code.R
@@ -13,6 +13,9 @@ test_that("generate code", {
     )
   )
 
+  plugin_args <- generate_plugin_args(board)
+  plugin_args$update <- reactiveVal()
+
   testServer(
     generate_code_server,
     {
@@ -21,9 +24,24 @@ test_that("generate code", {
       expect_match(as.character(output$code_out), "merge", all = FALSE)
 
       session$setInputs(code_mod = 1)
+
+      # Showing the code asks for construction only: nothing joins the eval set
+      expect_identical(update(), list(construct = c("a", "b", "c")))
+
+      session$setInputs(code_eval = 1)
+
+      expect_identical(update(), list(evaluate = c("a", "b", "c")))
     },
-    args = generate_plugin_args(board)
+    args = plugin_args
   )
+})
+
+test_that("the code modal offers a one-off evaluation", {
+
+  modal <- as.character(code_modal(NS("gen")))
+
+  expect_match(modal, "id=\"gen-code_eval\"", fixed = TRUE)
+  expect_match(modal, "action-button", fixed = TRUE)
 })
 
 test_that("export would emit `NA` for an eval-complete but unbuilt board", {
@@ -46,8 +64,8 @@ test_that("export would emit `NA` for an eval-complete but unbuilt board", {
   # code_export_state gates on the built set, so the plugin never reaches the
   # exporter with `b` missing: it reports pending instead of exporting junk.
   ro <- list(
-    eval = reactiveValues(a = reactive("ready"), b = reactive("ready")),
     blocks = list(a = list(server = list(expr = reactive(quote(1))))),
+    conditions = empty_conditions_frame(),
     board = board
   )
 
@@ -63,42 +81,48 @@ test_that("code_export_state distinguishes ready, blocked and pending", {
     blocks = c(a = new_dataset_block("BOD"), b = new_dataset_block("BOD"))
   )
 
-  make_ro <- function(...) {
-    status <- list(...)
-    list(
-      eval = do.call(reactiveValues, status),
-      blocks = set_names(vector("list", length(status)), names(status)),
-      board = board
+  blk <- function(state_ready = TRUE) {
+    list(server = list(state_ready = state_ready))
+  }
+
+  errored <- function(id) {
+    rbind(
+      empty_conditions_frame(),
+      data.frame(
+        block = id,
+        phase = "eval",
+        severity = "error",
+        message = "boom",
+        id = "cnd"
+      )
     )
   }
 
+  make_ro <- function(blocks, conditions = empty_conditions_frame()) {
+    list(blocks = blocks, conditions = conditions, board = board)
+  }
+
   expect_identical(
-    code_export_state(make_ro(a = reactive("ready"), b = reactive("ready"))),
-    "ready"
-  )
-  expect_identical(
-    code_export_state(make_ro(a = reactive("ready"), b = reactive("dormant"))),
+    code_export_state(make_ro(list(a = blk(), b = blk()))),
     "ready"
   )
 
+  # A block whose user inputs were never set holds the export back, whether or
+  # not it has ever been evaluated
   expect_identical(
-    code_export_state(make_ro(a = reactive("ready"), b = reactive("waiting"))),
-    "blocked"
-  )
-  expect_identical(
-    code_export_state(make_ro(a = reactive("ready"), b = reactive("unset"))),
-    "blocked"
-  )
-  expect_identical(
-    code_export_state(make_ro(a = reactive("ready"), b = reactive("failed"))),
+    code_export_state(make_ro(list(a = blk(), b = blk(FALSE)))),
     "blocked"
   )
 
-  # a block still missing from the built set is pending, not blocked
+  # So does an error a block reported the last time it ran, which outlives the
+  # evaluation that raised it
   expect_identical(
-    code_export_state(make_ro(a = reactive("ready"))),
-    "pending"
+    code_export_state(make_ro(list(a = blk(), b = blk()), errored("b"))),
+    "blocked"
   )
+
+  # A block still missing from the built set is pending, not blocked
+  expect_identical(code_export_state(make_ro(list(a = blk()))), "pending")
 })
 
 test_that("code modal body shows a script, a preparing or a not-ready note", {
@@ -119,74 +143,53 @@ test_that("code modal body shows a script, a preparing or a not-ready note", {
   expect_match(as.character(blocked), "not ready")
 })
 
-test_that("require_all_blocks marks every block required on a gated board", {
+test_that("show code builds the board without evaluating or gating it", {
 
-  reactiveConsole(TRUE)
-  on.exit(reactiveConsole(FALSE))
-
-  board <- list(
-    board = new_board(
-      blocks = c(
-        a = new_dataset_block("BOD"),
-        b = new_dataset_block("BOD"),
-        c = new_dataset_block("BOD")
-      )
+  board <- new_board(
+    blocks = c(
+      a = new_dataset_block("BOD"),
+      b = new_dataset_block("BOD"),
+      c = new_dataset_block("BOD")
     )
   )
 
-  vis <- list(
-    required = new.env(parent = emptyenv()),
-    visible = new.env(parent = emptyenv())
+  withr::local_options(blockr.background_construction_delay = Inf)
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      vis$required[["a"]](TRUE)
+      vis$visible[["a"]](TRUE)
+      vis$required[["b"]](FALSE)
+      session$flushReact()
+
+      expect_identical(reval_if(rv$eval[["b"]]), "dormant")
+      expect_false("c" %in% names(rv$blocks))
+
+      session$setInputs(`generate_code-code_mod` = 1)
+      session$flushReact()
+
+      # The deferred block is built for its expression, and stays dormant: the
+      # export needs blocks present, not run
+      expect_true("c" %in% names(rv$blocks))
+      expect_identical(reval_if(rv$eval[["c"]]), "dormant")
+      expect_identical(reval_if(rv$eval[["b"]]), "dormant")
+
+      # Neither the front-end's gating channel nor the claim set is touched
+      expect_false(vis$required[["b"]]())
+      expect_true(is.na(vis$required[["c"]]()))
+      expect_length(rv$claims(), 0L)
+
+      session$setInputs(`generate_code-code_eval` = 1)
+      session$flushReact()
+
+      # The one-off runs them and hands them back, leaving nothing held
+      expect_length(rv$evaluating(), 0L)
+      expect_length(rv$claims(), 0L)
+      expect_identical(reval_if(rv$eval[["c"]]), "dormant")
+    },
+    args = list(x = board, plugins = board_plugins(board, "generate_code"))
   )
-  add_vis_slots(vis, c("a", "b", "c"))
-  vis$required[["a"]](TRUE)
-
-  require_all_blocks(board, vis)
-
-  expect_true(vis$required[["a"]]())
-  expect_true(vis$required[["b"]]())
-  expect_true(vis$required[["c"]]())
-})
-
-test_that("require_all_blocks is a no-op when ungated or standalone", {
-
-  reactiveConsole(TRUE)
-  on.exit(reactiveConsole(FALSE))
-
-  board <- list(board = new_board(blocks = c(a = new_dataset_block("BOD"))))
-
-  vis <- list(
-    required = new.env(parent = emptyenv()),
-    visible = new.env(parent = emptyenv())
-  )
-  add_vis_slots(vis, "a")
-
-  expect_null(require_all_blocks(board, vis))
-  expect_true(is.na(vis$required[["a"]]()))
-
-  expect_null(require_all_blocks(board, NULL))
-})
-
-test_that("require_all_blocks tolerates a block without a vis slot", {
-
-  reactiveConsole(TRUE)
-  on.exit(reactiveConsole(FALSE))
-
-  board <- list(
-    board = new_board(
-      blocks = c(a = new_dataset_block("BOD"), b = new_dataset_block("BOD"))
-    )
-  )
-
-  vis <- list(
-    required = new.env(parent = emptyenv()),
-    visible = new.env(parent = emptyenv())
-  )
-  add_vis_slots(vis, "a")
-  vis$required[["a"]](FALSE)
-
-  expect_no_error(require_all_blocks(board, vis))
-  expect_true(vis$required[["a"]]())
 })
 
 test_that("show code requires the whole board, gating export on config", {
@@ -215,20 +218,20 @@ test_that("show code requires the whole board, gating export on config", {
         }
         session$flushReact()
 
-        ro <- list(eval = rv$eval, blocks = rv$blocks, board = rv$board)
+        read_only <- function() {
+          list(blocks = rv$blocks, conditions = rv$conditions, board = rv$board)
+        }
 
-        pending <- code_export_state(ro)
+        pending <- code_export_state(read_only())
         pending_body <- as.character(code_modal_body(pending))
 
-        require_all_blocks(list(board = rv$board), vis)
+        session$setInputs(`generate_code-code_mod` = 1)
         session$flushReact()
-
-        ro <- list(eval = rv$eval, blocks = rv$blocks, board = rv$board)
 
         out <<- list(
           pending = pending,
           pending_body = pending_body,
-          state = code_export_state(ro),
+          state = code_export_state(read_only()),
           status = reval_if(rv$eval[["m"]]),
           script = export_wrapped_code(
             lst_xtr_reval(rv$blocks, "server", "expr"),
@@ -236,7 +239,7 @@ test_that("show code requires the whole board, gating export on config", {
           )
         )
       },
-      args = list(x = board, plugins = list())
+      args = list(x = board, plugins = board_plugins(board, "generate_code"))
     )
 
     out
@@ -248,20 +251,74 @@ test_that("show code requires the whole board, gating export on config", {
   expect_identical(configured$pending, "pending")
   expect_false(grepl("`NA` <-", configured$pending_body, fixed = TRUE))
 
-  # after "Show code", the whole board is built and exports cleanly
+  # After "Show code", the whole board is built and exports cleanly -- while
+  # `m` stays dormant, since building it is all the export needed
   expect_identical(configured$state, "ready")
-  expect_identical(configured$status, "ready")
+  expect_identical(configured$status, "dormant")
   expect_match(configured$script, "merge")
   expect_false(grepl("`NA` <-", configured$script, fixed = TRUE))
 
   # an unconfigured off-screen block holds the export back rather than
-  # exporting broken code
+  # exporting broken code, without having to be evaluated to say so
   unconfigured <- drive(new_merge_block())
 
   expect_identical(unconfigured$state, "blocked")
-  expect_identical(unconfigured$status, "unset")
+  expect_identical(unconfigured$status, "dormant")
 })
 
 test_that("dummy add/rm block ui test", {
   expect_s3_class(generate_code_ui("gen", new_board()), "shiny.tag.list")
+})
+
+test_that("showing code builds a deferred block in the browser", {
+
+  skip_on_cran()
+
+  app_path <- system.file("examples", "board", "code", "app.R",
+                          package = "blockr.core")
+
+  app <- try(
+    shinytest2::AppDriver$new(
+      app_path,
+      name = "code",
+      seed = 42,
+      load_timeout = 30 * 1000
+    )
+  )
+
+  testthat::skip_if(
+    inherits(app, "try-error"),
+    "Cannot start shinytest2 code board app."
+  )
+
+  on.exit(app$stop())
+
+  # The `b` block is off screen on a board that defers construction, so it
+  # starts out unbuilt
+  expect_identical(app$get_value(export = "my_board-built"), "a")
+
+  app$click(selector = "#my_board-generate_code-code_mod")
+
+  expect_setequal(
+    app$wait_for_value(export = "my_board-built", ignore = list("a")),
+    c("a", "b")
+  )
+
+  # Built for its expression, and left dormant rather than evaluated
+  expect_identical(app$get_value(export = "my_board-status_b"), "dormant")
+
+  # The construct request lands before the modal output is rendered and sent,
+  # so wait on the script itself rather than on the block having been built
+  app$wait_for_js(
+    paste0(
+      "document.querySelector('#my_board-generate_code-code_out')",
+      ".textContent.includes('ChickWeight')"
+    )
+  )
+
+  expect_match(
+    app$get_html("#my_board-generate_code-code_out"),
+    "ChickWeight",
+    fixed = TRUE
+  )
 })


### PR DESCRIPTION
## Summary

- Showing the code claimed the whole board by writing `visibility$required[[id]](TRUE)` for every block. Nothing ever wrote those back, and that slot belongs to the front-end, so a block parked with `required[[id]](FALSE)` was overwritten rather than supplemented: one "Show code" turned a lazily evaluating board into an eagerly evaluating one for the rest of the session, with nothing left to release it.
- The export asks for construction alone, through the `construct` component from #333. It assembles the script from block expressions and needs none of their results — `lang` (returned as `expr`) is not gated on `state_ready()` — so a board that defers its off-screen blocks now stays deferred while the code is shown. Nothing is claimed and nothing is released.
- Whether export is safe is read from what each block reports about itself rather than from eval status: `state_ready()` for user inputs that were never set, and the block's error conditions for its last run. Both are readable without putting anything in the eval set, and conditions outlive the evaluation that raised them. Eval status could not serve here, since a block reports `dormant` whenever nothing needs it, which says nothing about whether it works.
- A block that has never run reports neither, so the modal offers a one-off `evaluate` for the board. That leaves every block dormant again, but has each of them report what it found.

Worth spelling out, since it drove the design: an unconfigured merge block exports `merge(a, b, by = character(0), ...)`, which does not error when run — it cross joins, 6 x 6 into 36 rows. The harm is a silently wrong result rather than a crash, and `state_ready` is what catches it.

Breaking for a front-end supplying its own `generate_code_server()`:

| before | after |
| --- | --- |
| `generate_code_server(id, board, visibility = NULL, ...)` | `generate_code_server(id, board, update, ...)` |

Nothing downstream is affected in practice — blockr.dock reuses core's plugin server as is, replacing only where its UI is placed.

Fixes #320
