### PR TITLE
Stop bbquote deleting a call's NULL elements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: blockr.core
 Title: Graphical Web-Framework for Data Manipulation and Visualization
-Version: 0.1.4
+Version: 0.1.5
 Authors@R: 
     c(person(given = "Nicolas",
              family = "Bennett",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# blockr.core 0.1.5
+
+* `bbquote()` no longer drops `NULL` elements while walking a call. Assigning
+  the result of the recursive step with `[[<-` deleted the element whenever it
+  was `NULL`, leaving the call shorter than its names and aborting. This hit any
+  expression containing a literal `NULL` argument, and — because a `function`
+  definition's srcref slot is `NULL` under `keep.source = FALSE` — any
+  expression defining a function, but only once the package was installed
+  (#323).
+
 # blockr.core 0.1.4
 
 * `apply_board_update()` is now a real reducer rather than a no-op: its

--- a/R/utils-expr.R
+++ b/R/utils-expr.R
@@ -81,7 +81,16 @@ bbquote <- function(expr, where = parent.frame(), splice = FALSE) {
       if (nchar(names_e[i]) && is_dots(e_list[[i]])) {
         names_e[i] <- ""
       } else {
-        e_list[[i]] <- process_splices(e_list[[i]])
+        # `e_list[[i]] <- NULL` DELETES the element; single-bracket
+        # assignment of a one-element list replaces it. A call element is
+        # legitimately NULL: the srcref slot of a `function` definition is
+        # NULL whenever the code was parsed without srcrefs, which is what
+        # an INSTALLED package does (keep.source = FALSE) and load_all()
+        # does not. Deleting it left names one longer than the call and
+        # aborted with "'names' attribute [4] must be the same length as
+        # the vector [3]" -- so bquoting any expression that defines a
+        # function worked in every dev session and crashed in production.
+        e_list[i] <- list(process_splices(e_list[[i]]))
       }
     }
 

--- a/tests/testthat/test-utils-expr.R
+++ b/tests/testthat/test-utils-expr.R
@@ -129,3 +129,16 @@ test_that("bbquote survives an expression that defines a function", {
   out <- bbquote(fn, list())
   expect_identical(out[[2L]][[3L]][[2L]], quote(.(x)))
 })
+
+test_that("bbquote keeps NULL call elements", {
+
+  # `f(data, NULL)` is an ordinary shape in a block expression. A named NULL
+  # used to fail differently again ("subscript out of bounds"), because
+  # deleting an element shifts the indices the loop is still walking.
+  expect_identical(bbquote(f(x, NULL), list()), quote(f(x, NULL)))
+
+  expect_identical(
+    bbquote(list(a = NULL, b = .(x)), list(x = 1)),
+    quote(list(a = NULL, b = 1))
+  )
+})

--- a/tests/testthat/test-utils-expr.R
+++ b/tests/testthat/test-utils-expr.R
@@ -106,3 +106,26 @@ test_that("bbquote", {
   expect_error(.("a"), class = "dot_should_not_be_called")
   expect_error(..("a"), class = "dots_should_not_be_called")
 })
+
+test_that("bbquote survives an expression that defines a function", {
+
+  # A `function` definition is a 4-element call whose last slot is its
+  # srcref, and that slot is NULL whenever the code was parsed WITHOUT
+  # srcrefs -- which is what an installed package does (keep.source = FALSE)
+  # and what load_all() does not. Deleting a NULL element used to shorten
+  # the call below its names and abort, so bquoting such an expression
+  # worked in every dev session and crashed in production.
+  fn <- parse(text = "local({ f <- function(v, w) v; f(.(x), 1) })",
+              keep.source = FALSE)[[1L]]
+
+  expect_identical(as.list(fn[[2L]][[2L]][[3L]])[[4L]], NULL)
+
+  out <- bbquote(fn, list(x = 1))
+
+  expect_true(is.call(out))
+  expect_identical(eval(out), 1)
+
+  # An unresolved slot still survives the walk as a `.()` placeholder.
+  out <- bbquote(fn, list())
+  expect_identical(out[[2L]][[3L]][[2L]], quote(.(x)))
+})


### PR DESCRIPTION
Fixes #323.

`e_list[[i]] <- NULL` deletes the element instead of replacing it, so any call
containing a `NULL` element comes back shorter than its names and `bbquote()`
aborts. Single-bracket assignment of a one-element list replaces rather than
deletes.

Two triggers:

- **A literal `NULL` argument** — `f(data, NULL)` is an ordinary shape in a
  block expression. Fails everywhere, dev included. A *named* `NULL` fails
  differently again (`subscript out of bounds`), because the deletion shifts
  the indices the loop is still walking.
- **A function definition's srcref slot.** A `function` call has four elements
  and the fourth is its srcref, which is `NULL` whenever the code was parsed
  without srcrefs — what an installed package does (`keep.source = FALSE`) and
  what `load_all()` does not. So bquoting any expression that defines a
  function passed in every dev session and crashed only once installed.

**Blast radius:** anything that bquotes a block expression defining a function
was broken in production only. The known casualty is blockr.viz's picker block
(two function definitions), which took down a deployed board on a view switch.

Verified identical output to the current implementation on every existing call
shape (`.()`, `..()`, named splice, plain calls); the three failing shapes are
covered by new tests in `test-utils-expr.R`.
