### PR TITLE
Gate block control updates on front-end UI readiness

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -191,6 +191,20 @@
   is `NULL` under `keep.source = FALSE` -- any expression defining a function,
   but only once the package was installed rather than loaded with `load_all()`
   (#323).
+* Block servers can opt into a UI-readiness handshake by declaring a `ui_ready`
+  argument, which `expr_server()` fills with a reactive that is `TRUE` while
+  the front-end reports the block on screen. Controls whose state reaches the
+  client through `update*Input()` were pushed at module start, but a front-end
+  that defers panels builds an off-screen block (because something downstream
+  needs its result) long before its UI exists, so shiny dropped the message
+  against an unbound input and nothing re-sent it: a block on a non-startup
+  view came up with blank controls while computing correctly. Guarding the
+  pushes with `req(ui_ready())` holds them until the controls exist and
+  re-sends them whenever the block returns to screen. Like `...args`, the
+  argument is reserved and counts towards neither `block_inputs()` nor
+  `block_arity()`. Adopted by `merge_block`, `scatter_block` and `head_block`
+  -- the last two also pushed their column choices and row bound before first
+  paint, so they misbehaved on the startup view too (#317).
 
 # blockr.core 0.1.3
 

--- a/R/block-class.R
+++ b/R/block-class.R
@@ -332,7 +332,7 @@ validate_block_ui <- function(ui) {
 
 validate_data_validator <- function(validator, server) {
 
-  server_args <- setdiff(names(formals(server)), "id")
+  server_args <- server_data_args(server)
 
   if (!length(server_args) && not_null(validator)) {
     blockr_abort(
@@ -549,7 +549,10 @@ c.block <- function(...) {
 #' inputs like for example a block providing [base::rbind()]-like
 #' functionality), `block_arity()` returns `NA` and the special block server
 #' function argument `...args`, signalling variadic behavior is stripped from
-#' `block_inputs()`.
+#' `block_inputs()`. A second reserved server function argument, `ui_ready`
+#' (see [expr_server()]), carries the front-end readiness of the block UI
+#' rather than data and is stripped from `block_inputs()` and `block_arity()`
+#' as well.
 #'
 #' @section External control:
 #' Blocks can expose constructor inputs for programmatic control from outside
@@ -706,7 +709,11 @@ block_inputs.block <- function(x) {
 }
 
 block_expr_inputs <- function(x) {
-  setdiff(names(formals(block_expr_server(x))), "id")
+  server_data_args(block_expr_server(x))
+}
+
+server_data_args <- function(server) {
+  setdiff(names(formals(server)), c("id", "ui_ready"))
 }
 
 block_ctor_inputs <- function(x) {

--- a/R/block-server.R
+++ b/R/block-server.R
@@ -92,6 +92,20 @@
 #' `gate_visibility` [blockr_option()] (default `TRUE`) turns gating off
 #' entirely.
 #'
+#' The `visible` channel also drives the point at which a block may talk to its
+#' own controls. A block server that ships state to the client with
+#' [shiny::updateSelectInput()] and friends cannot do so at module start: on a
+#' front-end that defers panels the block is built (because something needs its
+#' result) long before its UI exists, the update addresses an unbound input and
+#' shiny drops the message, and nothing re-sends it. A block opts into the
+#' handshake by declaring a `ui_ready` argument on its server function --
+#' reserved, like `...args`, so it is not mistaken for a data input --
+#' whereupon [expr_server()] hands it a reactive that is `TRUE` while the
+#' front-end reports the block on screen (and constantly `TRUE` when nothing
+#' gates visibility). Guarding the pushes with `req(ui_ready())` holds them
+#' until the controls exist and re-sends them whenever the block returns to
+#' screen. Core's `merge_block`, `scatter_block` and `head_block` use it.
+#'
 #' The same bundle carries a third channel, `frozen`, through which a
 #' front-end reports the blocks whose inputs it has hidden (for example a
 #' locked board that shows outputs but not controls). While frozen a block is
@@ -136,6 +150,9 @@ block_server <- function(id, x, data = list(), ...) {
 #' `reactiveVal`s, supplied by [board_server()] to gate rendering and to
 #' freeze block inputs; `NULL` (the standalone default) leaves the block
 #' ungated
+#' @param ui_ready Reactive flag signaling whether the front-end has the block
+#' UI on screen, forwarded to block server functions that declare a `ui_ready`
+#' argument; defaults to always-ready when a block server is run standalone
 #' @rdname block_server
 #' @export
 block_server.block <- function(id, x, data = list(), block_id = id,
@@ -161,8 +178,18 @@ block_server.block <- function(id, x, data = list(), block_id = id,
         status = NULL
       )
 
+      gated <- is_board(isolate(board$board)) &&
+        isTRUE(blockr_option("gate_visibility", TRUE)) &&
+        not_null(visibility)
+
+      ui_ready <- if (gated) {
+        reactive(block_ui_ready(block_id, visibility))
+      } else {
+        reactive(TRUE)
+      }
+
       exp <- check_expr_val(
-        expr_server(x, data),
+        expr_server(x, data, ui_ready = ui_ready),
         x
       )
 
@@ -454,10 +481,6 @@ block_server.block <- function(id, x, data = list(), block_id = id,
           !failed()
       )
 
-      gated <- is_board(isolate(board$board)) &&
-        isTRUE(blockr_option("gate_visibility", TRUE)) &&
-        not_null(visibility)
-
       render_obs <- output_render_observer(x, block_ready, inputs_ready,
                                            state_ready, res, cond, session,
                                            suspended = gated)
@@ -521,8 +544,15 @@ expr_server <- function(x, data, ...) {
 }
 
 #' @export
-expr_server.block <- function(x, data, ...) {
-  do.call(block_expr_server(x), c(list(id = "expr"), data))
+expr_server.block <- function(x, data, ui_ready = reactive(TRUE), ...) {
+
+  srv <- block_expr_server(x)
+
+  ready <- if ("ui_ready" %in% names(formals(srv))) {
+    list(ui_ready = ui_ready)
+  }
+
+  do.call(srv, c(list(id = "expr"), data, ready))
 }
 
 validate_block_reactive <- function(id, x, dat, cond, sess, inputs_ready) {
@@ -697,8 +727,7 @@ render_gate_observer <- function(id, visibility, render_obs, sess) {
 
   observe(
     {
-      do_render <- !gating_active(visibility$required) ||
-        block_visible(id, visibility)
+      do_render <- block_ui_ready(id, visibility)
 
       if (do_render) render_obs$resume() else render_obs$suspend()
 

--- a/R/block-server.R
+++ b/R/block-server.R
@@ -539,7 +539,7 @@ block_server.block <- function(id, x, data = list(), block_id = id,
 
 #' @rdname block_server
 #' @export
-expr_server <- function(x, data, ...) {
+expr_server <- function(x, data, ui_ready = reactive(TRUE), ...) {
   UseMethod("expr_server")
 }
 

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -762,6 +762,10 @@ block_frozen <- function(id, vis) {
   isTRUE(vis$frozen[[id]]())
 }
 
+block_ui_ready <- function(id, vis) {
+  !gating_active(vis$required) || block_visible(id, vis)
+}
+
 required_fulfilled <- function(vis) {
   all(lgl_ply(required_now(vis$required), block_visible, vis))
 }

--- a/R/plot-scatter.R
+++ b/R/plot-scatter.R
@@ -27,7 +27,7 @@
 #' @export
 new_scatter_block <- function(x = character(), y = character(), ...) {
   new_plot_block(
-    function(id, data) {
+    function(id, data, ui_ready) {
       moduleServer(
         id,
         function(input, output, session) {
@@ -41,8 +41,10 @@ new_scatter_block <- function(x = character(), y = character(), ...) {
           observeEvent(input$ycol, y_col(input$ycol))
 
           observeEvent(
-            cols(),
+            list(ui_ready(), cols()),
             {
+              req(ui_ready())
+
               updateSelectInput(
                 session,
                 inputId = "xcol",

--- a/R/transform-head.R
+++ b/R/transform-head.R
@@ -29,7 +29,7 @@ new_head_block <- function(n = 6L, direction = c("head", "tail"), ...) {
   direction <- match.arg(direction)
 
   new_transform_block(
-    function(id, data) {
+    function(id, data, ui_ready) {
       moduleServer(
         id,
         function(input, output, session) {
@@ -41,13 +41,17 @@ new_head_block <- function(n = 6L, direction = c("head", "tail"), ...) {
           observeEvent(input$tail, til(input$tail))
 
           observeEvent(
-            nrow(data()),
-            updateNumericInput(
-              inputId = "n",
-              value = nrw(),
-              min = 1L,
-              max = nrow(data())
-            )
+            list(ui_ready(), nrow(data())),
+            {
+              req(ui_ready())
+
+              updateNumericInput(
+                inputId = "n",
+                value = nrw(),
+                min = 1L,
+                max = nrow(data())
+              )
+            }
           )
 
           list(

--- a/R/transform-merge.R
+++ b/R/transform-merge.R
@@ -39,7 +39,7 @@ new_merge_block <- function(by = character(), all_x = FALSE, all_y = FALSE,
   }
 
   new_transform_block(
-    function(id, x, y) {
+    function(id, x, y, ui_ready) {
       moduleServer(
         id,
         function(input, output, session) {
@@ -64,12 +64,16 @@ new_merge_block <- function(by = character(), all_x = FALSE, all_y = FALSE,
           cols <- reactive(by_choices(x(), y()))
 
           observe(
-            updateSelectInput(
-              session,
-              inputId = "by",
-              choices = cols(),
-              selected = sels()
-            )
+            {
+              req(ui_ready())
+
+              updateSelectInput(
+                session,
+                inputId = "by",
+                choices = cols(),
+                selected = sels()
+              )
+            }
           )
 
           list(

--- a/man/block_name.Rd
+++ b/man/block_name.Rd
@@ -77,7 +77,10 @@ In case of variadic blocks (i.e. blocks that take a variable number of
 inputs like for example a block providing \code{\link[base:rbind]{base::rbind()}}-like
 functionality), \code{block_arity()} returns \code{NA} and the special block server
 function argument \code{...args}, signalling variadic behavior is stripped from
-\code{block_inputs()}.
+\code{block_inputs()}. A second reserved server function argument, \code{ui_ready}
+(see \code{\link[=expr_server]{expr_server()}}), carries the front-end readiness of the block UI
+rather than data and is stripped from \code{block_inputs()} and \code{block_arity()}
+as well.
 }
 
 \section{External control}{

--- a/man/block_server.Rd
+++ b/man/block_server.Rd
@@ -74,6 +74,10 @@ block server is run standalone)}
 \code{reactiveVal}s, supplied by \code{\link[=board_server]{board_server()}} to gate rendering and to
 freeze block inputs; \code{NULL} (the standalone default) leaves the block
 ungated}
+
+\item{ui_ready}{Reactive flag signaling whether the front-end has the block
+UI on screen, forwarded to block server functions that declare a \code{ui_ready}
+argument; defaults to always-ready when a block server is run standalone}
 }
 \value{
 Both \code{block_server()} and \code{expr_server()} return shiny server module
@@ -176,6 +180,20 @@ the staggering and builds every block up front. With nothing writing
 \code{required} every block is needed and behaviour is unchanged; the
 \code{gate_visibility} \code{\link[=blockr_option]{blockr_option()}} (default \code{TRUE}) turns gating off
 entirely.
+
+The \code{visible} channel also drives the point at which a block may talk to its
+own controls. A block server that ships state to the client with
+\code{\link[shiny:updateSelectInput]{shiny::updateSelectInput()}} and friends cannot do so at module start: on a
+front-end that defers panels the block is built (because something needs its
+result) long before its UI exists, the update addresses an unbound input and
+shiny drops the message, and nothing re-sends it. A block opts into the
+handshake by declaring a \code{ui_ready} argument on its server function --
+reserved, like \code{...args}, so it is not mistaken for a data input --
+whereupon \code{\link[=expr_server]{expr_server()}} hands it a reactive that is \code{TRUE} while the
+front-end reports the block on screen (and constantly \code{TRUE} when nothing
+gates visibility). Guarding the pushes with \code{req(ui_ready())} holds them
+until the controls exist and re-sends them whenever the block returns to
+screen. Core's \code{merge_block}, \code{scatter_block} and \code{head_block} use it.
 
 The same bundle carries a third channel, \code{frozen}, through which a
 front-end reports the blocks whose inputs it has hidden (for example a

--- a/man/block_server.Rd
+++ b/man/block_server.Rd
@@ -33,7 +33,7 @@ block_server(id, x, data = list(), ...)
   ...
 )
 
-expr_server(x, data, ...)
+expr_server(x, data, ui_ready = reactive(TRUE), ...)
 
 block_render_trigger(x, session = get_session())
 }

--- a/tests/testthat/test-block-class.R
+++ b/tests/testthat/test-block-class.R
@@ -175,6 +175,38 @@ test_that("block utils", {
   expect_s3_class(c(blk, lst), "blocks")
 })
 
+test_that("ui_ready is not counted as a block data input", {
+
+  new_ready_block <- function() {
+    new_transform_block(
+      function(id, data, ui_ready) {
+        moduleServer(
+          id,
+          function(input, output, session) {
+            list(expr = reactive(quote(identity(data))), state = list())
+          }
+        )
+      },
+      function(id) {
+        tagList()
+      },
+      dat_valid = function(data) {
+        stopifnot(is.data.frame(data))
+      },
+      class = "ready_block",
+      block_metadata = list()
+    )
+  }
+
+  expect_identical(block_inputs(new_ready_block()), "data")
+  expect_identical(block_arity(new_ready_block()), 1L)
+
+  expect_identical(
+    server_data_args(function(id, x, ui_ready, y) {}),
+    c("x", "y")
+  )
+})
+
 test_that("Without package blocks can print", {
   blk <- new_dummy_block <- function(text = "Hello World", ...) {
     new_data_block(

--- a/tests/testthat/test-plot-scatter.R
+++ b/tests/testthat/test-plot-scatter.R
@@ -31,7 +31,7 @@ test_that("scetter plot block constructor", {
         )
       )
     },
-    args = list(data = function() iris)
+    args = list(data = function() iris, ui_ready = function() TRUE)
   )
 
   testServer(
@@ -47,5 +47,45 @@ test_that("scetter plot block constructor", {
       )
     },
     args = list(x = blk, data = list(data = function() iris))
+  )
+})
+
+test_that("scatter block holds its control updates until the UI is ready", {
+
+  pushed <- new.env()
+  pushed$ids <- character()
+
+  record_push <- function(...) {
+
+    args <- list(...)
+
+    pushed$ids <- c(pushed$ids, args$inputId)
+    pushed[[args$inputId]] <- args$choices
+
+    invisible()
+  }
+
+  local_mocked_bindings(
+    updateSelectInput = record_push,
+    .package = "blockr.core"
+  )
+
+  ready <- reactiveVal(FALSE)
+
+  testServer(
+    block_expr_server(new_scatter_block("Sepal.Length", "Sepal.Width")),
+    {
+      session$flushReact()
+
+      expect_identical(pushed$ids, character())
+
+      ready(TRUE)
+      session$flushReact()
+
+      expect_identical(pushed$ids, c("xcol", "ycol"))
+      expect_identical(pushed$xcol, colnames(iris))
+      expect_identical(pushed$ycol, colnames(iris))
+    },
+    args = list(data = function() iris, ui_ready = ready)
   )
 })

--- a/tests/testthat/test-transform-head.R
+++ b/tests/testthat/test-transform-head.R
@@ -20,7 +20,7 @@ test_that("head block constructor", {
       expect_equal(session$returned$state$n(), 10L)
       expect_equal(session$returned$state$direction(), "tail")
     },
-    args = list(data = mtcars)
+    args = list(data = function() mtcars, ui_ready = function() TRUE)
   )
 
   testServer(
@@ -36,5 +36,44 @@ test_that("head block constructor", {
       x = blk,
       data = list(data = function() datasets::mtcars)
     )
+  )
+})
+
+test_that("head block holds its row bound until the UI is ready", {
+
+  pushed <- new.env()
+  pushed$n <- 0L
+
+  record_push <- function(...) {
+
+    args <- list(...)
+
+    pushed$n <- pushed$n + 1L
+    pushed$max <- args$max
+
+    invisible()
+  }
+
+  local_mocked_bindings(
+    updateNumericInput = record_push,
+    .package = "blockr.core"
+  )
+
+  ready <- reactiveVal(FALSE)
+
+  testServer(
+    block_expr_server(new_head_block()),
+    {
+      session$flushReact()
+
+      expect_identical(pushed$n, 0L)
+
+      ready(TRUE)
+      session$flushReact()
+
+      expect_identical(pushed$n, 1L)
+      expect_identical(pushed$max, nrow(datasets::mtcars))
+    },
+    args = list(data = function() datasets::mtcars, ui_ready = ready)
   )
 })

--- a/tests/testthat/test-transform-merge.R
+++ b/tests/testthat/test-transform-merge.R
@@ -28,7 +28,53 @@ test_that("merge block constructor", {
     },
     args = list(
       x = function() band_members,
-      y = function() band_instruments
+      y = function() band_instruments,
+      ui_ready = function() TRUE
+    )
+  )
+})
+
+test_that("merge block holds its control update until the UI is ready", {
+
+  pushed <- new.env()
+  pushed$n <- 0L
+
+  record_push <- function(...) {
+
+    args <- list(...)
+
+    pushed$n <- pushed$n + 1L
+    pushed$choices <- args$choices
+    pushed$selected <- args$selected
+
+    invisible()
+  }
+
+  local_mocked_bindings(
+    updateSelectInput = record_push,
+    .package = "blockr.core"
+  )
+
+  ready <- reactiveVal(FALSE)
+
+  testServer(
+    block_expr_server(new_merge_block(by = "name")),
+    {
+      session$flushReact()
+
+      expect_identical(pushed$n, 0L)
+
+      ready(TRUE)
+      session$flushReact()
+
+      expect_identical(pushed$n, 1L)
+      expect_identical(pushed$choices, "name")
+      expect_identical(pushed$selected, "name")
+    },
+    args = list(
+      x = function() band_members,
+      y = function() band_instruments,
+      ui_ready = ready
     )
   )
 })

--- a/tests/testthat/test-visibility-gating.R
+++ b/tests/testthat/test-visibility-gating.R
@@ -10,6 +10,9 @@ probe_args$entry_classes <- NULL
 probe_construct <- new.env()
 probe_construct$ids <- character()
 
+probe_push <- new.env()
+probe_push$ids <- character()
+
 registerS3method(
   "block_output", "probe_block",
   function(x, result, session) {
@@ -66,6 +69,30 @@ probe_source_alt <- function() {
         id,
         function(input, output, session) {
           list(expr = reactive(quote(datasets::ChickWeight)), state = list())
+        }
+      )
+    },
+    function(id) shiny::tagList(),
+    class = "probe_block",
+    block_metadata = FALSE
+  )
+}
+
+probe_ui_ready <- function() {
+  new_data_block(
+    function(id, ui_ready) {
+      moduleServer(
+        id,
+        function(input, output, session) {
+
+          observe(
+            {
+              req(ui_ready())
+              probe_push$ids <- c(probe_push$ids, session$ns(NULL))
+            }
+          )
+
+          list(expr = reactive(quote(datasets::BOD)), state = list())
         }
       )
     },
@@ -169,6 +196,7 @@ reset_probes <- function() {
   probe_render$ids <- character()
   probe_eval$ids <- character()
   probe_construct$ids <- character()
+  probe_push$ids <- character()
 }
 
 # Drives the background builder synchronously: the production scheduler paces
@@ -185,6 +213,10 @@ rendered <- function(id) {
 
 evaluated <- function(id) {
   id %in% probe_eval$ids
+}
+
+pushed <- function(id) {
+  any(endsWith(probe_push$ids, paste0("block_", id, "-expr")))
 }
 
 constructed <- function(id) {
@@ -310,6 +342,62 @@ test_that("a producer gates evaluation and rendering on visibility", {
         render_blocks(visibility, "b")
       }
     )
+  )
+})
+
+test_that("ui_ready follows the visible channel of a needed block", {
+
+  reset_probes()
+
+  withr::local_options(blockr.background_construction_delay = 0)
+
+  board <- new_board(
+    blocks = c(
+      a = with_id(probe_ui_ready(), "a"),
+      b = with_id(probe_passthrough(), "b")
+    ),
+    links = links(new_link(from = "a", to = "b"))
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      expect_true(evaluated("a"))
+      expect_false(rendered("a"))
+      expect_false(pushed("a"))
+
+      render_blocks(vis, "a")
+      session$flushReact()
+
+      expect_true(pushed("a"))
+    },
+    args = list(
+      x = board,
+      plugins = list(),
+      callbacks = function(visibility, ...) {
+        require_blocks(visibility, "b")
+        render_blocks(visibility, "b")
+      }
+    )
+  )
+})
+
+test_that("ui_ready is always set with nothing gating visibility", {
+
+  reset_probes()
+
+  board <- new_board(blocks = c(a = with_id(probe_ui_ready(), "a")))
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      expect_true(pushed("a"))
+    },
+    args = list(x = board, plugins = list())
   )
 })
 


### PR DESCRIPTION
## Summary

Block servers can declare a reserved `ui_ready` argument, which `expr_server()` fills with a reactive that is `TRUE` while the front-end reports the block on screen. It reads the `visible` channel that already drives the render gate, so no new channel is plumbed, and it is constantly `TRUE` when nothing gates visibility. Guarding a push with `req(ui_ready())` holds it until the controls exist and re-sends it whenever the block returns to screen.

Like `...args`, the argument is reserved rather than a data input: `block_inputs()`, `block_arity()` and the `dat_valid` arity check all skip it, so declaring it neither opens a link slot nor breaks the validator.

Adopted by `merge_block`, `scatter_block` and `head_block`. The issue names the first two; `head_block` turned out to carry the same defect in the row bound it pushes (`max = nrow(data())`), sent once at boot and dropped on a deferred panel the same way.

## What I measured

The seam itself is verified end to end against blockr.dock 0.1.3 and dockViewR 0.4.0. An instrumented off-screen block logs `ui_ready=FALSE` at boot, `ui_ready=TRUE` roughly 1.4 s after its view is opened, pushes there, and its select comes up populated.

The reported symptom, though, did **not** reproduce on that stack. Running the issue's verbatim repro against `main`, the merge block's "By columns" is blank for about 2 s after the switch to the Hidden view and then fills in on its own — it does not stay blank. An A/B on a single board (one block gated, an otherwise identical one not) shows why: the ungated block's push observer re-fires when its upstream re-publishes on the view switch, so the dropped boot-time push gets repaired by accident. The defect is directly observable either way — the ungated block logs its push at boot with no panel in the DOM, and its control is empty for as long as the panel is absent — but whether it stays broken depends on whether some upstream happens to invalidate later. The gated block does not depend on that luck.

The unit tests carry the regression teeth: each of the three block tests fails on the unguarded code at the "no push while hidden" assertion, and the board-level test fails if `ui_ready` is stubbed to a constant `TRUE`.

Fixes #317
