### PR TITLE
Key evaluation claims by owner instead of one shared set

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -175,16 +175,15 @@
   are joined, with their upstream closure, to the eval set so they publish a
   current result and current conditions; core drops an `evaluate` request once
   the block has run, while a `require` claim is held until released. Claims are
-  keyed by owner (`list(<owner> = <block IDs>)`, conventionally labelled
-  `session$ns("...")`), each payload stating that owner's whole set and an empty
-  one releasing it, so two consumers may hold the same block without either
-  releasing the other's claim. Previously the only lever was the front-end's
-  `required` channel, which extensions never receive and which latches the block
-  into the eval set, so a consumer had no way to tell whether a change it had
-  just made broke an off-screen block. Since they carry no state change, request
-  components are also the one part of a payload a locked board still accepts,
-  and a payload rejected for being locked now records an outcome in
-  `board$last_update` instead of being dropped silently (#318, #325).
+  keyed by owner (`list(<owner> = list(set =, add =, rm =))`, conventionally
+  labelled `session$ns("...")`), so two consumers may hold the same block
+  without either releasing the other's claim. Previously the only lever was the
+  front-end's `required` channel, which extensions never receive and which
+  latches the block into the eval set, so a consumer had no way to tell whether
+  a change it had just made broke an off-screen block. Since they carry no state
+  change, request components are also the one part of a payload a locked board
+  still accepts, and a payload rejected for being locked now records an outcome
+  in `board$last_update` instead of being dropped silently (#318).
 * The `bbquote()` walk no longer drops `NULL` elements from a call. Assigning
   the recursive step's result with `[[<-` deleted the element whenever it was
   `NULL`, leaving the call shorter than its names and aborting with an `'names'

--- a/NEWS.md
+++ b/NEWS.md
@@ -174,14 +174,17 @@
   evaluating a dormant block without making it visible. Both name blocks that
   are joined, with their upstream closure, to the eval set so they publish a
   current result and current conditions; core drops an `evaluate` request once
-  the block has run, while a `require` claim (`list(add =, rm =)`) is held until
-  released. Previously the only lever was the front-end's `required` channel,
-  which extensions never receive and which latches the block into the eval set,
-  so a consumer had no way to tell whether a change it had just made broke an
-  off-screen block. Since they carry no state change, request components are
-  also the one part of a payload a locked board still accepts, and a payload
-  rejected for being locked now records an outcome in `board$last_update`
-  instead of being dropped silently (#318).
+  the block has run, while a `require` claim is held until released. Claims are
+  keyed by owner (`list(<owner> = <block IDs>)`, conventionally labelled
+  `session$ns("...")`), each payload stating that owner's whole set and an empty
+  one releasing it, so two consumers may hold the same block without either
+  releasing the other's claim. Previously the only lever was the front-end's
+  `required` channel, which extensions never receive and which latches the block
+  into the eval set, so a consumer had no way to tell whether a change it had
+  just made broke an off-screen block. Since they carry no state change, request
+  components are also the one part of a payload a locked board still accepts,
+  and a payload rejected for being locked now records an outcome in
+  `board$last_update` instead of being dropped silently (#318, #325).
 * The `bbquote()` walk no longer drops `NULL` elements from a call. Assigning
   the recursive step's result with `[[<-` deleted the element whenever it was
   `NULL`, leaving the call shorter than its names and aborting with an `'names'

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -27,7 +27,31 @@
 #' with their upstream closure over [board_links()] (without which they cannot
 #' produce a result), to the eval set. They differ only in who lets go: an
 #' `evaluate` request is a one-off that core drops once the block has run, while
-#' a `require` claim is held until the requester removes it.
+#' a `require` claim is held until its owner releases it.
+#'
+#' Claims are keyed by owner, the `require` component being a list of block IDs
+#' named by whoever needs them, so several consumers may hold the same block and
+#' none of them writes another's claim:
+#'
+#' ```r
+#' update(
+#'   list(
+#'     require = set_names(
+#'       list(board_block_ids(board$board)),
+#'       session$ns("code_export")
+#'     )
+#'   )
+#' )
+#' ```
+#'
+#' Each value states that owner's entire current set rather than a delta, so an
+#' owner releases everything it holds by naming itself with `character()` (or
+#' `NULL`), and a release that never arrives is repaired by that owner's next
+#' payload rather than accumulating. Core cannot infer the owner — the write and
+#' its effect are separated by a flush — so the label travels in the payload.
+#' Nothing keys off shiny's namespacing, but taking the label from
+#' `session$ns()` as above is what keeps owners unique without a registry, and
+#' lets one module hold two independent claims under two labels.
 #'
 #' Requests are orthogonal to the `required` visibility channel, so neither
 #' competes with the front-end's gating, and nothing about what is on screen
@@ -142,10 +166,10 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
       # The two request sets fed by the `evaluate` and `require` board update
       # components. Both join the needed set below; they differ in who lets go.
       # Core drops an `evaluating` entry once that block has had its evaluation
-      # pass (see the observer below), while a `required_blocks` entry stays
-      # until its requester removes it.
+      # pass (see the observer below), while `required_blocks` holds one entry
+      # per claim owner until that owner releases it.
       rv$evaluating <- reactiveVal(character())
-      rv$required_blocks <- reactiveVal(character())
+      rv$required_blocks <- reactiveVal(list())
 
       observe(
         {
@@ -811,7 +835,7 @@ valid_frozen <- function(x) {
 }
 
 requested_blocks <- function(rv) {
-  union(rv$evaluating(), rv$required_blocks())
+  union(rv$evaluating(), unlst(rv$required_blocks()))
 }
 
 # A block owes an evaluation pass while anything it needs for a result -- itself
@@ -994,7 +1018,9 @@ destroy_rm_blocks <- function(ids, rv, sess) {
   }
 
   rv$evaluating(setdiff(isolate(rv$evaluating()), ids))
-  rv$required_blocks(setdiff(isolate(rv$required_blocks()), ids))
+  rv$required_blocks(
+    filter_empty(lapply(isolate(rv$required_blocks()), setdiff, ids))
+  )
 
   invisible()
 }
@@ -1274,14 +1300,16 @@ add_blocks_to_stacks <- function(rv, add, session) {
 #' @section Request components:
 #' Two components carry a request rather than a state change:
 #' `evaluate`, a character vector of block IDs to evaluate once, and
-#' `require`, a list with `add` / `rm` character vectors claiming and
-#' releasing blocks that are to stay evaluated. Both put the named
-#' blocks (and their upstream closure) into the eval set without
-#' touching what the front-end shows — see the Evaluation requests
-#' section of [board_server()] — and both resolve their IDs against
-#' the post-update block set, so a payload may add a block and ask for
-#' it in one go. They are applied after the state delta, so a payload
-#' that edits a block and evaluates it sees the edit.
+#' `require`, a list of the block IDs that are to stay evaluated, named
+#' by claim owner. Each `require` value replaces that owner's claim, an
+#' empty one (`character()` or `NULL`) releasing it, so no owner writes
+#' another's. Both put the named blocks (and their upstream closure)
+#' into the eval set without touching what the front-end shows — see
+#' the Evaluation requests section of [board_server()] — and both
+#' resolve their IDs against the post-update block set, so a payload
+#' may add a block and ask for it in one go. They are applied after the
+#' state delta, so a payload that edits a block and evaluates it sees
+#' the edit.
 #'
 #' A locked board (see [is_board_locked()]) still accepts a payload of
 #' request components alone; one that also carries a state change is
@@ -1505,29 +1533,26 @@ validate_board_update_evaluate <- function(x, ids) {
 
 validate_board_update_require <- function(x, ids) {
 
-  exp_cmp <- c("rm", "add")
-
   if (!is.list(x) || length(names(x)) != length(x) ||
-        !all(names(x) %in% exp_cmp)) {
+        !all(nzchar(names(x))) || anyDuplicated(names(x)) != 0L) {
     blockr_abort(
-      "Expecting a board update `require` component to consist of components ",
-      "{exp_cmp}.",
-      class = "board_update_require_components_invalid"
+      "Expecting a board update `require` component to be specified as a list ",
+      "of claimed block IDs, named by owner with unique nonempty names.",
+      class = "board_update_require_owners_invalid"
     )
   }
 
-  for (cmp in intersect(exp_cmp, names(x))) {
+  invalid <- names(x)[!lgl_ply(x, valid_claim)]
 
-    if (!(is.null(x[[cmp]]) || is.character(x[[cmp]]))) {
-      blockr_abort(
-        "Expecting a board update `require` {cmp} component be specified as a ",
-        "character vector (or NULL).",
-        class = "board_update_require_component_invalid"
-      )
-    }
+  if (length(invalid)) {
+    blockr_abort(
+      "Expecting the blocks claimed by owner{?s} {invalid} to be specified as ",
+      "a character vector (or NULL).",
+      class = "board_update_require_claim_invalid"
+    )
   }
 
-  unknown <- setdiff(c(x$add, x$rm), ids)
+  unknown <- setdiff(unlst(x), ids)
 
   if (length(unknown)) {
     blockr_abort(
@@ -1537,6 +1562,10 @@ validate_board_update_require <- function(x, ids) {
   }
 
   invisible()
+}
+
+valid_claim <- function(x) {
+  is.null(x) || is.character(x)
 }
 
 has_comp <- function(comp, x) {
@@ -2028,14 +2057,17 @@ apply_core_board_update <- function(rv, upd, session,
 
 apply_eval_requests <- function(rv, upd) {
 
-  if (length(upd$require$rm)) {
-    log_debug("releasing block{?s} {upd$require$rm}")
-    rv$required_blocks(setdiff(isolate(rv$required_blocks()), upd$require$rm))
-  }
+  if (length(upd$require)) {
 
-  if (length(upd$require$add)) {
-    log_debug("requiring block{?s} {upd$require$add}")
-    rv$required_blocks(union(isolate(rv$required_blocks()), upd$require$add))
+    log_debug("updating block claims of owner{?s} {names(upd$require)}")
+
+    # Each value is that owner's whole set, so a per-owner overwrite rather
+    # than a union, and either spelling of "holds nothing" leaves no entry.
+    rv$required_blocks(
+      filter_empty(
+        utils::modifyList(isolate(rv$required_blocks()), upd$require)
+      )
+    )
   }
 
   if (length(upd$evaluate)) {

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -29,29 +29,35 @@
 #' `evaluate` request is a one-off that core drops once the block has run, while
 #' a `require` claim is held until its owner releases it.
 #'
-#' Claims are keyed by owner, the `require` component being a list of block IDs
-#' named by whoever needs them, so several consumers may hold the same block and
-#' none of them writes another's claim:
+#' Claims are keyed by owner, the `require` component mapping each owner to a
+#' delta over the blocks it holds, so several consumers may hold the same block
+#' and none of them writes another's claim:
 #'
 #' ```r
 #' update(
 #'   list(
 #'     require = set_names(
-#'       list(board_block_ids(board$board)),
-#'       session$ns("code_export")
+#'       list(list(set = board_block_ids(board$board))),
+#'       session$ns("preview")
 #'     )
 #'   )
 #' )
 #' ```
 #'
-#' Each value states that owner's entire current set rather than a delta, so an
-#' owner releases everything it holds by naming itself with `character()` (or
-#' `NULL`), and a release that never arrives is repaired by that owner's next
-#' payload rather than accumulating. Core cannot infer the owner — the write and
-#' its effect are separated by a flush — so the label travels in the payload.
-#' Nothing keys off shiny's namespacing, but taking the label from
-#' `session$ns()` as above is what keeps owners unique without a registry, and
-#' lets one module hold two independent claims under two labels.
+#' A delta is `set`, `add` and `rm`, of which `set` states that owner's entire
+#' set at once and cannot be combined with the other two. Releasing everything
+#' is `set = character()`; releasing part of a claim is `rm`, which — unlike
+#' `set` and `add` — may name a block the board no longer has, so a release
+#' cannot be rejected by a removal that raced it. Restating a set repairs a
+#' release that never arrived, rather than letting it accumulate.
+#'
+#' Core cannot infer the owner — the write and its effect are separated by a
+#' flush — so the label travels in the payload. Nothing keys off shiny's
+#' namespacing, but taking the label from `session$ns()` as above is what keeps
+#' owners unique without a registry, and lets one module hold two independent
+#' claims under two labels. A claim outlives the module that made it: core
+#' drops a claimed block once it leaves the board, but an owner that goes away
+#' without releasing holds what it held for the rest of the session.
 #'
 #' Requests are orthogonal to the `required` visibility channel, so neither
 #' competes with the front-end's gating, and nothing about what is on screen
@@ -1300,16 +1306,18 @@ add_blocks_to_stacks <- function(rv, add, session) {
 #' @section Request components:
 #' Two components carry a request rather than a state change:
 #' `evaluate`, a character vector of block IDs to evaluate once, and
-#' `require`, a list of the block IDs that are to stay evaluated, named
-#' by claim owner. Each `require` value replaces that owner's claim, an
-#' empty one (`character()` or `NULL`) releasing it, so no owner writes
-#' another's. Both put the named blocks (and their upstream closure)
-#' into the eval set without touching what the front-end shows — see
-#' the Evaluation requests section of [board_server()] — and both
-#' resolve their IDs against the post-update block set, so a payload
-#' may add a block and ask for it in one go. They are applied after the
-#' state delta, so a payload that edits a block and evaluates it sees
-#' the edit.
+#' `require`, a list of per-owner deltas over the blocks that are to
+#' stay evaluated. Each delta is `set`, `add` and `rm` — `set` states
+#' that owner's whole set and is exclusive with the other two — so no
+#' owner writes another's claim. Both components put the named blocks
+#' (and their upstream closure) into the eval set without touching what
+#' the front-end shows — see the Evaluation requests section of
+#' [board_server()] — and both resolve their IDs against the
+#' post-update block set, so a payload may add a block and ask for it
+#' in one go. A `require` `rm` is the exception, naming blocks to
+#' release rather than to evaluate, and so may name one the board no
+#' longer has. They are applied after the state delta, so a payload
+#' that edits a block and evaluates it sees the edit.
 #'
 #' A locked board (see [is_board_locked()]) still accepts a payload of
 #' request components alone; one that also carries a state change is
@@ -1537,35 +1545,73 @@ validate_board_update_require <- function(x, ids) {
         !all(nzchar(names(x))) || anyDuplicated(names(x)) != 0L) {
     blockr_abort(
       "Expecting a board update `require` component to be specified as a list ",
-      "of claimed block IDs, named by owner with unique nonempty names.",
+      "of per-owner claim deltas with unique nonempty names.",
       class = "board_update_require_owners_invalid"
     )
   }
 
-  invalid <- names(x)[!lgl_ply(x, valid_claim)]
-
-  if (length(invalid)) {
-    blockr_abort(
-      "Expecting the blocks claimed by owner{?s} {invalid} to be specified as ",
-      "a character vector (or NULL).",
-      class = "board_update_require_claim_invalid"
-    )
-  }
-
-  unknown <- setdiff(unlst(x), ids)
-
-  if (length(unknown)) {
-    blockr_abort(
-      "Requested evaluation of unknown block{?s} {unknown}.",
-      class = "board_update_require_unknown_id"
-    )
+  for (owner in names(x)) {
+    validate_claim_delta(x[[owner]], owner, ids)
   }
 
   invisible()
 }
 
-valid_claim <- function(x) {
-  is.null(x) || is.character(x)
+validate_claim_delta <- function(x, owner, ids) {
+
+  exp_cmp <- c("set", "add", "rm")
+
+  if (!is.list(x) || length(names(x)) != length(x) ||
+        !all(names(x) %in% exp_cmp)) {
+    blockr_abort(
+      "Expecting the claim of owner {owner} to consist of components ",
+      "{exp_cmp}.",
+      class = "board_update_require_components_invalid"
+    )
+  }
+
+  for (cmp in names(x)) {
+
+    if (!(is.null(x[[cmp]]) || is.character(x[[cmp]]))) {
+      blockr_abort(
+        "Expecting the {cmp} component of the claim of owner {owner} to be ",
+        "specified as a character vector (or NULL).",
+        class = "board_update_require_component_invalid"
+      )
+    }
+  }
+
+  if ("set" %in% names(x) && any(c("add", "rm") %in% names(x))) {
+    blockr_abort(
+      "Expecting the claim of owner {owner} to state a whole set via `set` or ",
+      "a delta via `add` and `rm`, but not both.",
+      class = "board_update_require_set_delta_clash"
+    )
+  }
+
+  both <- intersect(x$add, x$rm)
+
+  if (length(both)) {
+    blockr_abort(
+      "Expecting the claim of owner {owner} to either add or remove ",
+      "{qty(both)}block{?s} {both}.",
+      class = "board_update_require_add_rm_clash"
+    )
+  }
+
+  # Only a claim has to name blocks that exist -- a release commonly follows
+  # the very removal that made it necessary.
+  unknown <- setdiff(c(x$set, x$add), ids)
+
+  if (length(unknown)) {
+    blockr_abort(
+      "Owner {owner} requested evaluation of unknown {qty(unknown)}",
+      "block{?s} {unknown}.",
+      class = "board_update_require_unknown_id"
+    )
+  }
+
+  invisible()
 }
 
 has_comp <- function(comp, x) {
@@ -2057,17 +2103,19 @@ apply_core_board_update <- function(rv, upd, session,
 
 apply_eval_requests <- function(rv, upd) {
 
-  if (length(upd$require)) {
+  req <- upd[["require"]]
 
-    log_debug("updating block claims of owner{?s} {names(upd$require)}")
+  if (length(req)) {
 
-    # Each value is that owner's whole set, so a per-owner overwrite rather
-    # than a union, and either spelling of "holds nothing" leaves no entry.
-    rv$required_blocks(
-      filter_empty(
-        utils::modifyList(isolate(rv$required_blocks()), upd$require)
-      )
-    )
+    log_debug("updating block claims of owner{?s} {names(req)}")
+
+    claims <- isolate(rv$required_blocks())
+
+    for (owner in names(req)) {
+      claims[[owner]] <- apply_claim_delta(claims[[owner]], req[[owner]])
+    }
+
+    rv$required_blocks(filter_empty(claims))
   }
 
   if (length(upd$evaluate)) {
@@ -2076,6 +2124,15 @@ apply_eval_requests <- function(rv, upd) {
   }
 
   invisible()
+}
+
+apply_claim_delta <- function(cur, delta) {
+
+  if ("set" %in% names(delta)) {
+    return(delta$set)
+  }
+
+  union(setdiff(cur, delta$rm), delta$add)
 }
 
 preprocess_board_update <- function(update, board) {

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -1477,15 +1477,15 @@ validate_board_update_structure <- function(payload, board) {
   }
 
   if ("blocks" %in% names(payload)) {
-    validate_board_update_blocks(payload$blocks, board)
+    validate_board_update_blocks(payload[["blocks"]], board)
   }
 
   if ("links" %in% names(payload)) {
-    validate_board_update_links(payload$links, board)
+    validate_board_update_links(payload[["links"]], board)
   }
 
   if ("stacks" %in% names(payload)) {
-    validate_board_update_stacks(payload$stacks, board)
+    validate_board_update_stacks(payload[["stacks"]], board)
   }
 
   # Both request components name blocks, and a payload may add the very block it
@@ -1495,11 +1495,11 @@ validate_board_update_structure <- function(payload, board) {
     ids <- updated_block_ids(payload, board)
 
     if ("evaluate" %in% names(payload)) {
-      validate_board_update_evaluate(payload$evaluate, ids)
+      validate_board_update_evaluate(payload[["evaluate"]], ids)
     }
 
     if ("require" %in% names(payload)) {
-      validate_board_update_require(payload$require, ids)
+      validate_board_update_require(payload[["require"]], ids)
     }
   }
 
@@ -1514,7 +1514,7 @@ updated_block_ids <- function(payload, board) {
     return(ids)
   }
 
-  union(setdiff(ids, payload$blocks$rm), names(payload$blocks$add))
+  union(setdiff(ids, payload[["blocks"]]$rm), names(payload[["blocks"]]$add))
 }
 
 validate_board_update_evaluate <- function(x, ids) {
@@ -1861,27 +1861,29 @@ augment_board_update <- function(upd, board, ...,
 augment_board_update.board <- function(upd, board, ...,
                                        session = get_session()) {
 
-  if ("blocks" %in% names(upd) && "rm" %in% names(upd$blocks)) {
+  if ("blocks" %in% names(upd) && "rm" %in% names(upd[["blocks"]])) {
 
-    rm <- upd$blocks$rm
+    rm <- upd[["blocks"]]$rm
 
     links <- board_links(board)
 
     mis_lnk <- setdiff(
       names(links[links_incident(links, rm)]),
-      upd$links$rm
+      upd[["links"]]$rm
     )
 
     merged_stks <- board_stacks(board)
 
-    if (length(upd$stacks$mod)) {
-      merged_stks[names(upd$stacks$mod)] <- merge_stack_mods(
-        board, upd$stacks$mod
+    if (length(upd[["stacks"]]$mod)) {
+      merged_stks[names(upd[["stacks"]]$mod)] <- merge_stack_mods(
+        board, upd[["stacks"]]$mod
       )
     }
 
-    if (length(upd$stacks$rm)) {
-      merged_stks <- merged_stks[setdiff(names(merged_stks), upd$stacks$rm)]
+    if (length(upd[["stacks"]]$rm)) {
+      merged_stks <- merged_stks[
+        setdiff(names(merged_stks), upd[["stacks"]]$rm)
+      ]
     }
 
     affected <- merged_stks[
@@ -1901,33 +1903,33 @@ augment_board_update.board <- function(upd, board, ...,
 
   add_lnk <- NULL
 
-  if ("links" %in% names(upd) && "add" %in% names(upd$links)) {
+  if ("links" %in% names(upd) && "add" %in% names(upd[["links"]])) {
 
-    tmp <- complete_unary_inputs(upd$links$add, board_blocks(board))
+    tmp <- complete_unary_inputs(upd[["links"]]$add, board_blocks(board))
 
-    if (!identical(tmp$input, upd$links$add$input)) {
+    if (!identical(tmp$input, upd[["links"]]$add$input)) {
       add_lnk <- tmp
     }
   }
 
   if (length(mis_lnk)) {
     log_debug("adding link removal{?s} for {mis_lnk}")
-    upd$links$rm <- c(mis_lnk, upd$links$rm)
+    upd[["links"]]$rm <- c(mis_lnk, upd[["links"]]$rm)
   }
 
   if (length(upd_stk)) {
     log_debug("adding stack update{?s} for {names(upd_stk)}")
-    upd$stacks$mod <- c(
+    upd[["stacks"]]$mod <- c(
       upd_stk,
-      upd$stacks$mod[setdiff(names(upd$stacks$mod), names(upd_stk))]
+      upd[["stacks"]]$mod[setdiff(names(upd[["stacks"]]$mod), names(upd_stk))]
     )
   }
 
   if (length(add_lnk)) {
     log_debug("adding link input update{?s} for {names(add_lnk)}")
-    upd$links$add <- c(
+    upd[["links"]]$add <- c(
       add_lnk,
-      upd$links$add[setdiff(names(upd$links$add), names(add_lnk))]
+      upd[["links"]]$add[setdiff(names(upd[["links"]]$add), names(add_lnk))]
     )
   }
 
@@ -1945,29 +1947,29 @@ apply_board_update <- function(board, upd, ...,
 apply_board_update.board <- function(board, upd, ...,
                                      session = get_session()) {
 
-  if (length(upd$blocks$add)) {
-    board_blocks(board) <- c(board_blocks(board), upd$blocks$add)
+  if (length(upd[["blocks"]]$add)) {
+    board_blocks(board) <- c(board_blocks(board), upd[["blocks"]]$add)
   }
 
-  add <- upd$links$add
-  rm <- upd$links$rm
+  add <- upd[["links"]]$add
+  rm <- upd[["links"]]$rm
 
-  if (length(upd$links$mod)) {
-    add <- vec_c(add, merge_link_mods(board, upd$links$mod))
-    rm <- c(rm, names(upd$links$mod))
+  if (length(upd[["links"]]$mod)) {
+    add <- vec_c(add, merge_link_mods(board, upd[["links"]]$mod))
+    rm <- c(rm, names(upd[["links"]]$mod))
   }
 
   board <- modify_board_links(board, add, rm, ..., session = session)
 
   board <- modify_board_stacks(
-    board, upd$stacks$add, upd$stacks$rm,
-    merge_stack_mods(board, upd$stacks$mod),
+    board, upd[["stacks"]]$add, upd[["stacks"]]$rm,
+    merge_stack_mods(board, upd[["stacks"]]$mod),
     ...,
     session = session
   )
 
-  if (length(upd$blocks$rm)) {
-    board <- rm_blocks(board, upd$blocks$rm, ..., session = session)
+  if (length(upd[["blocks"]]$rm)) {
+    board <- rm_blocks(board, upd[["blocks"]]$rm, ..., session = session)
   }
 
   board
@@ -1980,19 +1982,19 @@ apply_core_board_update <- function(rv, upd, session,
 
   ns <- session$ns
 
-  lnk_add <- upd$links$add
-  lnk_rm <- upd$links$rm
+  lnk_add <- upd[["links"]]$add
+  lnk_rm <- upd[["links"]]$rm
 
-  if (length(upd$links$mod)) {
-    lnk_add <- vec_c(lnk_add, merge_link_mods(rv$board, upd$links$mod))
-    lnk_rm <- c(lnk_rm, names(upd$links$mod))
+  if (length(upd[["links"]]$mod)) {
+    lnk_add <- vec_c(lnk_add, merge_link_mods(rv$board, upd[["links"]]$mod))
+    lnk_rm <- c(lnk_rm, names(upd[["links"]]$mod))
   }
 
   # Links into a block that is added or removed in this update are wired by
   # construct_block() / dropped by destroy_rm_blocks(); the reactive link delta
   # below only touches links between surviving blocks. Resolve it (and the stack
   # mod deltas) against the pre-update board before the reduce rewrites it.
-  lifecycle_blocks <- c(names(upd$blocks$add), upd$blocks$rm)
+  lifecycle_blocks <- c(names(upd[["blocks"]]$add), upd[["blocks"]]$rm)
   between_survivors <- function(x) {
     if (length(x)) x[!field(x, "to") %in% lifecycle_blocks] else x
   }
@@ -2002,7 +2004,7 @@ apply_core_board_update <- function(rv, upd, session,
   lnk_add <- between_survivors(lnk_add)
   lnk_rm <- between_survivors(cur_links[intersect(lnk_rm, names(cur_links))])
 
-  stk <- upd$stacks
+  stk <- upd[["stacks"]]
 
   if (length(stk$mod)) {
     stk$mod <- merge_stack_mods(rv$board, stk$mod)
@@ -2011,14 +2013,14 @@ apply_core_board_update <- function(rv, upd, session,
   # Tear down removed blocks before the reduce drops them from the board: the
   # remove_block_ui() method (e.g. blockr.dock's) asserts the block is still
   # present and reads it to locate the live panel it detaches.
-  if (length(upd$blocks$rm)) {
+  if (length(upd[["blocks"]]$rm)) {
 
-    log_debug("removing block{?s} {names(upd$blocks$rm)}")
+    log_debug("removing block{?s} {upd[['blocks']]$rm}")
 
     do.call(
       remove_block_ui,
       c(
-        list(ns(NULL), rv$board, upd$blocks$rm),
+        list(ns(NULL), rv$board, upd[["blocks"]]$rm),
         dot_args,
         list(
           edit_ui = edit_block,
@@ -2028,9 +2030,9 @@ apply_core_board_update <- function(rv, upd, session,
       )
     )
 
-    destroy_rm_blocks(upd$blocks$rm, rv, session)
+    destroy_rm_blocks(upd[["blocks"]]$rm, rv, session)
 
-    rm_vis_slots(vis, upd$blocks$rm)
+    rm_vis_slots(vis, upd[["blocks"]]$rm)
   }
 
   rv$board <- do.call(
@@ -2040,16 +2042,16 @@ apply_core_board_update <- function(rv, upd, session,
 
   stopifnot(is_board(rv$board))
 
-  if (length(upd$blocks$add)) {
+  if (length(upd[["blocks"]]$add)) {
 
-    log_debug("adding block{?s} {names(upd$blocks$add)}")
+    log_debug("adding block{?s} {names(upd[['blocks']]$add)}")
 
-    add_vis_slots(vis, names(upd$blocks$add))
+    add_vis_slots(vis, names(upd[["blocks"]]$add))
 
     do.call(
       insert_block_ui,
       c(
-        list(ns(NULL), rv$board, upd$blocks$add),
+        list(ns(NULL), rv$board, upd[["blocks"]]$add),
         dot_args,
         list(
           edit_ui = edit_block,
@@ -2059,17 +2061,17 @@ apply_core_board_update <- function(rv, upd, session,
       )
     )
 
-    construct_blocks(names(upd$blocks$add), rv, edit_block, ctrl_block,
+    construct_blocks(names(upd[["blocks"]]$add), rv, edit_block, ctrl_block,
                      edit_plugin_args, vis)
   }
 
-  if (length(upd$blocks$mod)) {
+  if (length(upd[["blocks"]]$mod)) {
 
-    log_debug("modifying block{?s} {names(upd$blocks$mod)}")
+    log_debug("modifying block{?s} {names(upd[['blocks']]$mod)}")
 
-    for (blk_id in names(upd$blocks$mod)) {
+    for (blk_id in names(upd[["blocks"]]$mod)) {
 
-      delta <- upd$blocks$mod[[blk_id]]
+      delta <- upd[["blocks"]]$mod[[blk_id]]
 
       if (length(delta)) {
         construct_block(blk_id, rv, edit_block, ctrl_block, edit_plugin_args,
@@ -2118,9 +2120,9 @@ apply_eval_requests <- function(rv, upd) {
     rv$required_blocks(filter_empty(claims))
   }
 
-  if (length(upd$evaluate)) {
-    log_debug("requesting evaluation of block{?s} {upd$evaluate}")
-    rv$evaluating(union(isolate(rv$evaluating()), upd$evaluate))
+  if (length(upd[["evaluate"]])) {
+    log_debug("requesting evaluation of block{?s} {upd[['evaluate']]}")
+    rv$evaluating(union(isolate(rv$evaluating()), upd[["evaluate"]]))
   }
 
   invisible()

--- a/man/board_server.Rd
+++ b/man/board_server.Rd
@@ -83,28 +83,34 @@ produce a result), to the eval set. They differ only in who lets go: an
 \code{evaluate} request is a one-off that core drops once the block has run, while
 a \code{require} claim is held until its owner releases it.
 
-Claims are keyed by owner, the \code{require} component being a list of block IDs
-named by whoever needs them, so several consumers may hold the same block and
-none of them writes another's claim:
+Claims are keyed by owner, the \code{require} component mapping each owner to a
+delta over the blocks it holds, so several consumers may hold the same block
+and none of them writes another's claim:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{update(
   list(
     require = set_names(
-      list(board_block_ids(board$board)),
-      session$ns("code_export")
+      list(list(set = board_block_ids(board$board))),
+      session$ns("preview")
     )
   )
 )
 }\if{html}{\out{</div>}}
 
-Each value states that owner's entire current set rather than a delta, so an
-owner releases everything it holds by naming itself with \code{character()} (or
-\code{NULL}), and a release that never arrives is repaired by that owner's next
-payload rather than accumulating. Core cannot infer the owner — the write and
-its effect are separated by a flush — so the label travels in the payload.
-Nothing keys off shiny's namespacing, but taking the label from
-\code{session$ns()} as above is what keeps owners unique without a registry, and
-lets one module hold two independent claims under two labels.
+A delta is \code{set}, \code{add} and \code{rm}, of which \code{set} states that owner's entire
+set at once and cannot be combined with the other two. Releasing everything
+is \code{set = character()}; releasing part of a claim is \code{rm}, which — unlike
+\code{set} and \code{add} — may name a block the board no longer has, so a release
+cannot be rejected by a removal that raced it. Restating a set repairs a
+release that never arrived, rather than letting it accumulate.
+
+Core cannot infer the owner — the write and its effect are separated by a
+flush — so the label travels in the payload. Nothing keys off shiny's
+namespacing, but taking the label from \code{session$ns()} as above is what keeps
+owners unique without a registry, and lets one module hold two independent
+claims under two labels. A claim outlives the module that made it: core
+drops a claimed block once it leaves the board, but an owner that goes away
+without releasing holds what it held for the rest of the session.
 
 Requests are orthogonal to the \code{required} visibility channel, so neither
 competes with the front-end's gating, and nothing about what is on screen

--- a/man/board_server.Rd
+++ b/man/board_server.Rd
@@ -81,7 +81,30 @@ up to date, without putting it on screen, through the \code{evaluate} and
 with their upstream closure over \code{\link[=board_links]{board_links()}} (without which they cannot
 produce a result), to the eval set. They differ only in who lets go: an
 \code{evaluate} request is a one-off that core drops once the block has run, while
-a \code{require} claim is held until the requester removes it.
+a \code{require} claim is held until its owner releases it.
+
+Claims are keyed by owner, the \code{require} component being a list of block IDs
+named by whoever needs them, so several consumers may hold the same block and
+none of them writes another's claim:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{update(
+  list(
+    require = set_names(
+      list(board_block_ids(board$board)),
+      session$ns("code_export")
+    )
+  )
+)
+}\if{html}{\out{</div>}}
+
+Each value states that owner's entire current set rather than a delta, so an
+owner releases everything it holds by naming itself with \code{character()} (or
+\code{NULL}), and a release that never arrives is repaired by that owner's next
+payload rather than accumulating. Core cannot infer the owner — the write and
+its effect are separated by a flush — so the label travels in the payload.
+Nothing keys off shiny's namespacing, but taking the label from
+\code{session$ns()} as above is what keeps owners unique without a registry, and
+lets one module hold two independent claims under two labels.
 
 Requests are orthogonal to the \code{required} visibility channel, so neither
 competes with the front-end's gating, and nothing about what is on screen

--- a/man/board_update.Rd
+++ b/man/board_update.Rd
@@ -63,16 +63,18 @@ payload slots reach subclass augment / apply methods.
 
 Two components carry a request rather than a state change:
 \code{evaluate}, a character vector of block IDs to evaluate once, and
-\code{require}, a list of the block IDs that are to stay evaluated, named
-by claim owner. Each \code{require} value replaces that owner's claim, an
-empty one (\code{character()} or \code{NULL}) releasing it, so no owner writes
-another's. Both put the named blocks (and their upstream closure)
-into the eval set without touching what the front-end shows — see
-the Evaluation requests section of \code{\link[=board_server]{board_server()}} — and both
-resolve their IDs against the post-update block set, so a payload
-may add a block and ask for it in one go. They are applied after the
-state delta, so a payload that edits a block and evaluates it sees
-the edit.
+\code{require}, a list of per-owner deltas over the blocks that are to
+stay evaluated. Each delta is \code{set}, \code{add} and \code{rm} — \code{set} states
+that owner's whole set and is exclusive with the other two — so no
+owner writes another's claim. Both components put the named blocks
+(and their upstream closure) into the eval set without touching what
+the front-end shows — see the Evaluation requests section of
+\code{\link[=board_server]{board_server()}} — and both resolve their IDs against the
+post-update block set, so a payload may add a block and ask for it
+in one go. A \code{require} \code{rm} is the exception, naming blocks to
+release rather than to evaluate, and so may name one the board no
+longer has. They are applied after the state delta, so a payload
+that edits a block and evaluates it sees the edit.
 
 A locked board (see \code{\link[=is_board_locked]{is_board_locked()}}) still accepts a payload of
 request components alone; one that also carries a state change is

--- a/man/board_update.Rd
+++ b/man/board_update.Rd
@@ -63,14 +63,16 @@ payload slots reach subclass augment / apply methods.
 
 Two components carry a request rather than a state change:
 \code{evaluate}, a character vector of block IDs to evaluate once, and
-\code{require}, a list with \code{add} / \code{rm} character vectors claiming and
-releasing blocks that are to stay evaluated. Both put the named
-blocks (and their upstream closure) into the eval set without
-touching what the front-end shows — see the Evaluation requests
-section of \code{\link[=board_server]{board_server()}} — and both resolve their IDs against
-the post-update block set, so a payload may add a block and ask for
-it in one go. They are applied after the state delta, so a payload
-that edits a block and evaluates it sees the edit.
+\code{require}, a list of the block IDs that are to stay evaluated, named
+by claim owner. Each \code{require} value replaces that owner's claim, an
+empty one (\code{character()} or \code{NULL}) releasing it, so no owner writes
+another's. Both put the named blocks (and their upstream closure)
+into the eval set without touching what the front-end shows — see
+the Evaluation requests section of \code{\link[=board_server]{board_server()}} — and both
+resolve their IDs against the post-update block set, so a payload
+may add a block and ask for it in one go. They are applied after the
+state delta, so a payload that edits a block and evaluates it sees
+the edit.
 
 A locked board (see \code{\link[=is_board_locked]{is_board_locked()}}) still accepts a payload of
 request components alone; one that also carries a state change is

--- a/tests/testthat/test-board-lock.R
+++ b/tests/testthat/test-board-lock.R
@@ -76,7 +76,7 @@ test_that("a locked board still accepts evaluation requests", {
       session$flushReact()
 
       # A request carries no state change, so the lock does not apply to it.
-      board_update(list(require = list(consumer = "a")))
+      board_update(list(require = list(consumer = list(set = "a"))))
       session$flushReact()
 
       expect_identical(rv$required_blocks(), list(consumer = "a"))
@@ -86,7 +86,7 @@ test_that("a locked board still accepts evaluation requests", {
       board_update(
         list(
           blocks = list(add = as_blocks(list(b = new_dataset_block("BOD")))),
-          require = list(consumer = character())
+          require = list(consumer = list(set = character()))
         )
       )
       session$flushReact()

--- a/tests/testthat/test-board-lock.R
+++ b/tests/testthat/test-board-lock.R
@@ -76,24 +76,24 @@ test_that("a locked board still accepts evaluation requests", {
       session$flushReact()
 
       # A request carries no state change, so the lock does not apply to it.
-      board_update(list(require = list(add = "a")))
+      board_update(list(require = list(consumer = "a")))
       session$flushReact()
 
-      expect_setequal(rv$required_blocks(), "a")
+      expect_identical(rv$required_blocks(), list(consumer = "a"))
       expect_true(rv$last_update$ok)
 
       # Mixed with one that does, the payload is dropped whole.
       board_update(
         list(
           blocks = list(add = as_blocks(list(b = new_dataset_block("BOD")))),
-          require = list(rm = "a")
+          require = list(consumer = character())
         )
       )
       session$flushReact()
 
       expect_false(rv$last_update$ok)
       expect_length(board_blocks(rv$board), 1L)
-      expect_setequal(rv$required_blocks(), "a")
+      expect_identical(rv$required_blocks(), list(consumer = "a"))
     },
     args = list(x = board, plugins = list())
   )

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -804,7 +804,7 @@ test_that("update validation", {
 
   expect_error(
     validate_board_update(
-      list(require = list("a")),
+      list(require = list(list(set = "a"))),
       new_board(blocks(a = new_dataset_block()))
     ),
     class = "board_update_require_owners_invalid"
@@ -812,7 +812,7 @@ test_that("update validation", {
 
   expect_error(
     validate_board_update(
-      list(require = set_names(list("a"), "")),
+      list(require = set_names(list(list(set = "a")), "")),
       new_board(blocks(a = new_dataset_block()))
     ),
     class = "board_update_require_owners_invalid"
@@ -820,7 +820,12 @@ test_that("update validation", {
 
   expect_error(
     validate_board_update(
-      list(require = set_names(list("a", "a"), c("owner", "owner"))),
+      list(
+        require = set_names(
+          list(list(set = "a"), list(add = "a")),
+          c("board-code_export", "board-code_export")
+        )
+      ),
       new_board(blocks(a = new_dataset_block()))
     ),
     class = "board_update_require_owners_invalid"
@@ -828,18 +833,59 @@ test_that("update validation", {
 
   expect_error(
     validate_board_update(
-      list(require = list(owner = 1L)),
+      list(require = list(owner = "a")),
       new_board(blocks(a = new_dataset_block()))
     ),
-    class = "board_update_require_claim_invalid"
+    class = "board_update_require_components_invalid"
   )
 
   expect_error(
     validate_board_update(
-      list(require = list(owner = "b")),
+      list(require = list(owner = list(claim = "a"))),
+      new_board(blocks(a = new_dataset_block()))
+    ),
+    class = "board_update_require_components_invalid"
+  )
+
+  expect_error(
+    validate_board_update(
+      list(require = list(owner = list(set = 1L))),
+      new_board(blocks(a = new_dataset_block()))
+    ),
+    class = "board_update_require_component_invalid"
+  )
+
+  expect_error(
+    validate_board_update(
+      list(require = list(owner = list(set = "a", add = "a"))),
+      new_board(blocks(a = new_dataset_block()))
+    ),
+    class = "board_update_require_set_delta_clash"
+  )
+
+  expect_error(
+    validate_board_update(
+      list(require = list(owner = list(add = "a", rm = "a"))),
+      new_board(blocks(a = new_dataset_block()))
+    ),
+    class = "board_update_require_add_rm_clash"
+  )
+
+  expect_error(
+    validate_board_update(
+      list(require = list(owner = list(add = "b"))),
       new_board(blocks(a = new_dataset_block()))
     ),
     class = "board_update_require_unknown_id"
+  )
+
+  # Releasing is the one direction that may name a block the board no longer
+  # has, so a removal that races a release cannot reject the payload.
+  expect_silent(
+    validate_board_update(
+      list(require = list(owner = list(rm = "b"))),
+      new_board(blocks(a = new_dataset_block()))
+    )
   )
 })
 

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -889,6 +889,29 @@ test_that("update validation", {
   )
 })
 
+test_that("a subclass payload slot is not taken for a core component", {
+
+  board <- new_board(blocks(a = new_dataset_block()))
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      # Unknown top-level keys reach subclass methods untouched, and `$`
+      # partial-matches, so a slot whose name extends a core one would be
+      # applied here without ever having been validated.
+      board_update(list(evaluate_all = "nope", require_all = "nope"))
+      session$flushReact()
+
+      expect_true(rv$last_update$ok)
+      expect_length(rv$evaluating(), 0L)
+      expect_length(rv$required_blocks(), 0L)
+    },
+    args = list(x = board, plugins = list())
+  )
+})
+
 test_that("public validate_board_update", {
 
   brd <- new_board(

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -801,6 +801,46 @@ test_that("update validation", {
     ),
     class = "board_block_stack_name_mismatch"
   )
+
+  expect_error(
+    validate_board_update(
+      list(require = list("a")),
+      new_board(blocks(a = new_dataset_block()))
+    ),
+    class = "board_update_require_owners_invalid"
+  )
+
+  expect_error(
+    validate_board_update(
+      list(require = set_names(list("a"), "")),
+      new_board(blocks(a = new_dataset_block()))
+    ),
+    class = "board_update_require_owners_invalid"
+  )
+
+  expect_error(
+    validate_board_update(
+      list(require = set_names(list("a", "a"), c("owner", "owner"))),
+      new_board(blocks(a = new_dataset_block()))
+    ),
+    class = "board_update_require_owners_invalid"
+  )
+
+  expect_error(
+    validate_board_update(
+      list(require = list(owner = 1L)),
+      new_board(blocks(a = new_dataset_block()))
+    ),
+    class = "board_update_require_claim_invalid"
+  )
+
+  expect_error(
+    validate_board_update(
+      list(require = list(owner = "b")),
+      new_board(blocks(a = new_dataset_block()))
+    ),
+    class = "board_update_require_unknown_id"
+  )
 })
 
 test_that("public validate_board_update", {

--- a/tests/testthat/test-visibility-gating.R
+++ b/tests/testthat/test-visibility-gating.R
@@ -1008,7 +1008,7 @@ test_that("a required claim holds a block until it is released", {
       reset_probes()
 
       # A claim, unlike a one-off request, survives evaluation.
-      board_update(list(require = list(add = "r")))
+      board_update(list(require = list(consumer = "r")))
       session$flushReact()
 
       expect_identical(rv$eval[["r"]](), "ready")
@@ -1016,11 +1016,11 @@ test_that("a required claim holds a block until it is released", {
       for (i in 1:3) session$flushReact()
 
       expect_identical(rv$eval[["r"]](), "ready")
-      expect_setequal(rv$required_blocks(), "r")
+      expect_identical(rv$required_blocks(), list(consumer = "r"))
 
       # Releasing it hands the block back to the front-end's gating, which
       # parked it.
-      board_update(list(require = list(rm = "r")))
+      board_update(list(require = list(consumer = character())))
       session$flushReact()
 
       expect_identical(rv$eval[["r"]](), "dormant")
@@ -1033,6 +1033,107 @@ test_that("a required claim holds a block until it is released", {
       callbacks = function(visibility, ...) {
         require_blocks(visibility, "s", "r")
         render_blocks(visibility, "s", "r")
+      }
+    )
+  )
+})
+
+test_that("one owner's release leaves another owner's claim standing", {
+
+  reset_probes()
+
+  withr::local_options(blockr.background_construction_delay = 0)
+
+  board <- new_board(
+    blocks = c(
+      s = with_id(probe_source(), "s"),
+      r = with_id(probe_passthrough(), "r")
+    ),
+    links = links(sr = new_link("s", "r", "data"))
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      park_blocks(vis, "r")
+      session$flushReact()
+
+      expect_identical(rv$eval[["r"]](), "dormant")
+
+      board_update(list(require = list(one = "r")))
+      session$flushReact()
+
+      board_update(list(require = list(two = "r")))
+      session$flushReact()
+
+      expect_identical(rv$required_blocks(), list(one = "r", two = "r"))
+      expect_identical(rv$eval[["r"]](), "ready")
+
+      # The block is held by two owners, so the first letting go does not
+      # release the second's claim.
+      board_update(list(require = list(one = character())))
+      session$flushReact()
+
+      expect_identical(rv$required_blocks(), list(two = "r"))
+      expect_identical(rv$eval[["r"]](), "ready")
+
+      # An owner states its whole set, and mapping it to NULL is the same
+      # release as mapping it to no blocks.
+      board_update(list(require = list(two = NULL)))
+      session$flushReact()
+
+      expect_length(rv$required_blocks(), 0L)
+      expect_identical(rv$eval[["r"]](), "dormant")
+    },
+    args = list(
+      x = board,
+      plugins = list(),
+      callbacks = function(visibility, ...) {
+        require_blocks(visibility, "s", "r")
+        render_blocks(visibility, "s", "r")
+      }
+    )
+  )
+})
+
+test_that("removing a claimed block prunes it from every owner", {
+
+  reset_probes()
+
+  withr::local_options(blockr.background_construction_delay = 0)
+
+  board <- new_board(
+    blocks = c(
+      s = with_id(probe_source(), "s"),
+      r = with_id(probe_passthrough(), "r")
+    ),
+    links = links(sr = new_link("s", "r", "data"))
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      board_update(list(require = list(one = c("s", "r"), two = "r")))
+      session$flushReact()
+
+      board_update(list(blocks = list(rm = "r")))
+      session$flushReact()
+
+      # An owner left holding nothing is dropped, so a stale claim cannot
+      # outlive the block it named.
+      expect_identical(rv$required_blocks(), list(one = "s"))
+      expect_setequal(rv$needed(), "s")
+    },
+    args = list(
+      x = board,
+      plugins = list(),
+      callbacks = function(visibility, ...) {
+        require_blocks(visibility, "s")
+        render_blocks(visibility, "s")
       }
     )
   )
@@ -1102,7 +1203,14 @@ test_that("a request naming an unknown block is rejected", {
       expect_identical(rv$last_update$phase, "validate")
       expect_length(rv$evaluating(), 0L)
 
-      board_update(list(require = list(add = "nope")))
+      board_update(list(require = list(consumer = "nope")))
+      session$flushReact()
+
+      expect_false(rv$last_update$ok)
+      expect_length(rv$required_blocks(), 0L)
+
+      # A claim with no owner to release it is refused as well.
+      board_update(list(require = list("a")))
       session$flushReact()
 
       expect_false(rv$last_update$ok)

--- a/tests/testthat/test-visibility-gating.R
+++ b/tests/testthat/test-visibility-gating.R
@@ -1008,7 +1008,7 @@ test_that("a required claim holds a block until it is released", {
       reset_probes()
 
       # A claim, unlike a one-off request, survives evaluation.
-      board_update(list(require = list(consumer = "r")))
+      board_update(list(require = list(consumer = list(set = "r"))))
       session$flushReact()
 
       expect_identical(rv$eval[["r"]](), "ready")
@@ -1020,7 +1020,7 @@ test_that("a required claim holds a block until it is released", {
 
       # Releasing it hands the block back to the front-end's gating, which
       # parked it.
-      board_update(list(require = list(consumer = character())))
+      board_update(list(require = list(consumer = list(set = character()))))
       session$flushReact()
 
       expect_identical(rv$eval[["r"]](), "dormant")
@@ -1062,10 +1062,10 @@ test_that("one owner's release leaves another owner's claim standing", {
 
       expect_identical(rv$eval[["r"]](), "dormant")
 
-      board_update(list(require = list(one = "r")))
+      board_update(list(require = list(one = list(set = "r"))))
       session$flushReact()
 
-      board_update(list(require = list(two = "r")))
+      board_update(list(require = list(two = list(add = "r"))))
       session$flushReact()
 
       expect_identical(rv$required_blocks(), list(one = "r", two = "r"))
@@ -1073,15 +1073,15 @@ test_that("one owner's release leaves another owner's claim standing", {
 
       # The block is held by two owners, so the first letting go does not
       # release the second's claim.
-      board_update(list(require = list(one = character())))
+      board_update(list(require = list(one = list(set = character()))))
       session$flushReact()
 
       expect_identical(rv$required_blocks(), list(two = "r"))
       expect_identical(rv$eval[["r"]](), "ready")
 
-      # An owner states its whole set, and mapping it to NULL is the same
-      # release as mapping it to no blocks.
-      board_update(list(require = list(two = NULL)))
+      # Releasing the last block an owner holds drops the owner, whether it
+      # says so with `rm` or by setting an empty set.
+      board_update(list(require = list(two = list(rm = "r"))))
       session$flushReact()
 
       expect_length(rv$required_blocks(), 0L)
@@ -1117,7 +1117,14 @@ test_that("removing a claimed block prunes it from every owner", {
     {
       session$flushReact()
 
-      board_update(list(require = list(one = c("s", "r"), two = "r")))
+      board_update(
+        list(
+          require = list(
+            one = list(set = c("s", "r")),
+            two = list(set = "r")
+          )
+        )
+      )
       session$flushReact()
 
       board_update(list(blocks = list(rm = "r")))
@@ -1127,6 +1134,14 @@ test_that("removing a claimed block prunes it from every owner", {
       # outlive the block it named.
       expect_identical(rv$required_blocks(), list(one = "s"))
       expect_setequal(rv$needed(), "s")
+
+      # The owner that lost its block still releases cleanly: `rm` names a
+      # block the board no longer has, and that must not reject the payload.
+      board_update(list(require = list(two = list(rm = "r"))))
+      session$flushReact()
+
+      expect_true(rv$last_update$ok)
+      expect_identical(rv$required_blocks(), list(one = "s"))
     },
     args = list(
       x = board,
@@ -1203,14 +1218,14 @@ test_that("a request naming an unknown block is rejected", {
       expect_identical(rv$last_update$phase, "validate")
       expect_length(rv$evaluating(), 0L)
 
-      board_update(list(require = list(consumer = "nope")))
+      board_update(list(require = list(consumer = list(set = "nope"))))
       session$flushReact()
 
       expect_false(rv$last_update$ok)
       expect_length(rv$required_blocks(), 0L)
 
       # A claim with no owner to release it is refused as well.
-      board_update(list(require = list("a")))
+      board_update(list(require = list(list(set = "a"))))
       session$flushReact()
 
       expect_false(rv$last_update$ok)


### PR DESCRIPTION
## Summary

- The `require` component unioned every claim into one shared set, so whoever sent `rm` released the block for the other claimants too. Measured on `main`: with two owners holding `r` and one sending `require = list(rm = "r")`, the block drops back to `dormant` while the second still needs it.
- Claims are now keyed by owner, each owner mapping to a `set` / `add` / `rm` delta over the blocks it holds: `require = list(<owner> = list(set = ids))`. The state is the same shape, so applying a payload is a per-owner fold and the needed set is `unlst()` over the values.
- The `set` verb states an owner's whole set and is exclusive with `add` / `rm`, so releasing everything is `set = character()` and a release that never arrived is repaired by restating rather than accumulating. An owner left holding nothing is dropped, so "holds nothing" has one encoding in the state.
- Validation requires owner names that are present, nonempty and unique — a plain `list()` accepts duplicate names, and every later per-owner lookup would silently see only the first entry, so a payload naming one owner twice is rejected outright. Within an owner, `set` alongside `add` / `rm` and an `add` / `rm` overlap are both clashes.
- Only `set` and `add` resolve their IDs against the post-update block set. A `rm` may name a block the board no longer has, since a removal is usually what prompts a release; that is what lets PR #322 drop the `intersect()` guard it needs today.

Nesting the verbs below the owner rather than above follows the entity being mutated. For `blocks` / `links` / `stacks` the verb sits on top because there is one shared collection and `add` / `rm` / `mod` act on it; a claim mutates one owner's set, so the owner keys the map exactly as a block id keys `blocks$mod`. Hoisting the verbs instead would have kept the words but not the types — the generic checks at `R/board-server.R:1425-1468` type `rm` as a character vector of ids, and a verb-outer `require$rm` would have had to be an owner-keyed list.

Inferring the owner from the writing module was investigated and rejected. It does work mechanically: the reactive domain is ambient, so a `update` handle forwarded through dock's `create_view()` and into an extension server still reports the extension's namespace at call time, not dock's. What kills it is deferral — a claim written from an observer and released from `session$onFlushed()` resolves to two different keys, so the release lands on nothing and the claim leaks while the consumer's own source reads as correct. An explicit key is correct wherever it runs, and it already carries the writer's namespace into the debug log.

The keys therefore stay a convention (`session$ns("...")`), which core cannot enforce across payloads because it never sees who sent one. A claim also outlives the module that made it: core drops a claimed block once it leaves the board, but an owner that goes away without releasing holds what it held for the session. Both are documented in the Evaluation requests section.

The last commit sweeps a related hazard the claim work exposed. Unknown top-level keys are passed through to subclass methods by design, and `$` matches on a prefix, so a payload slot named `evaluate_all` was read as `evaluate` by the apply step while validation, which matches exactly, never saw it — verified by running the new regression test against the unswept file, where the id lands in `rv$evaluating()`. Inner component names need no such care, since anything other than `add` / `rm` / `mod` is rejected. It also drops a `names()` around the removal log's block IDs, which are a bare character vector, so a removal names the blocks again instead of logging `removing blocks` with nothing after it.

Nothing in `R/` calls `require`, and neither does blockr.dock, blockr.dag, blockr.ui, blockr.assistant or blockr.session, so the only callers that moved are the five test drivers. The component is unreleased, so the 0.1.4 NEWS entry is reworded rather than joined by a second one. PR #322 stacks on this and needs its `list(add =)` / `list(rm =)` calls switched to a per-owner `set` before it can merge.

Fixes #325
