### PR TITLE
Send Chrome scratch dirs where R CMD check does not look

### DIFF
--- a/tests/testthat/setup-chrome-ci.R
+++ b/tests/testthat/setup-chrome-ci.R
@@ -11,50 +11,34 @@ withr::local_options(
 )
 
 # Chrome leaves scratch dirs (com.google.Chrome.* / org.chromium.Chromium.*,
-# scoped_dir variants included) in the session temp parent (`$TMPDIR`), which
-# R CMD check then flags as "detritus in the temp directory" -- a NOTE the CI
-# gate fails on. `app$stop()` only ends the shinytest2 session; the shared
-# browser stays alive until R exits, so its scratch is never reclaimed. At the
-# end of the suite, close the browser (a clean shutdown reclaims its scratch),
-# then sweep anything that still leaked.
+# scoped_dir variants included) wherever `$TMPDIR` pointed when it was spawned,
+# and R CMD check flags leftovers in the temp directory it hands to subprocesses
+# as "detritus in the temp directory" -- a NOTE the CI gate fails on. Sweeping
+# those dirs at the end of the suite races a Chrome helper (crashpad, zygote)
+# dropping a fresh one afterwards.
 #
-# On CI the sweep is unconditional. Closing the browser waits for its main
-# process, but a Chrome helper (crashpad, zygote) can drop a fresh scratch dir
-# a moment later -- past a snapshot taken here -- so settle first, then remove
-# every match. A throwaway runner has no unrelated dirs to protect. Locally,
-# keep the conservative `setdiff(before)` so a shared `$TMPDIR` retains its own.
+# Keep them out of the inspected directory instead. Chrome reads `TMPDIR` at
+# spawn while R fixes `tempdir()` at startup, so pointing it at a suite-owned
+# directory below the session temp dir puts the scratch one level down from
+# what check lists -- it looks at that top level only, and skips the `Rtmp*`
+# directory holding this one.
 local({
 
-  pat <- "^(com\\.google\\.Chrome|org\\.chromium\\.Chromium)"
-  tmp_parent <- dirname(tempdir())
-  before <- list.files(tmp_parent, pattern = pat)
-  on_ci <- nzchar(Sys.getenv("CI"))
+  chrome_tmp <- withr::local_tempdir(
+    "chrome",
+    .local_envir = testthat::teardown_env()
+  )
 
+  withr::local_envvar(
+    TMPDIR = chrome_tmp,
+    .local_envir = testthat::teardown_env()
+  )
+
+  # Close the browser so it does not outlive the suite: `app$stop()` only ends
+  # the shinytest2 session, leaving the shared browser to R's exit.
   withr::defer(
-    {
-      had_browser <- isTRUE(chromote::has_default_chromote_object())
-
-      if (had_browser) {
-        try(chromote::default_chromote_object()$close(), silent = TRUE)
-      }
-
-      if (on_ci) {
-
-        if (had_browser) {
-          Sys.sleep(2)
-        }
-
-        leaked <- list.files(tmp_parent, pattern = pat)
-
-      } else {
-        leaked <- setdiff(list.files(tmp_parent, pattern = pat), before)
-      }
-
-      unlink(
-        file.path(tmp_parent, leaked),
-        recursive = TRUE,
-        force = TRUE
-      )
+    if (isTRUE(chromote::has_default_chromote_object())) {
+      try(chromote::default_chromote_object()$close(), silent = TRUE)
     },
     testthat::teardown_env()
   )


### PR DESCRIPTION
The settle-then-sweep teardown from #314 does not close this: it ran on the #322 PR ref and a `com.google.Chrome.LqTzTR` still came through, alongside `checking tests ... OK` and `Status: 1 NOTE`. Any sweep is racy by construction — closing the browser waits for its main process, but a helper (crashpad, zygote) can drop a fresh scratch directory after the sweep has taken its listing.

## Why check sees the directory at all

The `R CMD check` code creates `sessdir <- file.path(tempdir(), "working_dir")`, points `TMPDIR` at it for every subprocess, and afterwards reports what it finds there (`tools:::.check_packages`):

```r
ff <- list.files(sessdir, include.dirs = TRUE)
dir <- file.info(ff)$isdir
poss <- grepl("^Rtmp[A-Za-z0-9.]{6}$", ff, useBytes = TRUE)
ff <- ff[!(poss & dir)]
```

Two properties of that listing decide the fix: it covers the top level only, and it skips directories named `Rtmp*`. The test R process inherits `TMPDIR=sessdir` and fixes its own `tempdir()` to `sessdir/RtmpXXXXXX` at startup, but Chrome is spawned later and reads `TMPDIR` from the environment — so its scratch lands directly in `sessdir`, the one directory check inspects. That is also the evidence that the runner's Google Chrome takes its scratch path from `TMPDIR`: check points `TMPDIR` at `sessdir`, and `com.google.Chrome.6RxMPX` turned up in exactly that directory.

## The change

Point `TMPDIR` at a suite-owned directory below the session `tempdir()` before the browser launches, so the scratch lands one level down, inside the `Rtmp*` directory check skips. The sweep, the 2s settle and the `CI` gate all go away, and with them any dependence on when a helper process finishes. Closing the browser at teardown stays, so it does not outlive the suite.

## Verified

With an empty directory standing in for `sessdir` exactly as check sets it, the scratch lands at its top level before the change:

```
sessdir after launch : org.chromium.Chromium.705nxn | org.chromium.Chromium.scoped_dir.O50wH6 | RtmpXtk8N1
MATCHES in sessdir   : 2
```

After the change, with Chrome `SIGKILL`ed so nothing is ever reclaimed — the worst case no sweep can cover:

```
AFTER KILL scratch : org.chromium.Chromium.268SQS | org.chromium.Chromium.scoped_dir.p47CXp
AFTER KILL sessdir : Rtmp68Qi6F
AFTER KILL matches : 0
```

Running the real suite the same way puts the scratch two levels down while the tests run, leaving only the `Rtmp*` directory at the inspected top level:

```
/tmp/sessdir-suite-A8tvBL/RtmpICW05j/chrome1829816654eb69/org.chromium.Chromium.4NtpWT
```

The full suite was exercised under the redirect too, since it applies to every child process the tests spawn, not only the browser. Local Chrome here is Chromium, hence the `org.chromium.*` spelling; the CI NOTEs carry the Google Chrome spelling.

Two caveats on this PR's own checks. The `ci / check` job that reported the NOTE on #307 runs only on `merge_group`, so the queue run is the definitive test; and because the failure is intermittent, a green `ci / smoke` here is consistent with the fix but does not prove it — the mechanism above is what carries it.

No test and no NEWS entry, matching #233 and #314: this is suite infrastructure, and the assertion is the one `R CMD check` already performs.

The same `setup-chrome-ci.R` sits in blockr.assistant, blockr.dag, blockr.dm, blockr.dock and blockr.ui. Worth propagating once this has held on the queue, but out of scope here.

Fixes #312
