### PR TITLE
Apply a link mod in place instead of folding it into add + rm

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # blockr.core 0.1.4
 
+* A link edit arriving as a `links$mod` board update is now applied in place
+  rather than folded into an add plus a removal. Where the edit keeps the
+  link's input slot -- a retarget that changes only `from` -- the target
+  block's existing input reactive is pointed at the new source, so only that
+  input re-fires. The fold previously tore the wiring down and rebuilt it,
+  which on a variadic target meant dropping and recreating every one of its
+  `...args` reactives, re-firing all of the block's data inputs for a single
+  link's edit. An edit that moves the link to another slot (a changed `to` or
+  `input`) still rewires. Correspondingly, `modify_board_links()` gains a
+  `mod` argument that replaces links in place, keeping each one's position
+  (#316).
 * `apply_board_update()` is now a real reducer rather than a no-op: its
   default `.board` method applies the core delta (block, link and stack
   mutations) to the supplied board and returns it, and update validation

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,15 +2,18 @@
 
 * A link edit arriving as a `links$mod` board update is now applied in place
   rather than folded into an add plus a removal. Where the edit keeps the
-  link's input slot -- a retarget that changes only `from` -- the target
-  block's existing input reactive is pointed at the new source, so only that
-  input re-fires. The fold previously tore the wiring down and rebuilt it,
-  which on a variadic target meant dropping and recreating every one of its
-  `...args` reactives, re-firing all of the block's data inputs for a single
-  link's edit. An edit that moves the link to another slot (a changed `to` or
-  `input`) still rewires. Correspondingly, `modify_board_links()` gains a
-  `mod` argument that replaces links in place, keeping each one's position
-  (#316).
+  link's input slot -- `to` and `input` unchanged -- the existing slot is
+  pointed at the new source, so the target block's input wiring survives the
+  edit. The fold previously tore that wiring down and rebuilt it, which on a
+  variadic target meant `sync_dot_args()` discarding and recreating every one
+  of the block's `...args` reactives and invalidating its dot-arg name
+  derivation. A genuine retarget re-evaluates the target block once either
+  way, so that part is unchanged; what the fold added on top was the rebuild,
+  plus a re-evaluation for a mod that leaves the wiring untouched -- that one
+  is now free, on fixed and variadic targets alike. An edit that moves the
+  link (a changed `to` or `input`) still rewires. Correspondingly,
+  `modify_board_links()` gains a `mod` argument that replaces links in place,
+  keeping each one's position (#316).
 * `apply_board_update()` is now a real reducer rather than a no-op: its
   default `.board` method applies the core delta (block, link and stack
   mutations) to the supplied board and returns it, and update validation

--- a/R/board-class.R
+++ b/R/board-class.R
@@ -357,7 +357,9 @@ rm_blocks.board <- function(x, rm, ..., session = get_session()) {
 #' of interest, this is available as `board_link_ids()`, which is short for
 #' `names(board_links(x))`. A (generic) convenience function for all kinds of
 #' updates to board links in one is available as `modify_board_links()`. With
-#' arguments `add` and `rm`, links can be added or removed in one go.
+#' arguments `add`, `rm` and `mod`, links can be added, removed or replaced in
+#' one go, where a link passed as `mod` keeps the position of the link it
+#' replaces.
 #'
 #' @rdname board_blocks
 #' @export
@@ -381,13 +383,13 @@ board_link_ids <- function(x) {
 }
 
 #' @param add Links/stacks to add
-#' @param mod Stacks to modify
+#' @param mod Links/stacks to modify
 #' @rdname board_blocks
 #' @export
-modify_board_links <- function(x, add = NULL, rm = NULL, ...,
+modify_board_links <- function(x, add = NULL, rm = NULL, mod = NULL, ...,
                                session = get_session()) {
 
-  if (!length(add) && !length(rm)) {
+  if (!length(add) && !length(rm) && !length(mod)) {
     return(x)
   }
 
@@ -395,13 +397,19 @@ modify_board_links <- function(x, add = NULL, rm = NULL, ...,
 }
 
 #' @export
-modify_board_links.board <- function(x, add = NULL, rm = NULL, ...,
+modify_board_links.board <- function(x, add = NULL, rm = NULL, mod = NULL, ...,
                                      session = get_session()) {
 
   links <- board_links(x)
 
   if (is_links(rm)) {
     rm <- names(rm)
+  }
+
+  if (length(mod)) {
+    stopifnot(all(names(mod) %in% names(links)))
+    links[names(mod)] <- mod
+    rm <- setdiff(rm, names(mod))
   }
 
   keep <- intersect(names(add), rm)

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -1036,6 +1036,11 @@ link_slot_key <- function(rv, to, id, input) {
   if (input %in% block_inputs(board_blocks(rv$board)[[to]])) input else id
 }
 
+reuses_link_slot <- function(old, new) {
+  field(old, "to") == field(new, "to") &
+    field(old, "input") == field(new, "input")
+}
+
 setup_link <- function(rv, id, from, to, input) {
 
   rv$sources[[to]][[link_slot_key(rv, to, id, input)]] <- from
@@ -1102,7 +1107,7 @@ sync_dot_args <- function(rv, to, lnks) {
   invisible()
 }
 
-update_block_links <- function(rv, add = NULL, rm = NULL) {
+update_block_links <- function(rv, add = NULL, rm = NULL, mod = NULL) {
 
   todo <- as.list(rm)
 
@@ -1110,7 +1115,10 @@ update_block_links <- function(rv, add = NULL, rm = NULL) {
     do.call(destroy_link, c(list(rv, i), todo[[i]]))
   }
 
-  todo <- as.list(add)
+  # A modified link keeps the slot it already occupies, so pointing that slot
+  # at the new source re-fires the one input reading it -- no teardown, and no
+  # dot-arg resync of the sibling links into the same block.
+  todo <- c(as.list(add), as.list(mod))
 
   for (i in names(todo)) {
     do.call(setup_link, c(list(rv, i), todo[[i]]))
@@ -1308,6 +1316,14 @@ add_blocks_to_stacks <- function(rv, add, session) {
 #' reactive side effects that mirror the delta — block UI insertion /
 #' removal, server construction / teardown, link and stack wiring — run
 #' around this single reduce.
+#'
+#' A link `mod` that leaves the link in the input slot it already
+#' occupies — a retarget changing only `from` — is applied in place,
+#' so the target block's input wiring survives the edit and only the
+#' retargeted input re-fires. One that moves the link (a changed `to`
+#' or `input`) is rewired instead. A front-end editing a link should
+#' therefore submit a `mod` rather than a matched `rm` plus `add` pair
+#' naming the same ID, which rewires either way.
 #'
 #' Errors thrown from either augment or apply are caught by the
 #' observer, reported via [notify()], and the reactive is reset so the
@@ -1874,15 +1890,12 @@ apply_board_update.board <- function(board, upd, ...,
     board_blocks(board) <- c(board_blocks(board), upd$blocks$add)
   }
 
-  add <- upd$links$add
-  rm <- upd$links$rm
-
-  if (length(upd$links$mod)) {
-    add <- vec_c(add, merge_link_mods(board, upd$links$mod))
-    rm <- c(rm, names(upd$links$mod))
-  }
-
-  board <- modify_board_links(board, add, rm, ..., session = session)
+  board <- modify_board_links(
+    board, upd$links$add, upd$links$rm,
+    merge_link_mods(board, upd$links$mod),
+    ...,
+    session = session
+  )
 
   board <- modify_board_stacks(
     board, upd$stacks$add, upd$stacks$rm,
@@ -1907,10 +1920,17 @@ apply_core_board_update <- function(rv, upd, session,
 
   lnk_add <- upd$links$add
   lnk_rm <- upd$links$rm
+  lnk_mod <- NULL
 
   if (length(upd$links$mod)) {
-    lnk_add <- vec_c(lnk_add, merge_link_mods(rv$board, upd$links$mod))
-    lnk_rm <- c(lnk_rm, names(upd$links$mod))
+
+    merged <- merge_link_mods(rv$board, upd$links$mod)
+    in_slot <- reuses_link_slot(board_links(rv$board)[names(merged)], merged)
+
+    lnk_mod <- merged[in_slot]
+
+    lnk_add <- vec_c(lnk_add, merged[!in_slot])
+    lnk_rm <- c(lnk_rm, names(merged)[!in_slot])
   }
 
   # Links into a block that is added or removed in this update are wired by
@@ -1925,6 +1945,7 @@ apply_core_board_update <- function(rv, upd, session,
   cur_links <- board_links(rv$board)
 
   lnk_add <- between_survivors(lnk_add)
+  lnk_mod <- between_survivors(lnk_mod)
   lnk_rm <- between_survivors(cur_links[intersect(lnk_rm, names(cur_links))])
 
   stk <- upd$stacks
@@ -2004,7 +2025,7 @@ apply_core_board_update <- function(rv, upd, session,
     }
   }
 
-  if (length(lnk_add) || length(lnk_rm)) {
+  if (length(lnk_add) || length(lnk_rm) || length(lnk_mod)) {
 
     if (length(lnk_add)) {
       log_debug("adding link{?s} {names(lnk_add)}")
@@ -2014,7 +2035,11 @@ apply_core_board_update <- function(rv, upd, session,
       log_debug("removing link{?s} {names(lnk_rm)}")
     }
 
-    update_block_links(rv, lnk_add, lnk_rm)
+    if (length(lnk_mod)) {
+      log_debug("modifying link{?s} {names(lnk_mod)}")
+    }
+
+    update_block_links(rv, lnk_add, lnk_rm, lnk_mod)
   }
 
   update_stack_blocks(rv, stk, edit_stack, edit_plugin_args, session)

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -1318,10 +1318,11 @@ add_blocks_to_stacks <- function(rv, add, session) {
 #' around this single reduce.
 #'
 #' A link `mod` that leaves the link in the input slot it already
-#' occupies — a retarget changing only `from` — is applied in place,
-#' so the target block's input wiring survives the edit and only the
-#' retargeted input re-fires. One that moves the link (a changed `to`
-#' or `input`) is rewired instead. A front-end editing a link should
+#' occupies — `to` and `input` unchanged — is applied in place, so the
+#' target block's input wiring survives the edit: the slot is pointed
+#' at the new source rather than the block's inputs being torn down and
+#' rebuilt. One that moves the link (a changed `to` or `input`) is
+#' rewired instead. A front-end editing a link should
 #' therefore submit a `mod` rather than a matched `rm` plus `add` pair
 #' naming the same ID, which rewires either way.
 #'

--- a/man/board_blocks.Rd
+++ b/man/board_blocks.Rd
@@ -34,7 +34,14 @@ board_links(x) <- value
 
 board_link_ids(x)
 
-modify_board_links(x, add = NULL, rm = NULL, ..., session = get_session())
+modify_board_links(
+  x,
+  add = NULL,
+  rm = NULL,
+  mod = NULL,
+  ...,
+  session = get_session()
+)
 
 board_stacks(x)
 
@@ -78,7 +85,7 @@ clear_board(x)
 
 \item{add}{Links/stacks to add}
 
-\item{mod}{Stacks to modify}
+\item{mod}{Links/stacks to modify}
 
 \item{blocks, stacks}{Sets of blocks/stacks}
 }
@@ -119,7 +126,9 @@ corresponding replacement function \verb{board_links<-()}. If only links IDs are
 of interest, this is available as \code{board_link_ids()}, which is short for
 \code{names(board_links(x))}. A (generic) convenience function for all kinds of
 updates to board links in one is available as \code{modify_board_links()}. With
-arguments \code{add} and \code{rm}, links can be added or removed in one go.
+arguments \code{add}, \code{rm} and \code{mod}, links can be added, removed or replaced in
+one go, where a link passed as \code{mod} keeps the position of the link it
+replaces.
 }
 
 \section{Stacks}{

--- a/man/board_update.Rd
+++ b/man/board_update.Rd
@@ -102,6 +102,14 @@ reactive side effects that mirror the delta — block UI insertion /
 removal, server construction / teardown, link and stack wiring — run
 around this single reduce.
 
+A link \code{mod} that leaves the link in the input slot it already
+occupies — a retarget changing only \code{from} — is applied in place,
+so the target block's input wiring survives the edit and only the
+retargeted input re-fires. One that moves the link (a changed \code{to}
+or \code{input}) is rewired instead. A front-end editing a link should
+therefore submit a \code{mod} rather than a matched \code{rm} plus \code{add} pair
+naming the same ID, which rewires either way.
+
 Errors thrown from either augment or apply are caught by the
 observer, reported via \code{\link[=notify]{notify()}}, and the reactive is reset so the
 app keeps running.

--- a/man/board_update.Rd
+++ b/man/board_update.Rd
@@ -103,10 +103,11 @@ removal, server construction / teardown, link and stack wiring — run
 around this single reduce.
 
 A link \code{mod} that leaves the link in the input slot it already
-occupies — a retarget changing only \code{from} — is applied in place,
-so the target block's input wiring survives the edit and only the
-retargeted input re-fires. One that moves the link (a changed \code{to}
-or \code{input}) is rewired instead. A front-end editing a link should
+occupies — \code{to} and \code{input} unchanged — is applied in place, so the
+target block's input wiring survives the edit: the slot is pointed
+at the new source rather than the block's inputs being torn down and
+rebuilt. One that moves the link (a changed \code{to} or \code{input}) is
+rewired instead. A front-end editing a link should
 therefore submit a \code{mod} rather than a matched \code{rm} plus \code{add} pair
 naming the same ID, which rewires either way.
 

--- a/tests/testthat/test-board-class.R
+++ b/tests/testthat/test-board-class.R
@@ -277,3 +277,30 @@ test_that("editing a link via add + rm overlap preserves its position", {
   expect_identical(names(board_links(edited)), c("ac", "bc"))
   expect_identical(board_links(edited)[["ac"]][["input"]], "x")
 })
+
+test_that("modify_board_links() replaces a link in place", {
+
+  board <- new_board(
+    blocks = c(
+      a = new_dataset_block("BOD"),
+      b = new_dataset_block("BOD"),
+      c = new_rbind_block()
+    ),
+    links = links(
+      ac = new_link("a", "c", "left"),
+      bc = new_link("b", "c")
+    )
+  )
+
+  edited <- modify_board_links(
+    board,
+    mod = links(ac = new_link("b", "c", "left"))
+  )
+
+  expect_identical(names(board_links(edited)), c("ac", "bc"))
+  expect_identical(board_links(edited)[["ac"]][["from"]], "b")
+
+  expect_error(
+    modify_board_links(board, mod = links(xy = new_link("a", "c")))
+  )
+})

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -526,6 +526,52 @@ test_that("links$mod retargets a variadic input without rebuilding dot args", {
   )
 })
 
+test_that("links$mod that leaves the wiring alone costs no re-evaluation", {
+
+  board <- new_board(
+    blocks = c(
+      a = new_dataset_block("BOD"),
+      b = new_dataset_block("BOD"),
+      c = new_rbind_block()
+    ),
+    links = links(l1 = new_link("a", "c"), l2 = new_link("b", "c"))
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      n_eval <- 0L
+
+      observe({
+        try(rv$blocks[["c"]]$server$result(), silent = TRUE)
+        n_eval <<- n_eval + 1L
+      })
+
+      session$flushReact()
+      n_eval <- 0L
+
+      board_update(
+        list(links = list(mod = list(l1 = list(from = "a"))))
+      )
+
+      session$flushReact()
+
+      expect_identical(n_eval, 0L)
+
+      board_update(
+        list(links = list(mod = list(l1 = list(from = "b"))))
+      )
+
+      session$flushReact()
+
+      expect_identical(n_eval, 1L)
+    },
+    args = list(x = board)
+  )
+})
+
 test_that("links$mod re-parents a link by tearing down the old slot", {
 
   board <- new_board(

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -481,6 +481,115 @@ test_that("links$mod applies a value-changing delta (keeps links class)", {
   )
 })
 
+test_that("links$mod retargets a variadic input without rebuilding dot args", {
+
+  board <- new_board(
+    blocks = c(
+      a = new_dataset_block("iris"),
+      b = new_dataset_block("mtcars"),
+      c = new_rbind_block()
+    ),
+    links = links(l1 = new_link("a", "c"), l2 = new_link("b", "c"))
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      args <- rv$inputs[["c"]][["...args"]]
+      store <- .subset2(args, "store")
+
+      dot_args <- function() {
+        set_names(
+          lapply(isolate(raw_keys(args)), activeBindingFunction, env = store),
+          isolate(raw_keys(args))
+        )
+      }
+
+      before <- dot_args()
+
+      expect_length(before, 2L)
+
+      board_update(
+        list(links = list(mod = list(l1 = list(from = "b"))))
+      )
+
+      session$flushReact()
+
+      expect_identical(board_links(rv$board)$from, c("b", "b"))
+      expect_identical(rv$sources[["c"]][["l1"]], "b")
+
+      expect_identical(dot_args(), before)
+    },
+    args = list(x = board)
+  )
+})
+
+test_that("links$mod re-parents a link by tearing down the old slot", {
+
+  board <- new_board(
+    blocks = c(
+      a = new_dataset_block("iris"),
+      b = new_head_block(),
+      c = new_head_block()
+    ),
+    links = links(l1 = new_link("a", "b", "data"))
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      board_update(
+        list(links = list(mod = list(l1 = list(to = "c"))))
+      )
+
+      session$flushReact()
+
+      lnks <- board_links(rv$board)
+
+      expect_identical(names(lnks), "l1")
+      expect_identical(lnks$to, "c")
+
+      expect_null(rv$sources[["b"]][["data"]])
+      expect_identical(rv$sources[["c"]][["data"]], "a")
+    },
+    args = list(x = board)
+  )
+})
+
+test_that("links$mod renames a variadic dot arg", {
+
+  board <- new_board(
+    blocks = c(
+      a = new_dataset_block("iris"),
+      b = new_dataset_block("mtcars"),
+      c = new_rbind_block()
+    ),
+    links = links(l1 = new_link("a", "c"), l2 = new_link("b", "c"))
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      board_update(
+        list(links = list(mod = list(l2 = list(input = "second"))))
+      )
+
+      session$flushReact()
+
+      expect_identical(board_links(rv$board)$input, c("", "second"))
+      expect_identical(names(rv$inputs[["c"]][["...args"]]), c("", "second"))
+      expect_identical(rv$sources[["c"]][["l2"]], "b")
+    },
+    args = list(x = board)
+  )
+})
+
 test_that("stacks$mod merges deltas onto current stack via update_stack", {
 
   board <- new_board(


### PR DESCRIPTION
## Summary

- A `links$mod` delta was resolved to a fresh link and folded into an add plus a removal, so editing a link tore the target block's input wiring down and rebuilt it. Where the edit keeps the slot the link already occupies — `to` and `input` unchanged — the existing slot is now pointed at the new source instead. An edit that moves the link (a changed `to` or `input`) still rewires through add + rm.
- The variadic case needs no arg-order reconciliation after all, so it is in scope rather than deferred. A fixed input's `upstream_result()` reads `src_rv[[input]]` and a variadic one reads `src_rv[[link_id]]`, while the dot-arg name comes from `input` — none of those keys move when only `from` changes, so the link set and its order are untouched.
- The `modify_board_links()` function regains the `mod` argument #311 retired, mirroring `modify_board_stacks()`, so the data side replaces a link in place rather than reconstructing its position through an add + rm overlap. An ID named in both `mod` and `rm` is replaced rather than removed — the rule `add` + `rm` already followed, and what keeps the #177 block-removal guard firing.
- The issue also asked for an `input` change to become a targeted slot move, and it did not get its own path. On a fixed-input target the rewire already *is* that slot move: `destroy_link()` clears the old key, `setup_link()` writes the new one, and no dot-arg resync runs on a non-variadic block. Only a variadic target still resyncs wholesale on an `input` rename, since renaming a dot arg is the arg-order reconciliation the issue flagged as needing more care — worth its own change if it proves to matter.

## What this actually costs, measured

The issue was filed on the premise of a `sync_dot_args()` blast radius, unprofiled. Measured against a pre-fix build (`sync` = `sync_dot_args()` calls, `keys` = invalidations of the dot-arg name derivation the block's expression reads, `eval` = re-evaluations of the target block), variadic target with two incoming links:

| payload | before | after |
| --- | --- | --- |
| `mod` changing `from` (retarget) | sync 1, wiring replaced, keys 1, eval 1 | sync 0, wiring kept, keys 0, **eval 1** |
| `mod` leaving `from` alone | sync 1, wiring replaced, keys 1, eval 1 | sync 0, wiring kept, keys 0, **eval 0** |
| `mod` renaming a dot arg (`input`) | sync 1, wiring replaced, keys 1, eval 1 | unchanged — falls back to add + rm |

So this is not a uniform win, and it is worth saying plainly which parts are which. Shiny coalesces invalidations within a flush, so a genuine retarget re-evaluates the target block exactly once before and after — the fold never multiplied downstream evaluation, and an earlier draft of this description claiming otherwise was wrong. What the fold did add is the rebuild itself (every `...args` reactive discarded and recreated, the block's arg-name derivation invalidated), and one wholly spurious re-evaluation whenever a mod leaves the wiring untouched. That last row is the only place an evaluation disappears, and it applies to fixed-input targets too, where the rest of the change is a no-op beyond dropping one redundant `reactiveValues` write. The data-side `mod` argument is a pure refactor — byte-identical results to the add + rm overlap it replaces.

Both effects are pinned by tests that fail against the pre-fix sources: one asserts the dot-arg reactives survive a retarget as the *same objects*, the other that a no-change mod costs zero evaluations and a real retarget costs one.

Fixes #316
