### PR TITLE
Add a construct component and rename require to sustain

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
   evaluation as a side effect, so a consumer that needed a block merely present
   -- the code export reads each block's expression and none of their results --
   had to make it run as well, holding the whole board in the eval set for as
-  long as it needed the expressions. Unlike `evaluate` and `require` it retains
+  long as it needed the expressions. Unlike `evaluate` and `sustain` it retains
   no state: a built block stays built, so there is no owner to name and nothing
   to release, and requesting a block that is already built does nothing. The
   request joins neither the eval set nor the front-end's `required` channel, so
@@ -181,11 +181,11 @@
   front-end can render it distinctly (e.g. a muted node badge); previously such
   a block was indistinguishable from an up-to-date dormant one, so a break
   introduced upstream stayed hidden until the block was visited (#310).
-* Board updates gain two request components, `evaluate` and `require`, for
+* Board updates gain two request components, `evaluate` and `sustain`, for
   evaluating a dormant block without making it visible. Both name blocks that
   are joined, with their upstream closure, to the eval set so they publish a
   current result and current conditions; core drops an `evaluate` request once
-  the block has run, while a `require` claim is held until released. Claims are
+  the block has run, while a `sustain` claim is held until released. Claims are
   keyed by owner (`list(<owner> = list(set =, add =, rm =))`, conventionally
   labelled `session$ns("...")`), so two consumers may hold the same block
   without either releasing the other's claim. Previously the only lever was the

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # blockr.core 0.1.4
 
+* Board updates gain a third request component, `construct`, a character vector
+  of block IDs to build without evaluating. Construction previously followed
+  evaluation as a side effect, so a consumer that needed a block merely present
+  -- the code export reads each block's expression and none of their results --
+  had to make it run as well, holding the whole board in the eval set for as
+  long as it needed the expressions. Unlike `evaluate` and `require` it retains
+  no state: a built block stays built, so there is no owner to name and nothing
+  to release, and requesting a block that is already built does nothing. The
+  request joins neither the eval set nor the front-end's `required` channel, so
+  it cannot turn a lazily evaluating board into an eagerly evaluating one
+  (#333).
 * `apply_board_update()` is now a real reducer rather than a no-op: its
   default `.board` method applies the core delta (block, link and stack
   mutations) to the supplied board and returns it, and update validation

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -1355,6 +1355,12 @@ add_blocks_to_stacks <- function(rv, add, session) {
 #' the state delta, so a payload that edits a block and evaluates it
 #' sees the edit.
 #'
+#' The three are independent sets rather than alternatives: a payload
+#' may name one block in several of them and core takes the union.
+#' Overlap is redundant rather than rejected, which it has to be —
+#' claims are per-owner, so a consumer asking for a block cannot know
+#' that another owner already holds it.
+#'
 #' A locked board (see [is_board_locked()]) still accepts a payload of
 #' request components alone; one that also carries a state change is
 #' dropped whole rather than applied in part.

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -1565,7 +1565,7 @@ validate_block_id_request <- function(x, ids, cmp) {
     blockr_abort(
       "Expecting a board update `{cmp}` component to be specified as a ",
       "character vector.",
-      class = paste0("board_update_", cmp, "_type_invalid")
+      class = "board_update_request_type_invalid"
     )
   }
 
@@ -1574,7 +1574,7 @@ validate_block_id_request <- function(x, ids, cmp) {
   if (length(unknown)) {
     blockr_abort(
       "Cannot {cmp} unknown {qty(unknown)}block{?s} {unknown}.",
-      class = paste0("board_update_", cmp, "_unknown_id")
+      class = "board_update_request_unknown_id"
     )
   }
 

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -86,6 +86,12 @@
 #' neither the eval set nor the front-end's `required` channel, so it cannot
 #' turn a lazily evaluating board into an eagerly evaluating one.
 #'
+#' A block that the same payload adds, or that an `evaluate` or `require` names,
+#' is already constructed — the add builds it directly, and evaluation demand
+#' joins the needed set, which the background constructor builds. Pairing
+#' `construct` with either is redundant rather than wrong. The component covers
+#' what neither does: a block that must exist while nothing needs it evaluated.
+#'
 #' The named blocks are built in the flush that applies the payload, which is
 #' the work `background_construction_delay` otherwise paces out. A caller that
 #' wants that pacing sends several smaller payloads rather than one.

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -68,6 +68,28 @@
 #' cannot, such as an unconnected data input or a user input that was never set.
 #' Requesting a block that is already in the eval set does nothing.
 #'
+#' @section Construction requests:
+#' Evaluation implies construction, but not the reverse: a consumer that needs a
+#' block merely *present* — the code export reads each block's expression and
+#' none of their results — had to make it run as well. The `construct` payload
+#' component asks for construction on its own. Like `evaluate` it is a bare
+#' character vector of block IDs, and the blocks it names are built in
+#' dependency order and left `dormant`:
+#'
+#' ```r
+#' update(list(construct = board_block_ids(board$board)))
+#' ```
+#'
+#' Nothing is retained. Once a block is built it stays built, so unlike the two
+#' evaluation components there is no owner to name and nothing to hand back, and
+#' asking for a block that is already built does nothing. The request joins
+#' neither the eval set nor the front-end's `required` channel, so it cannot
+#' turn a lazily evaluating board into an eagerly evaluating one.
+#'
+#' The named blocks are built in the flush that applies the payload, which is
+#' the work `background_construction_delay` otherwise paces out. A caller that
+#' wants that pacing sends several smaller payloads rather than one.
+#'
 #' @param x Board
 #' @param id Parent namespace
 #' @param ... Generic consistency
@@ -95,7 +117,8 @@ board_server <- function(id, x, ...) {
 #' `visibility$frozen[[id]](TRUE)` to freeze a block's inputs (for example when
 #' its controls are hidden), so a forged input can no longer steer it. A
 #' callback also receives the `update` channel (see [board_update]), through
-#' which it can request block evaluation (see the Evaluation requests section).
+#' which it can request block evaluation or construction (see the Evaluation
+#' requests and Construction requests sections).
 #' @param callback_location Location of callback invocation (before or after
 #' plugins)
 #' @rdname board_server
@@ -857,8 +880,12 @@ block_deferred <- function(id, rv) {
   is.null(status) || status %in% c("dormant", "stale")
 }
 
+id_request_components <- function() {
+  c("evaluate", "construct")
+}
+
 update_request_components <- function() {
-  c("evaluate", "require")
+  c(id_request_components(), "require")
 }
 
 needed_block_ids <- function(rv, required) {
@@ -1304,20 +1331,23 @@ add_blocks_to_stacks <- function(rv, add, session) {
 #' payload slots reach subclass augment / apply methods.
 #'
 #' @section Request components:
-#' Two components carry a request rather than a state change:
-#' `evaluate`, a character vector of block IDs to evaluate once, and
+#' Three components carry a request rather than a state change:
+#' `evaluate`, a character vector of block IDs to evaluate once;
 #' `require`, a list of per-owner deltas over the blocks that are to
-#' stay evaluated. Each delta is `set`, `add` and `rm` — `set` states
-#' that owner's whole set and is exclusive with the other two — so no
-#' owner writes another's claim. Both components put the named blocks
-#' (and their upstream closure) into the eval set without touching what
-#' the front-end shows — see the Evaluation requests section of
-#' [board_server()] — and both resolve their IDs against the
-#' post-update block set, so a payload may add a block and ask for it
-#' in one go. A `require` `rm` is the exception, naming blocks to
-#' release rather than to evaluate, and so may name one the board no
-#' longer has. They are applied after the state delta, so a payload
-#' that edits a block and evaluates it sees the edit.
+#' stay evaluated; and `construct`, a character vector of block IDs to
+#' build without evaluating. Each `require` delta is `set`, `add` and
+#' `rm` — `set` states that owner's whole set and is exclusive with the
+#' other two — so no owner writes another's claim. The two evaluation
+#' components put the named blocks (and their upstream closure) into
+#' the eval set while `construct` leaves them `dormant`, and none of
+#' the three touches what the front-end shows — see the Evaluation
+#' requests and Construction requests sections of [board_server()].
+#' All three resolve their IDs against the post-update block set, so a
+#' payload may add a block and ask for it in one go. A `require` `rm`
+#' is the exception, naming blocks to release rather than to evaluate,
+#' and so may name one the board no longer has. They are applied after
+#' the state delta, so a payload that edits a block and evaluates it
+#' sees the edit.
 #'
 #' A locked board (see [is_board_locked()]) still accepts a payload of
 #' request components alone; one that also carries a state change is
@@ -1488,14 +1518,14 @@ validate_board_update_structure <- function(payload, board) {
     validate_board_update_stacks(payload[["stacks"]], board)
   }
 
-  # Both request components name blocks, and a payload may add the very block it
-  # asks for, so they resolve against the post-update block set.
+  # Every request component names blocks, and a payload may add the very block
+  # it asks for, so they resolve against the post-update block set.
   if (any(update_request_components() %in% names(payload))) {
 
     ids <- updated_block_ids(payload, board)
 
-    if ("evaluate" %in% names(payload)) {
-      validate_board_update_evaluate(payload[["evaluate"]], ids)
+    for (cmp in intersect(id_request_components(), names(payload))) {
+      validate_block_id_request(payload[[cmp]], ids, cmp)
     }
 
     if ("require" %in% names(payload)) {
@@ -1517,13 +1547,13 @@ updated_block_ids <- function(payload, board) {
   union(setdiff(ids, payload[["blocks"]]$rm), names(payload[["blocks"]]$add))
 }
 
-validate_board_update_evaluate <- function(x, ids) {
+validate_block_id_request <- function(x, ids, cmp) {
 
   if (!is.character(x)) {
     blockr_abort(
-      "Expecting a board update `evaluate` component to be specified as a ",
+      "Expecting a board update `{cmp}` component to be specified as a ",
       "character vector.",
-      class = "board_update_evaluate_type_invalid"
+      class = paste0("board_update_", cmp, "_type_invalid")
     )
   }
 
@@ -1531,8 +1561,8 @@ validate_board_update_evaluate <- function(x, ids) {
 
   if (length(unknown)) {
     blockr_abort(
-      "Requested evaluation of unknown block{?s} {unknown}.",
-      class = "board_update_evaluate_unknown_id"
+      "Cannot {cmp} unknown {qty(unknown)}block{?s} {unknown}.",
+      class = paste0("board_update_", cmp, "_unknown_id")
     )
   }
 
@@ -2098,6 +2128,9 @@ apply_core_board_update <- function(rv, upd, session,
 
   # Last, so that a payload which edits a block and asks for it in one go
   # evaluates the edit rather than what it replaced.
+  construct_blocks(upd[["construct"]], rv, edit_block, ctrl_block,
+                   edit_plugin_args, vis)
+
   apply_eval_requests(rv, upd)
 
   invisible()

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -23,20 +23,20 @@
 #' last run — not only its result, but the conditions it reports. Anything that
 #' can reach the [board_update()] channel can ask for such a block to be brought
 #' up to date, without putting it on screen, through the `evaluate` and
-#' `require` payload components. Both name blocks, and core joins them, together
+#' `sustain` payload components. Both name blocks, and core joins them, together
 #' with their upstream closure over [board_links()] (without which they cannot
 #' produce a result), to the eval set. They differ only in who lets go: an
 #' `evaluate` request is a one-off that core drops once the block has run, while
-#' a `require` claim is held until its owner releases it.
+#' a `sustain` claim is held until its owner releases it.
 #'
-#' Claims are keyed by owner, the `require` component mapping each owner to a
+#' Claims are keyed by owner, the `sustain` component mapping each owner to a
 #' delta over the blocks it holds, so several consumers may hold the same block
 #' and none of them writes another's claim:
 #'
 #' ```r
 #' update(
 #'   list(
-#'     require = set_names(
+#'     sustain = set_names(
 #'       list(list(set = board_block_ids(board$board))),
 #'       session$ns("preview")
 #'     )
@@ -86,7 +86,7 @@
 #' neither the eval set nor the front-end's `required` channel, so it cannot
 #' turn a lazily evaluating board into an eagerly evaluating one.
 #'
-#' A block that the same payload adds, or that an `evaluate` or `require` names,
+#' A block that the same payload adds, or that an `evaluate` or `sustain` names,
 #' is already constructed — the add builds it directly, and evaluation demand
 #' joins the needed set, which the background constructor builds. Pairing
 #' `construct` with either is redundant rather than wrong. The component covers
@@ -198,13 +198,13 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
       # changed.
       rv$needed_slots <- new.env(parent = emptyenv())
 
-      # The two request sets fed by the `evaluate` and `require` board update
+      # The two request sets fed by the `evaluate` and `sustain` board update
       # components. Both join the needed set below; they differ in who lets go.
       # Core drops an `evaluating` entry once that block has had its evaluation
-      # pass (see the observer below), while `required_blocks` holds one entry
-      # per claim owner until that owner releases it.
+      # pass (see the observer below), while `claims` holds one entry per claim
+      # owner until that owner releases it.
       rv$evaluating <- reactiveVal(character())
-      rv$required_blocks <- reactiveVal(list())
+      rv$claims <- reactiveVal(list())
 
       observe(
         {
@@ -870,7 +870,7 @@ valid_frozen <- function(x) {
 }
 
 requested_blocks <- function(rv) {
-  union(rv$evaluating(), unlst(rv$required_blocks()))
+  union(rv$evaluating(), unlst(rv$claims()))
 }
 
 # A block owes an evaluation pass while anything it needs for a result -- itself
@@ -891,7 +891,7 @@ id_request_components <- function() {
 }
 
 update_request_components <- function() {
-  c(id_request_components(), "require")
+  c(id_request_components(), "sustain")
 }
 
 needed_block_ids <- function(rv, required) {
@@ -1057,8 +1057,8 @@ destroy_rm_blocks <- function(ids, rv, sess) {
   }
 
   rv$evaluating(setdiff(isolate(rv$evaluating()), ids))
-  rv$required_blocks(
-    filter_empty(lapply(isolate(rv$required_blocks()), setdiff, ids))
+  rv$claims(
+    filter_empty(lapply(isolate(rv$claims()), setdiff, ids))
   )
 
   invisible()
@@ -1339,9 +1339,9 @@ add_blocks_to_stacks <- function(rv, add, session) {
 #' @section Request components:
 #' Three components carry a request rather than a state change:
 #' `evaluate`, a character vector of block IDs to evaluate once;
-#' `require`, a list of per-owner deltas over the blocks that are to
+#' `sustain`, a list of per-owner deltas over the blocks that are to
 #' stay evaluated; and `construct`, a character vector of block IDs to
-#' build without evaluating. Each `require` delta is `set`, `add` and
+#' build without evaluating. Each `sustain` delta is `set`, `add` and
 #' `rm` — `set` states that owner's whole set and is exclusive with the
 #' other two — so no owner writes another's claim. The two evaluation
 #' components put the named blocks (and their upstream closure) into
@@ -1349,7 +1349,7 @@ add_blocks_to_stacks <- function(rv, add, session) {
 #' the three touches what the front-end shows — see the Evaluation
 #' requests and Construction requests sections of [board_server()].
 #' All three resolve their IDs against the post-update block set, so a
-#' payload may add a block and ask for it in one go. A `require` `rm`
+#' payload may add a block and ask for it in one go. A `sustain` `rm`
 #' is the exception, naming blocks to release rather than to evaluate,
 #' and so may name one the board no longer has. They are applied after
 #' the state delta, so a payload that edits a block and evaluates it
@@ -1534,8 +1534,8 @@ validate_board_update_structure <- function(payload, board) {
       validate_block_id_request(payload[[cmp]], ids, cmp)
     }
 
-    if ("require" %in% names(payload)) {
-      validate_board_update_require(payload[["require"]], ids)
+    if ("sustain" %in% names(payload)) {
+      validate_board_update_sustain(payload[["sustain"]], ids)
     }
   }
 
@@ -1575,14 +1575,14 @@ validate_block_id_request <- function(x, ids, cmp) {
   invisible()
 }
 
-validate_board_update_require <- function(x, ids) {
+validate_board_update_sustain <- function(x, ids) {
 
   if (!is.list(x) || length(names(x)) != length(x) ||
         !all(nzchar(names(x))) || anyDuplicated(names(x)) != 0L) {
     blockr_abort(
-      "Expecting a board update `require` component to be specified as a list ",
+      "Expecting a board update `sustain` component to be specified as a list ",
       "of per-owner claim deltas with unique nonempty names.",
-      class = "board_update_require_owners_invalid"
+      class = "board_update_sustain_owners_invalid"
     )
   }
 
@@ -1602,7 +1602,7 @@ validate_claim_delta <- function(x, owner, ids) {
     blockr_abort(
       "Expecting the claim of owner {owner} to consist of components ",
       "{exp_cmp}.",
-      class = "board_update_require_components_invalid"
+      class = "board_update_sustain_components_invalid"
     )
   }
 
@@ -1612,7 +1612,7 @@ validate_claim_delta <- function(x, owner, ids) {
       blockr_abort(
         "Expecting the {cmp} component of the claim of owner {owner} to be ",
         "specified as a character vector (or NULL).",
-        class = "board_update_require_component_invalid"
+        class = "board_update_sustain_component_invalid"
       )
     }
   }
@@ -1621,7 +1621,7 @@ validate_claim_delta <- function(x, owner, ids) {
     blockr_abort(
       "Expecting the claim of owner {owner} to state a whole set via `set` or ",
       "a delta via `add` and `rm`, but not both.",
-      class = "board_update_require_set_delta_clash"
+      class = "board_update_sustain_set_delta_clash"
     )
   }
 
@@ -1631,7 +1631,7 @@ validate_claim_delta <- function(x, owner, ids) {
     blockr_abort(
       "Expecting the claim of owner {owner} to either add or remove ",
       "{qty(both)}block{?s} {both}.",
-      class = "board_update_require_add_rm_clash"
+      class = "board_update_sustain_add_rm_clash"
     )
   }
 
@@ -1643,7 +1643,7 @@ validate_claim_delta <- function(x, owner, ids) {
     blockr_abort(
       "Owner {owner} requested evaluation of unknown {qty(unknown)}",
       "block{?s} {unknown}.",
-      class = "board_update_require_unknown_id"
+      class = "board_update_sustain_unknown_id"
     )
   }
 
@@ -2144,19 +2144,19 @@ apply_core_board_update <- function(rv, upd, session,
 
 apply_eval_requests <- function(rv, upd) {
 
-  req <- upd[["require"]]
+  deltas <- upd[["sustain"]]
 
-  if (length(req)) {
+  if (length(deltas)) {
 
-    log_debug("updating block claims of owner{?s} {names(req)}")
+    log_debug("updating block claims of owner{?s} {names(deltas)}")
 
-    claims <- isolate(rv$required_blocks())
+    claims <- isolate(rv$claims())
 
-    for (owner in names(req)) {
-      claims[[owner]] <- apply_claim_delta(claims[[owner]], req[[owner]])
+    for (owner in names(deltas)) {
+      claims[[owner]] <- apply_claim_delta(claims[[owner]], deltas[[owner]])
     }
 
-    rv$required_blocks(filter_empty(claims))
+    rv$claims(filter_empty(claims))
   }
 
   if (length(upd[["evaluate"]])) {

--- a/man/board_server.Rd
+++ b/man/board_server.Rd
@@ -41,7 +41,8 @@ construction, evaluation and rendering. Set
 \code{visibility$frozen[[id]](TRUE)} to freeze a block's inputs (for example when
 its controls are hidden), so a forged input can no longer steer it. A
 callback also receives the \code{update} channel (see \link{board_update}), through
-which it can request block evaluation (see the Evaluation requests section).}
+which it can request block evaluation or construction (see the Evaluation
+requests and Construction requests sections).}
 
 \item{callback_location}{Location of callback invocation (before or after
 plugins)}
@@ -120,5 +121,28 @@ payload a locked board still accepts.
 Core drops a one-off request once the block has run — or has reported why it
 cannot, such as an unconnected data input or a user input that was never set.
 Requesting a block that is already in the eval set does nothing.
+}
+
+\section{Construction requests}{
+
+Evaluation implies construction, but not the reverse: a consumer that needs a
+block merely \emph{present} — the code export reads each block's expression and
+none of their results — had to make it run as well. The \code{construct} payload
+component asks for construction on its own. Like \code{evaluate} it is a bare
+character vector of block IDs, and the blocks it names are built in
+dependency order and left \code{dormant}:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{update(list(construct = board_block_ids(board$board)))
+}\if{html}{\out{</div>}}
+
+Nothing is retained. Once a block is built it stays built, so unlike the two
+evaluation components there is no owner to name and nothing to hand back, and
+asking for a block that is already built does nothing. The request joins
+neither the eval set nor the front-end's \code{required} channel, so it cannot
+turn a lazily evaluating board into an eagerly evaluating one.
+
+The named blocks are built in the flush that applies the payload, which is
+the work \code{background_construction_delay} otherwise paces out. A caller that
+wants that pacing sends several smaller payloads rather than one.
 }
 

--- a/man/board_server.Rd
+++ b/man/board_server.Rd
@@ -141,6 +141,12 @@ asking for a block that is already built does nothing. The request joins
 neither the eval set nor the front-end's \code{required} channel, so it cannot
 turn a lazily evaluating board into an eagerly evaluating one.
 
+A block that the same payload adds, or that an \code{evaluate} or \code{require} names,
+is already constructed — the add builds it directly, and evaluation demand
+joins the needed set, which the background constructor builds. Pairing
+\code{construct} with either is redundant rather than wrong. The component covers
+what neither does: a block that must exist while nothing needs it evaluated.
+
 The named blocks are built in the flush that applies the payload, which is
 the work \code{background_construction_delay} otherwise paces out. A caller that
 wants that pacing sends several smaller payloads rather than one.

--- a/man/board_server.Rd
+++ b/man/board_server.Rd
@@ -78,19 +78,19 @@ Deferred evaluation leaves a block that nothing currently needs holding its
 last run — not only its result, but the conditions it reports. Anything that
 can reach the \code{\link[=board_update]{board_update()}} channel can ask for such a block to be brought
 up to date, without putting it on screen, through the \code{evaluate} and
-\code{require} payload components. Both name blocks, and core joins them, together
+\code{sustain} payload components. Both name blocks, and core joins them, together
 with their upstream closure over \code{\link[=board_links]{board_links()}} (without which they cannot
 produce a result), to the eval set. They differ only in who lets go: an
 \code{evaluate} request is a one-off that core drops once the block has run, while
-a \code{require} claim is held until its owner releases it.
+a \code{sustain} claim is held until its owner releases it.
 
-Claims are keyed by owner, the \code{require} component mapping each owner to a
+Claims are keyed by owner, the \code{sustain} component mapping each owner to a
 delta over the blocks it holds, so several consumers may hold the same block
 and none of them writes another's claim:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{update(
   list(
-    require = set_names(
+    sustain = set_names(
       list(list(set = board_block_ids(board$board))),
       session$ns("preview")
     )
@@ -141,7 +141,7 @@ asking for a block that is already built does nothing. The request joins
 neither the eval set nor the front-end's \code{required} channel, so it cannot
 turn a lazily evaluating board into an eagerly evaluating one.
 
-A block that the same payload adds, or that an \code{evaluate} or \code{require} names,
+A block that the same payload adds, or that an \code{evaluate} or \code{sustain} names,
 is already constructed — the add builds it directly, and evaluation demand
 joins the needed set, which the background constructor builds. Pairing
 \code{construct} with either is redundant rather than wrong. The component covers

--- a/man/board_update.Rd
+++ b/man/board_update.Rd
@@ -63,9 +63,9 @@ payload slots reach subclass augment / apply methods.
 
 Three components carry a request rather than a state change:
 \code{evaluate}, a character vector of block IDs to evaluate once;
-\code{require}, a list of per-owner deltas over the blocks that are to
+\code{sustain}, a list of per-owner deltas over the blocks that are to
 stay evaluated; and \code{construct}, a character vector of block IDs to
-build without evaluating. Each \code{require} delta is \code{set}, \code{add} and
+build without evaluating. Each \code{sustain} delta is \code{set}, \code{add} and
 \code{rm} — \code{set} states that owner's whole set and is exclusive with the
 other two — so no owner writes another's claim. The two evaluation
 components put the named blocks (and their upstream closure) into
@@ -73,7 +73,7 @@ the eval set while \code{construct} leaves them \code{dormant}, and none of
 the three touches what the front-end shows — see the Evaluation
 requests and Construction requests sections of \code{\link[=board_server]{board_server()}}.
 All three resolve their IDs against the post-update block set, so a
-payload may add a block and ask for it in one go. A \code{require} \code{rm}
+payload may add a block and ask for it in one go. A \code{sustain} \code{rm}
 is the exception, naming blocks to release rather than to evaluate,
 and so may name one the board no longer has. They are applied after
 the state delta, so a payload that edits a block and evaluates it

--- a/man/board_update.Rd
+++ b/man/board_update.Rd
@@ -61,20 +61,23 @@ payload slots reach subclass augment / apply methods.
 
 \section{Request components}{
 
-Two components carry a request rather than a state change:
-\code{evaluate}, a character vector of block IDs to evaluate once, and
+Three components carry a request rather than a state change:
+\code{evaluate}, a character vector of block IDs to evaluate once;
 \code{require}, a list of per-owner deltas over the blocks that are to
-stay evaluated. Each delta is \code{set}, \code{add} and \code{rm} — \code{set} states
-that owner's whole set and is exclusive with the other two — so no
-owner writes another's claim. Both components put the named blocks
-(and their upstream closure) into the eval set without touching what
-the front-end shows — see the Evaluation requests section of
-\code{\link[=board_server]{board_server()}} — and both resolve their IDs against the
-post-update block set, so a payload may add a block and ask for it
-in one go. A \code{require} \code{rm} is the exception, naming blocks to
-release rather than to evaluate, and so may name one the board no
-longer has. They are applied after the state delta, so a payload
-that edits a block and evaluates it sees the edit.
+stay evaluated; and \code{construct}, a character vector of block IDs to
+build without evaluating. Each \code{require} delta is \code{set}, \code{add} and
+\code{rm} — \code{set} states that owner's whole set and is exclusive with the
+other two — so no owner writes another's claim. The two evaluation
+components put the named blocks (and their upstream closure) into
+the eval set while \code{construct} leaves them \code{dormant}, and none of
+the three touches what the front-end shows — see the Evaluation
+requests and Construction requests sections of \code{\link[=board_server]{board_server()}}.
+All three resolve their IDs against the post-update block set, so a
+payload may add a block and ask for it in one go. A \code{require} \code{rm}
+is the exception, naming blocks to release rather than to evaluate,
+and so may name one the board no longer has. They are applied after
+the state delta, so a payload that edits a block and evaluates it
+sees the edit.
 
 A locked board (see \code{\link[=is_board_locked]{is_board_locked()}}) still accepts a payload of
 request components alone; one that also carries a state change is

--- a/man/board_update.Rd
+++ b/man/board_update.Rd
@@ -79,6 +79,12 @@ and so may name one the board no longer has. They are applied after
 the state delta, so a payload that edits a block and evaluates it
 sees the edit.
 
+The three are independent sets rather than alternatives: a payload
+may name one block in several of them and core takes the union.
+Overlap is redundant rather than rejected, which it has to be —
+claims are per-owner, so a consumer asking for a block cannot know
+that another owner already holds it.
+
 A locked board (see \code{\link[=is_board_locked]{is_board_locked()}}) still accepts a payload of
 request components alone; one that also carries a state change is
 dropped whole rather than applied in part.

--- a/tests/testthat/test-board-lock.R
+++ b/tests/testthat/test-board-lock.R
@@ -76,10 +76,10 @@ test_that("a locked board still accepts block requests", {
       session$flushReact()
 
       # A request carries no state change, so the lock does not apply to it.
-      board_update(list(require = list(consumer = list(set = "a"))))
+      board_update(list(sustain = list(consumer = list(set = "a"))))
       session$flushReact()
 
-      expect_identical(rv$required_blocks(), list(consumer = "a"))
+      expect_identical(rv$claims(), list(consumer = "a"))
       expect_true(rv$last_update$ok)
 
       board_update(list(construct = "a"))
@@ -91,14 +91,14 @@ test_that("a locked board still accepts block requests", {
       board_update(
         list(
           blocks = list(add = as_blocks(list(b = new_dataset_block("BOD")))),
-          require = list(consumer = list(set = character()))
+          sustain = list(consumer = list(set = character()))
         )
       )
       session$flushReact()
 
       expect_false(rv$last_update$ok)
       expect_length(board_blocks(rv$board), 1L)
-      expect_identical(rv$required_blocks(), list(consumer = "a"))
+      expect_identical(rv$claims(), list(consumer = "a"))
     },
     args = list(x = board, plugins = list())
   )

--- a/tests/testthat/test-board-lock.R
+++ b/tests/testthat/test-board-lock.R
@@ -64,7 +64,7 @@ test_that("a locked board records the outcome of what it dropped", {
   )
 })
 
-test_that("a locked board still accepts evaluation requests", {
+test_that("a locked board still accepts block requests", {
 
   withr::local_options(blockr.locked = TRUE)
 
@@ -80,6 +80,11 @@ test_that("a locked board still accepts evaluation requests", {
       session$flushReact()
 
       expect_identical(rv$required_blocks(), list(consumer = "a"))
+      expect_true(rv$last_update$ok)
+
+      board_update(list(construct = "a"))
+      session$flushReact()
+
       expect_true(rv$last_update$ok)
 
       # Mixed with one that does, the payload is dropped whole.

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -804,86 +804,86 @@ test_that("update validation", {
 
   expect_error(
     validate_board_update(
-      list(require = list(list(set = "a"))),
+      list(sustain = list(list(set = "a"))),
       new_board(blocks(a = new_dataset_block()))
     ),
-    class = "board_update_require_owners_invalid"
+    class = "board_update_sustain_owners_invalid"
   )
 
   expect_error(
     validate_board_update(
-      list(require = set_names(list(list(set = "a")), "")),
+      list(sustain = set_names(list(list(set = "a")), "")),
       new_board(blocks(a = new_dataset_block()))
     ),
-    class = "board_update_require_owners_invalid"
+    class = "board_update_sustain_owners_invalid"
   )
 
   expect_error(
     validate_board_update(
       list(
-        require = set_names(
+        sustain = set_names(
           list(list(set = "a"), list(add = "a")),
           c("board-code_export", "board-code_export")
         )
       ),
       new_board(blocks(a = new_dataset_block()))
     ),
-    class = "board_update_require_owners_invalid"
+    class = "board_update_sustain_owners_invalid"
   )
 
   expect_error(
     validate_board_update(
-      list(require = list(owner = "a")),
+      list(sustain = list(owner = "a")),
       new_board(blocks(a = new_dataset_block()))
     ),
-    class = "board_update_require_components_invalid"
+    class = "board_update_sustain_components_invalid"
   )
 
   expect_error(
     validate_board_update(
-      list(require = list(owner = list(claim = "a"))),
+      list(sustain = list(owner = list(claim = "a"))),
       new_board(blocks(a = new_dataset_block()))
     ),
-    class = "board_update_require_components_invalid"
+    class = "board_update_sustain_components_invalid"
   )
 
   expect_error(
     validate_board_update(
-      list(require = list(owner = list(set = 1L))),
+      list(sustain = list(owner = list(set = 1L))),
       new_board(blocks(a = new_dataset_block()))
     ),
-    class = "board_update_require_component_invalid"
+    class = "board_update_sustain_component_invalid"
   )
 
   expect_error(
     validate_board_update(
-      list(require = list(owner = list(set = "a", add = "a"))),
+      list(sustain = list(owner = list(set = "a", add = "a"))),
       new_board(blocks(a = new_dataset_block()))
     ),
-    class = "board_update_require_set_delta_clash"
+    class = "board_update_sustain_set_delta_clash"
   )
 
   expect_error(
     validate_board_update(
-      list(require = list(owner = list(add = "a", rm = "a"))),
+      list(sustain = list(owner = list(add = "a", rm = "a"))),
       new_board(blocks(a = new_dataset_block()))
     ),
-    class = "board_update_require_add_rm_clash"
+    class = "board_update_sustain_add_rm_clash"
   )
 
   expect_error(
     validate_board_update(
-      list(require = list(owner = list(add = "b"))),
+      list(sustain = list(owner = list(add = "b"))),
       new_board(blocks(a = new_dataset_block()))
     ),
-    class = "board_update_require_unknown_id"
+    class = "board_update_sustain_unknown_id"
   )
 
   # Releasing is the one direction that may name a block the board no longer
   # has, so a removal that races a release cannot reject the payload.
   expect_silent(
     validate_board_update(
-      list(require = list(owner = list(rm = "b"))),
+      list(sustain = list(owner = list(rm = "b"))),
       new_board(blocks(a = new_dataset_block()))
     )
   )
@@ -937,12 +937,12 @@ test_that("a subclass payload slot is not taken for a core component", {
       # Unknown top-level keys reach subclass methods untouched, and `$`
       # partial-matches, so a slot whose name extends a core one would be
       # applied here without ever having been validated.
-      board_update(list(evaluate_all = "nope", require_all = "nope"))
+      board_update(list(evaluate_all = "nope", sustain_all = "nope"))
       session$flushReact()
 
       expect_true(rv$last_update$ok)
       expect_length(rv$evaluating(), 0L)
-      expect_length(rv$required_blocks(), 0L)
+      expect_length(rv$claims(), 0L)
     },
     args = list(x = board, plugins = list())
   )

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -893,7 +893,7 @@ test_that("update validation", {
       list(evaluate = 1L),
       new_board(blocks(a = new_dataset_block()))
     ),
-    class = "board_update_evaluate_type_invalid"
+    class = "board_update_request_type_invalid"
   )
 
   expect_error(
@@ -901,7 +901,7 @@ test_that("update validation", {
       list(construct = 1L),
       new_board(blocks(a = new_dataset_block()))
     ),
-    class = "board_update_construct_type_invalid"
+    class = "board_update_request_type_invalid"
   )
 
   expect_error(
@@ -909,7 +909,7 @@ test_that("update validation", {
       list(construct = "b"),
       new_board(blocks(a = new_dataset_block()))
     ),
-    class = "board_update_construct_unknown_id"
+    class = "board_update_request_unknown_id"
   )
 
   # Resolving against the post-update block set is what lets one payload add a

--- a/tests/testthat/test-board-server.R
+++ b/tests/testthat/test-board-server.R
@@ -887,6 +887,42 @@ test_that("update validation", {
       new_board(blocks(a = new_dataset_block()))
     )
   )
+
+  expect_error(
+    validate_board_update(
+      list(evaluate = 1L),
+      new_board(blocks(a = new_dataset_block()))
+    ),
+    class = "board_update_evaluate_type_invalid"
+  )
+
+  expect_error(
+    validate_board_update(
+      list(construct = 1L),
+      new_board(blocks(a = new_dataset_block()))
+    ),
+    class = "board_update_construct_type_invalid"
+  )
+
+  expect_error(
+    validate_board_update(
+      list(construct = "b"),
+      new_board(blocks(a = new_dataset_block()))
+    ),
+    class = "board_update_construct_unknown_id"
+  )
+
+  # Resolving against the post-update block set is what lets one payload add a
+  # block and ask for it.
+  expect_silent(
+    validate_board_update(
+      list(
+        blocks = list(add = as_blocks(list(b = new_dataset_block()))),
+        construct = "b"
+      ),
+      new_board(blocks(a = new_dataset_block()))
+    )
+  )
 })
 
 test_that("a subclass payload slot is not taken for a core component", {

--- a/tests/testthat/test-visibility-gating.R
+++ b/tests/testthat/test-visibility-gating.R
@@ -1195,6 +1195,59 @@ test_that("a request for a block added in the same payload is honoured", {
   )
 })
 
+test_that("a construction request builds a block without evaluating it", {
+
+  reset_probes()
+
+  withr::local_options(blockr.background_construction_delay = Inf)
+
+  board <- new_board(
+    blocks = c(
+      s = with_id(probe_source(), "s"),
+      a = with_id(probe_passthrough(), "a"),
+      r = with_id(probe_passthrough(), "r")
+    ),
+    links = links(
+      sa = new_link("s", "a", "data"),
+      ar = new_link("a", "r", "data")
+    )
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      expect_true(constructed("s"))
+      expect_false(constructed("r"))
+
+      board_update(list(construct = c("s", "r")))
+      session$flushReact()
+
+      expect_true(constructed("r"))
+      expect_false(evaluated("r"))
+      expect_identical(rv$eval[["r"]](), "dormant")
+
+      # Construction is not demand: `r` stays out of the eval set, `a` -- which
+      # it would need for a result -- stays unbuilt, and `s` is not rebuilt.
+      expect_setequal(rv$needed(), "s")
+      expect_identical(probe_construct$ids, c("s", "r"))
+
+      # Nor does the request touch the channel the front-end owns, which is what
+      # keeps it from flipping an ungated board into gated mode.
+      expect_true(is.na(vis$required[["r"]]()))
+    },
+    args = list(
+      x = board,
+      plugins = list(),
+      callbacks = function(visibility, ...) {
+        require_blocks(visibility, "s")
+        render_blocks(visibility, "s")
+      }
+    )
+  )
+})
+
 test_that("a request naming an unknown block is rejected", {
 
   reset_probes()
@@ -1217,6 +1270,12 @@ test_that("a request naming an unknown block is rejected", {
       expect_false(rv$last_update$ok)
       expect_identical(rv$last_update$phase, "validate")
       expect_length(rv$evaluating(), 0L)
+
+      board_update(list(construct = "nope"))
+      session$flushReact()
+
+      expect_false(rv$last_update$ok)
+      expect_identical(rv$last_update$phase, "validate")
 
       board_update(list(require = list(consumer = list(set = "nope"))))
       session$flushReact()

--- a/tests/testthat/test-visibility-gating.R
+++ b/tests/testthat/test-visibility-gating.R
@@ -1248,6 +1248,59 @@ test_that("a construction request builds a block without evaluating it", {
   )
 })
 
+test_that("overlapping requests union rather than clash", {
+
+  reset_probes()
+
+  withr::local_options(blockr.background_construction_delay = Inf)
+
+  board <- new_board(
+    blocks = c(
+      s = with_id(probe_source(), "s"),
+      r = with_id(probe_passthrough(), "r")
+    ),
+    links = links(sr = new_link("s", "r", "data"))
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      board_update(
+        list(
+          construct = "r",
+          evaluate = "r",
+          sustain = list(one = list(set = "r"))
+        )
+      )
+      session$flushReact()
+
+      expect_true(rv$last_update$ok)
+      expect_true(constructed("r"))
+      expect_identical(rv$eval[["r"]](), "ready")
+      expect_identical(rv$claims(), list(one = "r"))
+      expect_length(rv$evaluating(), 0L)
+
+      # A second consumer cannot know what the first holds, so a one-off over
+      # a block someone else claims must not be rejected either.
+      board_update(list(evaluate = "r"))
+      session$flushReact()
+
+      expect_true(rv$last_update$ok)
+      expect_identical(rv$claims(), list(one = "r"))
+    },
+    args = list(
+      x = board,
+      plugins = list(),
+      callbacks = function(visibility, ...) {
+        require_blocks(visibility, "s")
+        render_blocks(visibility, "s")
+      }
+    )
+  )
+})
+
 test_that("a request naming an unknown block is rejected", {
 
   reset_probes()

--- a/tests/testthat/test-visibility-gating.R
+++ b/tests/testthat/test-visibility-gating.R
@@ -1008,7 +1008,7 @@ test_that("a required claim holds a block until it is released", {
       reset_probes()
 
       # A claim, unlike a one-off request, survives evaluation.
-      board_update(list(require = list(consumer = list(set = "r"))))
+      board_update(list(sustain = list(consumer = list(set = "r"))))
       session$flushReact()
 
       expect_identical(rv$eval[["r"]](), "ready")
@@ -1016,15 +1016,15 @@ test_that("a required claim holds a block until it is released", {
       for (i in 1:3) session$flushReact()
 
       expect_identical(rv$eval[["r"]](), "ready")
-      expect_identical(rv$required_blocks(), list(consumer = "r"))
+      expect_identical(rv$claims(), list(consumer = "r"))
 
       # Releasing it hands the block back to the front-end's gating, which
       # parked it.
-      board_update(list(require = list(consumer = list(set = character()))))
+      board_update(list(sustain = list(consumer = list(set = character()))))
       session$flushReact()
 
       expect_identical(rv$eval[["r"]](), "dormant")
-      expect_length(rv$required_blocks(), 0L)
+      expect_length(rv$claims(), 0L)
       expect_false(rendered("r"))
     },
     args = list(
@@ -1062,29 +1062,29 @@ test_that("one owner's release leaves another owner's claim standing", {
 
       expect_identical(rv$eval[["r"]](), "dormant")
 
-      board_update(list(require = list(one = list(set = "r"))))
+      board_update(list(sustain = list(one = list(set = "r"))))
       session$flushReact()
 
-      board_update(list(require = list(two = list(add = "r"))))
+      board_update(list(sustain = list(two = list(add = "r"))))
       session$flushReact()
 
-      expect_identical(rv$required_blocks(), list(one = "r", two = "r"))
+      expect_identical(rv$claims(), list(one = "r", two = "r"))
       expect_identical(rv$eval[["r"]](), "ready")
 
       # The block is held by two owners, so the first letting go does not
       # release the second's claim.
-      board_update(list(require = list(one = list(set = character()))))
+      board_update(list(sustain = list(one = list(set = character()))))
       session$flushReact()
 
-      expect_identical(rv$required_blocks(), list(two = "r"))
+      expect_identical(rv$claims(), list(two = "r"))
       expect_identical(rv$eval[["r"]](), "ready")
 
       # Releasing the last block an owner holds drops the owner, whether it
       # says so with `rm` or by setting an empty set.
-      board_update(list(require = list(two = list(rm = "r"))))
+      board_update(list(sustain = list(two = list(rm = "r"))))
       session$flushReact()
 
-      expect_length(rv$required_blocks(), 0L)
+      expect_length(rv$claims(), 0L)
       expect_identical(rv$eval[["r"]](), "dormant")
     },
     args = list(
@@ -1119,7 +1119,7 @@ test_that("removing a claimed block prunes it from every owner", {
 
       board_update(
         list(
-          require = list(
+          sustain = list(
             one = list(set = c("s", "r")),
             two = list(set = "r")
           )
@@ -1132,16 +1132,16 @@ test_that("removing a claimed block prunes it from every owner", {
 
       # An owner left holding nothing is dropped, so a stale claim cannot
       # outlive the block it named.
-      expect_identical(rv$required_blocks(), list(one = "s"))
+      expect_identical(rv$claims(), list(one = "s"))
       expect_setequal(rv$needed(), "s")
 
       # The owner that lost its block still releases cleanly: `rm` names a
       # block the board no longer has, and that must not reject the payload.
-      board_update(list(require = list(two = list(rm = "r"))))
+      board_update(list(sustain = list(two = list(rm = "r"))))
       session$flushReact()
 
       expect_true(rv$last_update$ok)
-      expect_identical(rv$required_blocks(), list(one = "s"))
+      expect_identical(rv$claims(), list(one = "s"))
     },
     args = list(
       x = board,
@@ -1277,18 +1277,18 @@ test_that("a request naming an unknown block is rejected", {
       expect_false(rv$last_update$ok)
       expect_identical(rv$last_update$phase, "validate")
 
-      board_update(list(require = list(consumer = list(set = "nope"))))
+      board_update(list(sustain = list(consumer = list(set = "nope"))))
       session$flushReact()
 
       expect_false(rv$last_update$ok)
-      expect_length(rv$required_blocks(), 0L)
+      expect_length(rv$claims(), 0L)
 
       # A claim with no owner to release it is refused as well.
-      board_update(list(require = list(list(set = "a"))))
+      board_update(list(sustain = list(list(set = "a"))))
       session$flushReact()
 
       expect_false(rv$last_update$ok)
-      expect_length(rv$required_blocks(), 0L)
+      expect_length(rv$claims(), 0L)
 
       expect_setequal(rv$needed(), "a")
     },


### PR DESCRIPTION
## Add a `construct` request component

- Board updates gain a third request component, `construct`, a bare character vector of block IDs. The named blocks are built in dependency order and left `dormant`.
- Construction previously followed evaluation as a side effect, so the only way to get a block *present* was to make it run. The code export is the worked example: it reads each block's `expr` and none of their results, yet the plugin on the #322 branch claims the whole board for the modal's lifetime just to read them.
- Unlike its two siblings the component retains no state — once a block is built it stays built, so there is no owner to name and nothing to release, and asking for a block that is already built does nothing.
- The request joins neither the eval set nor `vis$required`. Keeping construction demand off that slot is what stops it flipping an ungated board into gated mode, which is the hazard #321 warns against when it names construction demand as one of the three jobs to split out of the `required` tri-state.
- Validation is shared with `evaluate` rather than duplicated, and resolves IDs against the post-update block set, so one payload can add a block and construct it. The component joins `update_request_components()`, so a locked board accepts it like the other two.

Adoption is left to #322. Nothing about the front-end contract changes here, and blockr.dock keeps writing `required[[id]](FALSE)` exactly as it does now.

## Rename `require` to `sustain`

- The old name collided with `visibility$required` and `rv$required_blocks` — one root over a single-writer front-end channel and an owner-keyed set any consumer writes — and it named only that something was demanded rather than what. Both siblings name the thing asked for.
- Taking a *state* as its object is what makes `sustain` work where `claim` or `hold` would not: an adjacent key supplies the object, so alongside `construct` and `evaluate` it reads as *keep it in the state those put it in*.
- Rejected on the way: `current` and `fresh` promise an outcome core cannot deliver, since a held block reaches `waiting`, `unset` or `failed` as legitimately as `ready` — membership in the eval set only buys leaving the `{dormant, stale}` branch.
- State moves to `rv$claims`, which is the collision that mattered, and the condition classes follow the key. The per-owner delta machinery keeps `claim`, since ownership is not what changed.

Nothing released breaks: the component landed in the unreleased 0.1.4, so the NEWS entry introducing it is edited in place rather than gaining a rename entry. One line on #322's unmerged branch, for whoever owns it to apply.

Fixes #333
