### PR TITLE
Stop `bbquote()` dropping `NULL` elements from a call

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -182,6 +182,15 @@
   also the one part of a payload a locked board still accepts, and a payload
   rejected for being locked now records an outcome in `board$last_update`
   instead of being dropped silently (#318).
+* The `bbquote()` walk no longer drops `NULL` elements from a call. Assigning
+  the recursive step's result with `[[<-` deleted the element whenever it was
+  `NULL`, leaving the call shorter than its names and aborting with an `'names'
+  attribute [4] must be the same length as the vector [3]` error (or, for a
+  named `NULL`, `subscript out of bounds`). This hit any expression carrying a
+  literal `NULL` argument, and -- because a `function` definition's srcref slot
+  is `NULL` under `keep.source = FALSE` -- any expression defining a function,
+  but only once the package was installed rather than loaded with `load_all()`
+  (#323).
 
 # blockr.core 0.1.3
 

--- a/R/utils-expr.R
+++ b/R/utils-expr.R
@@ -81,7 +81,8 @@ bbquote <- function(expr, where = parent.frame(), splice = FALSE) {
       if (nchar(names_e[i]) && is_dots(e_list[[i]])) {
         names_e[i] <- ""
       } else {
-        e_list[[i]] <- process_splices(e_list[[i]])
+        # Assigning NULL via `[[<-` would delete the element; `[<-` replaces it
+        e_list[i] <- list(process_splices(e_list[[i]]))
       }
     }
 

--- a/tests/testthat/test-utils-expr.R
+++ b/tests/testthat/test-utils-expr.R
@@ -106,3 +106,47 @@ test_that("bbquote", {
   expect_error(.("a"), class = "dot_should_not_be_called")
   expect_error(..("a"), class = "dots_should_not_be_called")
 })
+
+test_that("bbquote keeps NULL call elements", {
+
+  expect_identical(
+    bbquote(func(a, NULL), list()),
+    quote(func(a, NULL))
+  )
+
+  expect_identical(
+    bbquote(list(a = NULL, b = .(x)), list(x = 1L)),
+    quote(list(a = NULL, b = 1L))
+  )
+
+  expect_identical(
+    bbquote(func(inner(NULL, .(x))), list(x = 1L)),
+    quote(func(inner(NULL, 1L)))
+  )
+})
+
+test_that("bbquote handles a function definition parsed without srcrefs", {
+
+  # A `function` call carries its srcref as a fourth element, and that slot is
+  # NULL whenever the code was parsed without srcrefs -- what an installed
+  # package does (`keep.source = FALSE`) and what `load_all()` does not.
+  expr <- parse(
+    text = "local({ f <- function(v, w) v; f(.(x), 1L) })",
+    keep.source = FALSE
+  )[[1L]]
+
+  fn_def <- as.list(expr[[2L]][[2L]][[3L]])
+
+  expect_length(fn_def, 4L)
+  expect_null(fn_def[[4L]])
+
+  expect_identical(eval(bbquote(expr, list(x = 1L))), 1L)
+
+  expect_identical(bbquote(expr, list())[[2L]][[3L]][[2L]], quote(.(x)))
+})
+
+test_that("bbquote preserves missing arguments", {
+
+  expect_identical(bbquote(x[.(i), ], list(i = 1L)), quote(x[1L, ]))
+  expect_identical(bbquote(x[, .(j)], list(j = 2L)), quote(x[, 2L]))
+})


### PR DESCRIPTION
## Summary

* The `bbquote()` walk assigned its recursive step with `[[<-`, which deletes an element rather than replacing it when the value is `NULL`. The call then came back shorter than its names and aborted with `'names' attribute [4] must be the same length as the vector [3]` — or `subscript out of bounds` when the `NULL` was named, because deleting shifts the indices the loop is still walking.
* A call element is legitimately `NULL` two ways. A literal `NULL` argument (`f(data, NULL)`) is an ordinary shape in a block expression and failed everywhere, dev included. The srcref slot of a `function` definition is the production-only half: a `function` call has four elements and the fourth is `NULL` whenever the code was parsed without srcrefs, which is what an installed package does (`keep.source = FALSE`) and what `load_all()` does not. So bquoting any expression that defines a function passed in every dev session and crashed only once installed.
* Single-bracket assignment of a one-element list replaces rather than deletes.
* Checked against the previous implementation over 36 call shapes — the documented `.()` / `..()` / named-splice forms, control flow, and every block body in the package. The only two that differ are shapes it aborted on; everything it handled is unchanged. That includes a missing argument's empty symbol (`x[i, ]`), which is where wrapping in `list()` could have regressed, so it now carries a test.

Diagnosis and the one-line fix are from @christophsax on `fix/bbquote-null-call-elements` (PR #324, closed unmerged). This branch reaches the same change, with the differential check above and the empty-symbol guard added.

Fixes #323
