### PR TITLE
Fold front-end demand into the one multi-owner claim set

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,19 +1,34 @@
 # blockr.core 0.1.4
 
+* Evaluation demand is now one multi-owner set rather than two channels. The
+  front-end's per-block `required` channel is gone: what it needs evaluated is
+  a `sustain` claim held under an owner label like any other consumer's, and
+  what it needs merely built is a `construct` request. Core no longer
+  distinguishes a front-end's demand from a code export's, and because no owner
+  writes another's claim, the channel cannot silently become multi-writer the
+  way `required` did. The three jobs the tri-state used to do in one slot are
+  now separate: gating activation is an explicit declaration a front-end makes
+  by writing its owner label into the new board-wide `visibility$gate` channel
+  -- inferring it from claims instead would let a consumer asking about one
+  block park every other block on an ungated board -- and construction demand is
+  the `construct` component. Reporting paint on `visible` is unchanged, and the
+  background pass still holds until every block the gating front-end claims is
+  reported painted. Breaking for any front-end that drives
+  `visibility$required` (#321).
 * Core's own board UI now drives visibility, through a board callback like any
   other front-end rather than from inside the board server. Stacks render as an
   accordion which opens one stack and collapses the rest, so on a stacked board
   part of what is on screen was hidden from the first render while every block
   evaluated and rendered regardless -- nothing read the input `bslib` had
   already wired for reporting which stacks are open. The new `gate_stacks()`
-  callback marks the blocks of every open stack plus every unstacked block
-  required and parks the rest, so collapsing a stack stops its blocks
-  evaluating and expanding one starts them again. Parked rather than dropped: a
-  collapsed stack's blocks stay built, so re-expanding shows them without a
-  rebuild. It is `board_server()`'s default `callbacks` value and gates nothing
-  until that accordion reports, so a board driven by another front-end -- which
-  passes its own callbacks, and whose UI never binds the input -- is left
-  alone; a consumer that wants both keeps it in the list,
+  callback claims the blocks of every open stack plus every unstacked block and
+  parks the rest, so collapsing a stack stops its blocks evaluating and
+  expanding one starts them again. Parked rather than dropped: a collapsed
+  stack's blocks stay built through a `construct` request, so re-expanding shows
+  them without a rebuild. It is `board_server()`'s default `callbacks` value and
+  gates nothing until that accordion reports, so a board driven by another
+  front-end -- which passes its own callbacks, and whose UI never binds the
+  input -- is left alone; a consumer that wants both keeps it in the list,
   `callbacks = list(gate_stacks(), my_callback)`. The `gate_visibility` option
   turns it off along with all other gating. The accordion container ID moves
   from `<board>_stacks` to the board-namespaced `<board>-stacks`, which is what
@@ -26,11 +41,10 @@
   long as it needed the expressions. Unlike `evaluate` and `sustain` it retains
   no state: a built block stays built, so there is no owner to name and nothing
   to release, and requesting a block that is already built does nothing. The
-  request joins neither the eval set nor the front-end's `required` channel, so
-  it cannot turn a lazily evaluating board into an eagerly evaluating one
-  (#333).
-* Showing the generated code no longer writes the front-end's `required`
-  channel. A block parked with `required[[id]](FALSE)` was overwritten and
+  request joins neither the eval set nor the gate declaration, so it cannot
+  turn a lazily evaluating board into an eagerly evaluating one (#333).
+* Showing the generated code no longer writes the front-end's own demand
+  channel. A block the front-end had parked was overwritten and
   never restored, so a single "Show code" turned a lazily evaluating board
   into an eagerly evaluating one for the rest of the session, with nothing
   left to release it. The export asks for construction alone through the

--- a/R/block-server.R
+++ b/R/block-server.R
@@ -58,39 +58,49 @@
 #' [block_output()] generic. The [block_ui()] generic can then be used to
 #' control rendering of outputs.
 #'
-#' A front-end (such as blockr.dock) drives per-block channels that
-#' [board_server()] hands to the board callback as `visibility`. Two of them
-#' gate what is built and shown: `required` (which blocks it needs built and
-#' evaluated) and `visible` (which blocks it has arranged on screen).
-#' Requirements are a cause the front-end -- and
-#' core-side features such as code export -- declare; visibility is the effect
-#' the front-end reports back once it has painted a block. Rendering is gated
-#' on `visible`: the render observer is suspended while a block carries no
-#' visible slot and resumed once the front-end writes a non-empty string for
-#' it, starting suspended so nothing renders before the first report.
-#' Evaluation is gated on the *needed* set, the `required` blocks together with
-#' their upstream closure over [board_links()] (recomputed only when
-#' requirements or links change). A block's input data reactives stay
-#' unfulfilled (they [shiny::req()] out) unless the block is needed, so a block
-#' that is neither required nor feeding a required block pulls no input and
-#' stays fully quiescent: its result reactive, and any observer its expression
-#' server registers on the incoming data, all short-circuit and do nothing. A
-#' needed but off-screen block (one feeding a required block) evaluates but
-#' does not render. Block-server *construction* is prioritized the same way:
-#' the needed set is instantiated first so that first paint waits only for the
-#' required blocks and their upstreams, and the remaining block servers are
-#' built progressively in the background. That background pass holds until the
-#' front-end reports every required block as visible, so it never competes with
-#' first paint. A `required` slot of `FALSE` keeps a block built but dormant
-#' (ever required, not needed now); an absent slot leaves it unbuilt. Until a
+#' A front-end (such as blockr.dock) declares that it will drive visibility by
+#' writing an owner label into the `gate` channel of the `visibility` bundle
+#' that [board_server()] hands to the board callback. That declaration, and
+#' nothing else, is what flips the board from evaluating everything to
+#' evaluating only what is needed; with no front-end every block is needed and
+#' behaviour is unchanged, and the `gate_visibility` [blockr_option()] (default
+#' `TRUE`) turns gating off entirely. It is written synchronously, while the
+#' callback is set up, because it has to be in hand before the first flush
+#' decides what to construct.
+#'
+#' Which blocks the front-end needs evaluated is not a channel of its own: it
+#' is a `sustain` claim held under that same owner label, leaving the front-end
+#' one owner among several rather than a special case core can distinguish from
+#' a code export or an extension (see the Evaluation requests section of
+#' [board_server()]). Blocks it wants built without being evaluated -- a card
+#' it has created off screen, say -- are a `construct` request.
+#'
+#' Evaluation is gated on the *needed* set, the claimed blocks together with
+#' their upstream closure over [board_links()] (recomputed only when claims or
+#' links change). A block's input data reactives stay unfulfilled (they
+#' [shiny::req()] out) unless the block is needed, so a block that is neither
+#' claimed nor feeding a claimed block pulls no input and stays fully
+#' quiescent: its result reactive, and any observer its expression server
+#' registers on the incoming data, all short-circuit and do nothing. A needed
+#' but off-screen block (one feeding a claimed block) evaluates but does not
+#' render.
+#'
+#' Rendering is gated on `visible`, the per-block channel through which the
+#' front-end reports what it has painted -- the effect, where a claim is the
+#' cause. The render observer is suspended while a block carries no visible
+#' slot and resumed once the front-end reports it painted, starting suspended
+#' so nothing renders before the first report.
+#'
+#' Block-server *construction* is prioritized the same way: the needed set is
+#' instantiated first so that first paint waits only for the claimed blocks and
+#' their upstreams, and the remaining block servers are built progressively in
+#' the background. That background pass holds until the front-end reports every
+#' block it claims as visible, so it never competes with first paint. Until a
 #' block is built it is absent from the `board$blocks` handed to plugins and
 #' callbacks, which simply see it appear once constructed. The background
 #' cadence is set by the `background_construction_delay` [blockr_option()]
 #' (milliseconds between successive blocks, default 50); a value of 0 disables
-#' the staggering and builds every block up front. With nothing writing
-#' `required` every block is needed and behaviour is unchanged; the
-#' `gate_visibility` [blockr_option()] (default `TRUE`) turns gating off
-#' entirely.
+#' the staggering and builds every block up front.
 #'
 #' Core's own board UI drives those channels through a callback, on the same
 #' footing as a front-end rather than built into the board server. Stacks
@@ -145,11 +155,11 @@ block_server <- function(id, x, data = list(), ...) {
 #' @param needed Reactive flag signaling whether the block is currently in the
 #' eval set (supplied by [board_server()]; defaults to always-needed when a
 #' block server is run standalone)
-#' @param visibility Front-end channel bundle -- a list with three channels,
-#' `required`, `visible` and `frozen`, each an environment of per-block
-#' `reactiveVal`s, supplied by [board_server()] to gate rendering and to
-#' freeze block inputs; `NULL` (the standalone default) leaves the block
-#' ungated
+#' @param visibility Front-end channel bundle -- a `gate` `reactiveVal` naming
+#' the front-end driving visibility, plus `visible` and `frozen`, each an
+#' environment of per-block `reactiveVal`s, supplied by [board_server()] to
+#' gate rendering and to freeze block inputs; `NULL` (the standalone default)
+#' leaves the block ungated
 #' @rdname block_server
 #' @export
 block_server.block <- function(id, x, data = list(), block_id = id,
@@ -711,7 +721,7 @@ render_gate_observer <- function(id, visibility, render_obs, sess) {
 
   observe(
     {
-      do_render <- !gating_active(visibility$required) ||
+      do_render <- !gating_active(visibility) ||
         block_visible(id, visibility)
 
       if (do_render) render_obs$resume() else render_obs$suspend()

--- a/R/board-server.R
+++ b/R/board-server.R
@@ -59,10 +59,13 @@
 #' drops a claimed block once it leaves the board, but an owner that goes away
 #' without releasing holds what it held for the rest of the session.
 #'
-#' Requests are orthogonal to the `required` visibility channel, so neither
-#' competes with the front-end's gating, and nothing about what is on screen
-#' changes. Because they carry no state change, they are also the one part of a
-#' payload a locked board still accepts.
+#' A claim asks for evaluation and nothing else: nothing about what is on
+#' screen changes. The front-end is an owner like any other -- it holds a claim
+#' under the label it declared as `visibility$gate()` (see [block_server()]) --
+#' so core never distinguishes its demand from anyone else's, and a consumer
+#' claiming a block cannot park what the front-end is showing. Because claims
+#' carry no state change, they are also the one part of a payload a locked
+#' board still accepts.
 #'
 #' Core drops a one-off request once the block has run — or has reported why it
 #' cannot, such as an unconnected data input or a user input that was never set.
@@ -83,8 +86,8 @@
 #' Nothing is retained. Once a block is built it stays built, so unlike the two
 #' evaluation components there is no owner to name and nothing to hand back, and
 #' asking for a block that is already built does nothing. The request joins
-#' neither the eval set nor the front-end's `required` channel, so it cannot
-#' turn a lazily evaluating board into an eagerly evaluating one.
+#' neither the eval set nor the gate declaration, so it cannot turn a lazily
+#' evaluating board into an eagerly evaluating one.
 #'
 #' A block that the same payload adds, or that an `evaluate` or `sustain` names,
 #' is already constructed — the add builds it directly, and evaluation demand
@@ -112,19 +115,20 @@ board_server <- function(id, x, ...) {
 #' @param options Board options (`NULL` defaults to the union of board, block
 #' and registry sourced options)
 #' @param callbacks Single (or list of) callback function(s) registering
-#' additional observers. Each receives a `visibility` list with three channels,
-#' `required`, `visible` and `frozen`, each an environment of per-block
-#' `reactiveVal`s (core keeps one per board block as blocks are added and
-#' removed). Declare a block needed with `visibility$required[[id]](TRUE)` (or
-#' `FALSE` for built but dormant) and report whether it is currently painted
-#' with `visibility$visible[[id]](TRUE)` (or `FALSE` once built but off screen,
-#' leaving `NA` until it is first built); the board reads both to gate
-#' construction, evaluation and rendering. Set
-#' `visibility$frozen[[id]](TRUE)` to freeze a block's inputs (for example when
-#' its controls are hidden), so a forged input can no longer steer it. A
-#' callback also receives the `update` channel (see [board_update]), through
-#' which it can request block evaluation or construction (see the Evaluation
-#' requests and Construction requests sections).
+#' additional observers. Each receives a `visibility` list carrying a board-wide
+#' `gate` `reactiveVal` alongside the per-block channels `visible` and `frozen`,
+#' environments of `reactiveVal`s (core keeps one per board block as blocks are
+#' added and removed). A front-end declares that it drives visibility by writing
+#' its owner label, `visibility$gate("dock")`; until something does, every block
+#' is needed. What it needs evaluated then travels as a `sustain` claim under
+#' that label through the `update` channel it also receives (see [board_update]
+#' and the Evaluation requests section), and what it needs merely built as a
+#' `construct` request. Report whether a block is currently painted with
+#' `visibility$visible[[id]](TRUE)` (or `FALSE` once built but off screen,
+#' leaving `NA` until it is first built); the board gates rendering on it, and
+#' holds background construction until every claimed block is reported painted.
+#' Set `visibility$frozen[[id]](TRUE)` to freeze a block's inputs (for example
+#' when its controls are hidden), so a forged input can no longer steer it.
 #'
 #' Core's own front-end drives these channels through a callback like any
 #' other: `gate_stacks()` reads the stack accordion (see [stack_ui()]) and is
@@ -178,7 +182,7 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
       rv$eval <- reactiveValues()
 
       vis <- list(
-        required = new.env(parent = emptyenv()),
+        gate = reactiveVal(NULL),
         visible = new.env(parent = emptyenv()),
         frozen = new.env(parent = emptyenv())
       )
@@ -210,19 +214,24 @@ board_server.board <- function(id, x, plugins = board_plugins(x),
       # components. Both join the needed set below; they differ in who lets go.
       # Core drops an `evaluating` entry once that block has had its evaluation
       # pass (see the observer below), while `claims` holds one entry per claim
-      # owner until that owner releases it.
+      # owner until that owner releases it. The front-end is one such owner.
       rv$evaluating <- reactiveVal(character())
       rv$claims <- reactiveVal(list())
 
+      # A gating front-end declares itself as it is set up but states its
+      # opening claim through a payload, which only applies at the end of that
+      # flush. Holding nothing and not having spoken yet are the same empty
+      # claim, so the difference is latched here: until it resolves, the
+      # background pass must not build a backlog that may be about to race the
+      # first paint.
+      rv$gate_claimed <- reactiveVal(FALSE)
+
       observe(
         {
-          cur <- if (!gating_active(vis$required)) {
+          cur <- if (!gating_active(vis)) {
             TRUE
           } else {
-            upstream_blocks(
-              union(required_now(vis$required), requested_blocks(rv)),
-              rv$board
-            )
+            upstream_blocks(requested_blocks(rv), rv$board)
           }
 
           old <- isolate(rv$needed())
@@ -669,7 +678,7 @@ construct_needed_blocks <- function(rv, mod_ed, mod_ct, args, vis) {
 
   observe(
     {
-      need <- needed_block_ids(rv, vis$required)
+      need <- needed_block_ids(rv)
       construct_blocks(need, rv, mod_ed, mod_ct, args, vis)
     }
   )
@@ -692,7 +701,7 @@ construct_blocks_in_background <- function(rv, mod_ed, mod_ct, args, vis) {
 
         started <<- TRUE
 
-        if (!isolate(gating_active(vis$required))) {
+        if (!isolate(gating_active(vis))) {
 
           construct_blocks(board_block_ids(rv$board), rv, mod_ed, mod_ct,
                            args, vis)
@@ -718,7 +727,7 @@ construct_blocks_in_background <- function(rv, mod_ed, mod_ct, args, vis) {
       }
 
       needed <- isolate(
-        intersect(remaining, needed_block_ids(rv, vis$required))
+        intersect(remaining, needed_block_ids(rv))
       )
 
       if (length(needed)) {
@@ -730,7 +739,7 @@ construct_blocks_in_background <- function(rv, mod_ed, mod_ct, args, vis) {
         return(invisible())
       }
 
-      if (gating_active(vis$required) && !required_fulfilled(vis)) {
+      if (gating_active(vis) && !gate_fulfilled(vis, rv)) {
         return(invisible())
       }
 
@@ -770,7 +779,6 @@ background_construction_delay <- function() {
 add_vis_slots <- function(vis, ids) {
 
   for (id in ids) {
-    vis$required[[id]] <- reactiveVal(NA)
     vis$visible[[id]] <- reactiveVal(NA)
     vis$frozen[[id]] <- reactiveVal(FALSE)
   }
@@ -780,10 +788,9 @@ add_vis_slots <- function(vis, ids) {
 
 rm_vis_slots <- function(vis, ids) {
 
-  gone <- intersect(ids, ls(vis$required))
+  gone <- intersect(ids, ls(vis$visible))
 
   if (length(gone)) {
-    rm(list = gone, envir = vis$required)
     rm(list = gone, envir = vis$visible)
     rm(list = gone, envir = vis$frozen)
   }
@@ -791,30 +798,8 @@ rm_vis_slots <- function(vis, ids) {
   invisible()
 }
 
-gating_active <- function(required) {
-  isTRUE(blockr_option("gate_visibility", TRUE)) && has_required(required)
-}
-
-has_required <- function(required) {
-  length(ever_required(required)) > 0L
-}
-
-ever_required <- function(required) {
-  ids <- ls(required)
-  ids[lgl_ply(ids, slot_declared, required)]
-}
-
-slot_declared <- function(id, required) {
-  !is.na(required[[id]]())
-}
-
-required_now <- function(required) {
-  ids <- ls(required)
-  ids[lgl_ply(ids, slot_needed, required)]
-}
-
-slot_needed <- function(id, required) {
-  isTRUE(required[[id]]())
+gating_active <- function(vis) {
+  isTRUE(blockr_option("gate_visibility", TRUE)) && not_null(vis$gate())
 }
 
 is_visible <- function(x) {
@@ -829,19 +814,21 @@ block_frozen <- function(id, vis) {
   isTRUE(vis$frozen[[id]]())
 }
 
-required_fulfilled <- function(vis) {
-  all(lgl_ply(required_now(vis$required), block_visible, vis))
+# Only the gating front-end's own claim is compared against paint: a claim held
+# by anyone else names blocks nobody is putting on screen, and holding the
+# backlog for one would stall it for the rest of the session.
+gate_fulfilled <- function(vis, rv) {
+  isTRUE(rv$gate_claimed()) &&
+    all(lgl_ply(rv$claims()[[vis$gate()]], block_visible, vis))
 }
 
 validate_vis <- function(vis) {
 
-  for (id in ls(vis$required)) {
-    if (!valid_required(vis$required[[id]]())) {
-      blockr_abort(
-        "required[[{id}]] must be TRUE, FALSE or NA",
-        class = "invalid_required"
-      )
-    }
+  if (!valid_gate(vis$gate())) {
+    blockr_abort(
+      "gate must be a string or NULL",
+      class = "invalid_gate"
+    )
   }
 
   for (id in ls(vis$visible)) {
@@ -865,8 +852,8 @@ validate_vis <- function(vis) {
   invisible()
 }
 
-valid_required <- function(x) {
-  is.logical(x) && length(x) == 1L
+valid_gate <- function(x) {
+  is.null(x) || (is_string(x) && !is.na(x) && nzchar(x))
 }
 
 valid_visible <- function(x) {
@@ -902,7 +889,7 @@ update_request_components <- function() {
   c(id_request_components(), "sustain")
 }
 
-needed_block_ids <- function(rv, required) {
+needed_block_ids <- function(rv) {
 
   need <- rv$needed()
 
@@ -910,7 +897,7 @@ needed_block_ids <- function(rv, required) {
     return(board_block_ids(rv$board))
   }
 
-  union(need, ever_required(required))
+  need
 }
 
 block_inputs_ready <- function(src_rv, blk, rv) {
@@ -2151,12 +2138,12 @@ apply_core_board_update <- function(rv, upd, session,
   construct_blocks(upd[["construct"]], rv, edit_block, ctrl_block,
                    edit_plugin_args, vis)
 
-  apply_eval_requests(rv, upd)
+  apply_eval_requests(rv, upd, vis)
 
   invisible()
 }
 
-apply_eval_requests <- function(rv, upd) {
+apply_eval_requests <- function(rv, upd, vis) {
 
   deltas <- upd[["sustain"]]
 
@@ -2171,6 +2158,10 @@ apply_eval_requests <- function(rv, upd) {
     }
 
     rv$claims(filter_empty(claims))
+
+    if (isTRUE(vis$gate() %in% names(deltas))) {
+      rv$gate_claimed(TRUE)
+    }
   }
 
   if (length(upd[["evaluate"]])) {

--- a/R/stack-gate.R
+++ b/R/stack-gate.R
@@ -2,15 +2,15 @@
 #' @export
 gate_stacks <- function() {
 
-  function(board, visibility, session = get_session(), ...) {
+  function(board, visibility, update, session = get_session(), ...) {
 
-    observe(show_open_stacks(board, visibility, session))
+    observe(show_open_stacks(board, visibility, update, session))
 
     NULL
   }
 }
 
-show_open_stacks <- function(board, vis, session) {
+show_open_stacks <- function(board, vis, update, session) {
 
   open <- session$input[["stacks"]]
 
@@ -22,18 +22,34 @@ show_open_stacks <- function(board, vis, session) {
   }
 
   brd <- board$board
+  owner <- stack_gate_owner(session)
 
   shown <- shown_block_ids(brd, open_stack_ids(open, brd, session))
 
-  # A collapsed stack's blocks are parked rather than dropped: `FALSE` keeps
-  # them built and ready to show again, where an `NA` slot would leave them
-  # unbuilt.
-  for (id in ls(vis$required)) {
-    vis$required[[id]](id %in% shown)
+  # Declared on the first report rather than as the callback is set up, for the
+  # same reason: a board that never reports must not end up gated on a claim
+  # this callback is not making.
+  vis$gate(owner)
+
+  # A collapsed stack's blocks are parked rather than dropped -- held out of the
+  # claim but still built, so re-expanding shows them without a rebuild. Core
+  # ignores a `construct` request naming a block it has already built.
+  update(
+    list(
+      sustain = set_names(list(list(set = shown)), owner),
+      construct = setdiff(board_block_ids(brd), shown)
+    )
+  )
+
+  for (id in ls(vis$visible)) {
     vis$visible[[id]](id %in% shown)
   }
 
   invisible()
+}
+
+stack_gate_owner <- function(session) {
+  session$ns("gate_stacks")
 }
 
 # The accordion input reads NULL both before it has bound and once the user has

--- a/inst/examples/board/code/app.R
+++ b/inst/examples/board/code/app.R
@@ -10,9 +10,10 @@ serve(
     )
   ),
   "my_board",
-  callbacks = function(board, visibility, ...) {
+  callbacks = function(board, visibility, update, ...) {
 
-    visibility$required[["a"]](TRUE)
+    visibility$gate("front-end")
+    update(list(sustain = list(`front-end` = list(set = "a"))))
     visibility$visible[["a"]](TRUE)
 
     shiny::exportTestValues(

--- a/man/block_server.Rd
+++ b/man/block_server.Rd
@@ -69,11 +69,11 @@ standalone)}
 eval set (supplied by \code{\link[=board_server]{board_server()}}; defaults to always-needed when a
 block server is run standalone)}
 
-\item{visibility}{Front-end channel bundle -- a list with three channels,
-\code{required}, \code{visible} and \code{frozen}, each an environment of per-block
-\code{reactiveVal}s, supplied by \code{\link[=board_server]{board_server()}} to gate rendering and to
-freeze block inputs; \code{NULL} (the standalone default) leaves the block
-ungated}
+\item{visibility}{Front-end channel bundle -- a \code{gate} \code{reactiveVal} naming
+the front-end driving visibility, plus \code{visible} and \code{frozen}, each an
+environment of per-block \code{reactiveVal}s, supplied by \code{\link[=board_server]{board_server()}} to
+gate rendering and to freeze block inputs; \code{NULL} (the standalone default)
+leaves the block ungated}
 }
 \value{
 Both \code{block_server()} and \code{expr_server()} return shiny server module
@@ -143,39 +143,49 @@ from output, the behavior of which can be customized via the
 \code{\link[=block_output]{block_output()}} generic. The \code{\link[=block_ui]{block_ui()}} generic can then be used to
 control rendering of outputs.
 
-A front-end (such as blockr.dock) drives per-block channels that
-\code{\link[=board_server]{board_server()}} hands to the board callback as \code{visibility}. Two of them
-gate what is built and shown: \code{required} (which blocks it needs built and
-evaluated) and \code{visible} (which blocks it has arranged on screen).
-Requirements are a cause the front-end -- and
-core-side features such as code export -- declare; visibility is the effect
-the front-end reports back once it has painted a block. Rendering is gated
-on \code{visible}: the render observer is suspended while a block carries no
-visible slot and resumed once the front-end writes a non-empty string for
-it, starting suspended so nothing renders before the first report.
-Evaluation is gated on the \emph{needed} set, the \code{required} blocks together with
-their upstream closure over \code{\link[=board_links]{board_links()}} (recomputed only when
-requirements or links change). A block's input data reactives stay
-unfulfilled (they \code{\link[shiny:req]{shiny::req()}} out) unless the block is needed, so a block
-that is neither required nor feeding a required block pulls no input and
-stays fully quiescent: its result reactive, and any observer its expression
-server registers on the incoming data, all short-circuit and do nothing. A
-needed but off-screen block (one feeding a required block) evaluates but
-does not render. Block-server \emph{construction} is prioritized the same way:
-the needed set is instantiated first so that first paint waits only for the
-required blocks and their upstreams, and the remaining block servers are
-built progressively in the background. That background pass holds until the
-front-end reports every required block as visible, so it never competes with
-first paint. A \code{required} slot of \code{FALSE} keeps a block built but dormant
-(ever required, not needed now); an absent slot leaves it unbuilt. Until a
+A front-end (such as blockr.dock) declares that it will drive visibility by
+writing an owner label into the \code{gate} channel of the \code{visibility} bundle
+that \code{\link[=board_server]{board_server()}} hands to the board callback. That declaration, and
+nothing else, is what flips the board from evaluating everything to
+evaluating only what is needed; with no front-end every block is needed and
+behaviour is unchanged, and the \code{gate_visibility} \code{\link[=blockr_option]{blockr_option()}} (default
+\code{TRUE}) turns gating off entirely. It is written synchronously, while the
+callback is set up, because it has to be in hand before the first flush
+decides what to construct.
+
+Which blocks the front-end needs evaluated is not a channel of its own: it
+is a \code{sustain} claim held under that same owner label, leaving the front-end
+one owner among several rather than a special case core can distinguish from
+a code export or an extension (see the Evaluation requests section of
+\code{\link[=board_server]{board_server()}}). Blocks it wants built without being evaluated -- a card
+it has created off screen, say -- are a \code{construct} request.
+
+Evaluation is gated on the \emph{needed} set, the claimed blocks together with
+their upstream closure over \code{\link[=board_links]{board_links()}} (recomputed only when claims or
+links change). A block's input data reactives stay unfulfilled (they
+\code{\link[shiny:req]{shiny::req()}} out) unless the block is needed, so a block that is neither
+claimed nor feeding a claimed block pulls no input and stays fully
+quiescent: its result reactive, and any observer its expression server
+registers on the incoming data, all short-circuit and do nothing. A needed
+but off-screen block (one feeding a claimed block) evaluates but does not
+render.
+
+Rendering is gated on \code{visible}, the per-block channel through which the
+front-end reports what it has painted -- the effect, where a claim is the
+cause. The render observer is suspended while a block carries no visible
+slot and resumed once the front-end reports it painted, starting suspended
+so nothing renders before the first report.
+
+Block-server \emph{construction} is prioritized the same way: the needed set is
+instantiated first so that first paint waits only for the claimed blocks and
+their upstreams, and the remaining block servers are built progressively in
+the background. That background pass holds until the front-end reports every
+block it claims as visible, so it never competes with first paint. Until a
 block is built it is absent from the \code{board$blocks} handed to plugins and
 callbacks, which simply see it appear once constructed. The background
 cadence is set by the \code{background_construction_delay} \code{\link[=blockr_option]{blockr_option()}}
 (milliseconds between successive blocks, default 50); a value of 0 disables
-the staggering and builds every block up front. With nothing writing
-\code{required} every block is needed and behaviour is unchanged; the
-\code{gate_visibility} \code{\link[=blockr_option]{blockr_option()}} (default \code{TRUE}) turns gating off
-entirely.
+the staggering and builds every block up front.
 
 Core's own board UI drives those channels through a callback, on the same
 footing as a front-end rather than built into the board server. Stacks

--- a/man/board_server.Rd
+++ b/man/board_server.Rd
@@ -33,6 +33,7 @@ gate_stacks()
 and registry sourced options)}
 
 \item{callbacks}{Single (or list of) callback function(s) registering
+<<<<<<< HEAD
 additional observers. Each receives a \code{visibility} list with three channels,
 \code{required}, \code{visible} and \code{frozen}, each an environment of per-block
 \code{reactiveVal}s (core keeps one per board block as blocks are added and
@@ -54,6 +55,23 @@ that does not is left alone -- it passes its own callbacks, and the
 accordion input the callback waits on is never bound. A consumer that wants
 both keeps it in the list rather than replacing it --
 \code{callbacks = list(gate_stacks(), my_callback)}.}
+=======
+additional observers. Each receives a \code{visibility} list carrying a board-wide
+\code{gate} \code{reactiveVal} alongside the per-block channels \code{visible} and \code{frozen},
+environments of \code{reactiveVal}s (core keeps one per board block as blocks are
+added and removed). A front-end declares that it drives visibility by writing
+its owner label, \code{visibility$gate("dock")}, as it is set up; until something
+does, every block is needed. What it needs evaluated then travels as a
+\code{sustain} claim under that label through the \code{update} channel it also
+receives (see \link{board_update} and the Evaluation requests section), and what
+it needs merely built as a \code{construct} request. Report whether a block is
+currently painted with \code{visibility$visible[[id]](TRUE)} (or \code{FALSE} once
+built but off screen, leaving \code{NA} until it is first built); the board gates
+rendering on it, and holds background construction until every claimed block
+is reported painted. Set \code{visibility$frozen[[id]](TRUE)} to freeze a block's
+inputs (for example when its controls are hidden), so a forged input can no
+longer steer it.}
+>>>>>>> 780518d (Fold front-end demand into the one multi-owner claim set)
 
 \item{callback_location}{Location of callback invocation (before or after
 plugins)}
@@ -124,10 +142,13 @@ claims under two labels. A claim outlives the module that made it: core
 drops a claimed block once it leaves the board, but an owner that goes away
 without releasing holds what it held for the rest of the session.
 
-Requests are orthogonal to the \code{required} visibility channel, so neither
-competes with the front-end's gating, and nothing about what is on screen
-changes. Because they carry no state change, they are also the one part of a
-payload a locked board still accepts.
+A claim asks for evaluation and nothing else: nothing about what is on
+screen changes. The front-end is an owner like any other -- it holds a claim
+under the label it declared as \code{visibility$gate()} (see \code{\link[=block_server]{block_server()}}) --
+so core never distinguishes its demand from anyone else's, and a consumer
+claiming a block cannot park what the front-end is showing. Because claims
+carry no state change, they are also the one part of a payload a locked
+board still accepts.
 
 Core drops a one-off request once the block has run — or has reported why it
 cannot, such as an unconnected data input or a user input that was never set.
@@ -149,8 +170,8 @@ dependency order and left \code{dormant}:
 Nothing is retained. Once a block is built it stays built, so unlike the two
 evaluation components there is no owner to name and nothing to hand back, and
 asking for a block that is already built does nothing. The request joins
-neither the eval set nor the front-end's \code{required} channel, so it cannot
-turn a lazily evaluating board into an eagerly evaluating one.
+neither the eval set nor the gate declaration, so it cannot turn a lazily
+evaluating board into an eagerly evaluating one.
 
 A block that the same payload adds, or that an \code{evaluate} or \code{sustain} names,
 is already constructed — the add builds it directly, and evaluation demand

--- a/man/board_server.Rd
+++ b/man/board_server.Rd
@@ -33,20 +33,20 @@ gate_stacks()
 and registry sourced options)}
 
 \item{callbacks}{Single (or list of) callback function(s) registering
-<<<<<<< HEAD
-additional observers. Each receives a \code{visibility} list with three channels,
-\code{required}, \code{visible} and \code{frozen}, each an environment of per-block
-\code{reactiveVal}s (core keeps one per board block as blocks are added and
-removed). Declare a block needed with \code{visibility$required[[id]](TRUE)} (or
-\code{FALSE} for built but dormant) and report whether it is currently painted
-with \code{visibility$visible[[id]](TRUE)} (or \code{FALSE} once built but off screen,
-leaving \code{NA} until it is first built); the board reads both to gate
-construction, evaluation and rendering. Set
-\code{visibility$frozen[[id]](TRUE)} to freeze a block's inputs (for example when
-its controls are hidden), so a forged input can no longer steer it. A
-callback also receives the \code{update} channel (see \link{board_update}), through
-which it can request block evaluation or construction (see the Evaluation
-requests and Construction requests sections).
+additional observers. Each receives a \code{visibility} list carrying a board-wide
+\code{gate} \code{reactiveVal} alongside the per-block channels \code{visible} and \code{frozen},
+environments of \code{reactiveVal}s (core keeps one per board block as blocks are
+added and removed). A front-end declares that it drives visibility by writing
+its owner label, \code{visibility$gate("dock")}; until something does, every block
+is needed. What it needs evaluated then travels as a \code{sustain} claim under
+that label through the \code{update} channel it also receives (see \link{board_update}
+and the Evaluation requests section), and what it needs merely built as a
+\code{construct} request. Report whether a block is currently painted with
+\code{visibility$visible[[id]](TRUE)} (or \code{FALSE} once built but off screen,
+leaving \code{NA} until it is first built); the board gates rendering on it, and
+holds background construction until every claimed block is reported painted.
+Set \code{visibility$frozen[[id]](TRUE)} to freeze a block's inputs (for example
+when its controls are hidden), so a forged input can no longer steer it.
 
 Core's own front-end drives these channels through a callback like any
 other: \code{gate_stacks()} reads the stack accordion (see \code{\link[=stack_ui]{stack_ui()}}) and is
@@ -55,23 +55,6 @@ that does not is left alone -- it passes its own callbacks, and the
 accordion input the callback waits on is never bound. A consumer that wants
 both keeps it in the list rather than replacing it --
 \code{callbacks = list(gate_stacks(), my_callback)}.}
-=======
-additional observers. Each receives a \code{visibility} list carrying a board-wide
-\code{gate} \code{reactiveVal} alongside the per-block channels \code{visible} and \code{frozen},
-environments of \code{reactiveVal}s (core keeps one per board block as blocks are
-added and removed). A front-end declares that it drives visibility by writing
-its owner label, \code{visibility$gate("dock")}, as it is set up; until something
-does, every block is needed. What it needs evaluated then travels as a
-\code{sustain} claim under that label through the \code{update} channel it also
-receives (see \link{board_update} and the Evaluation requests section), and what
-it needs merely built as a \code{construct} request. Report whether a block is
-currently painted with \code{visibility$visible[[id]](TRUE)} (or \code{FALSE} once
-built but off screen, leaving \code{NA} until it is first built); the board gates
-rendering on it, and holds background construction until every claimed block
-is reported painted. Set \code{visibility$frozen[[id]](TRUE)} to freeze a block's
-inputs (for example when its controls are hidden), so a forged input can no
-longer steer it.}
->>>>>>> 780518d (Fold front-end demand into the one multi-owner claim set)
 
 \item{callback_location}{Location of callback invocation (before or after
 plugins)}

--- a/tests/testthat/test-input-freeze.R
+++ b/tests/testthat/test-input-freeze.R
@@ -1,7 +1,7 @@
 make_vis <- function(ids, frozen = character()) {
 
   vis <- list(
-    required = new.env(parent = emptyenv()),
+    gate = reactiveVal(NULL),
     visible = new.env(parent = emptyenv()),
     frozen = new.env(parent = emptyenv())
   )

--- a/tests/testthat/test-plugin-code.R
+++ b/tests/testthat/test-plugin-code.R
@@ -158,9 +158,11 @@ test_that("show code builds the board without evaluating or gating it", {
   testServer(
     get_s3_method("board_server", board),
     {
-      vis$required[["a"]](TRUE)
+      vis$gate("front-end")
+      board_update(
+        list(sustain = list(`front-end` = list(set = "a")), construct = "b")
+      )
       vis$visible[["a"]](TRUE)
-      vis$required[["b"]](FALSE)
       session$flushReact()
 
       expect_identical(reval_if(rv$eval[["b"]]), "dormant")
@@ -175,17 +177,17 @@ test_that("show code builds the board without evaluating or gating it", {
       expect_identical(reval_if(rv$eval[["c"]]), "dormant")
       expect_identical(reval_if(rv$eval[["b"]]), "dormant")
 
-      # Neither the front-end's gating channel nor the claim set is touched
-      expect_false(vis$required[["b"]]())
-      expect_true(is.na(vis$required[["c"]]()))
-      expect_length(rv$claims(), 0L)
+      # The front-end's claim is left exactly as it was, and the export adds
+      # none of its own
+      expect_identical(rv$claims(), list(`front-end` = "a"))
 
       session$setInputs(`generate_code-code_eval` = 1)
       session$flushReact()
 
-      # The one-off runs them and hands them back, leaving nothing held
+      # The one-off runs them and hands them back, leaving nothing held beyond
+      # the front-end's own claim
       expect_length(rv$evaluating(), 0L)
-      expect_length(rv$claims(), 0L)
+      expect_identical(rv$claims(), list(`front-end` = "a"))
       expect_identical(reval_if(rv$eval[["c"]]), "dormant")
     },
     args = list(x = board, plugins = board_plugins(board, "generate_code"))
@@ -212,10 +214,15 @@ test_that("show code requires the whole board, gating export on config", {
     testServer(
       get_s3_method("board_server", board),
       {
+        vis$gate("front-end")
+        board_update(
+          list(sustain = list(`front-end` = list(set = c("a", "b"))))
+        )
+
         for (id in c("a", "b")) {
-          vis$required[[id]](TRUE)
           vis$visible[[id]](TRUE)
         }
+
         session$flushReact()
 
         read_only <- function() {

--- a/tests/testthat/test-visibility-gating.R
+++ b/tests/testthat/test-visibility-gating.R
@@ -2153,6 +2153,12 @@ stacked_board <- function() {
 
 # Mirrors what bslib's accordion input reports: the panel values of the open
 # stacks, and NULL rather than an empty vector once none are open.
+# What core's own stack-gating callback holds: a claim like any other owner's,
+# under the label gate_stacks() takes from the board session.
+stack_claim <- function(rv, session) {
+  rv$claims()[[stack_gate_owner(session)]]
+}
+
 report_open_stacks <- function(session, ...) {
 
   ids <- c(...)
@@ -2177,13 +2183,13 @@ test_that("core requires the open stacks and every unstacked block", {
 
       # Nothing is gated until the accordion reports which stacks it rendered
       # open, so a board that renders a different UI is left alone entirely.
-      expect_false(gating_active(vis$required))
+      expect_false(gating_active(vis))
       expect_true(rv$needed())
 
       report_open_stacks(session, "s1")
       session$flushReact()
 
-      expect_setequal(required_now(vis$required), c("a", "b", "e"))
+      expect_setequal(stack_claim(rv, session), c("a", "b", "e"))
       expect_setequal(rv$needed(), c("a", "b", "e"))
 
       expect_true(block_visible("b", vis))
@@ -2225,7 +2231,7 @@ test_that("expanding a stack requires its blocks and collapsing parks them", {
       session$flushReact()
 
       expect_setequal(
-        required_now(vis$required),
+        stack_claim(rv, session),
         c("a", "b", "c", "d", "e")
       )
 
@@ -2235,12 +2241,12 @@ test_that("expanding a stack requires its blocks and collapsing parks them", {
       report_open_stacks(session, "s2")
       session$flushReact()
 
-      expect_setequal(required_now(vis$required), c("c", "d", "e"))
+      expect_setequal(stack_claim(rv, session), c("c", "d", "e"))
       expect_setequal(rv$needed(), c("c", "d", "e"))
 
       # Parked rather than dropped: still built, so re-expanding shows them
       # without a rebuild.
-      expect_setequal(ever_required(vis$required), board_block_ids(rv$board))
+      expect_setequal(names(rv$blocks), board_block_ids(rv$board))
       expect_true(constructed("a"))
 
       expect_false(block_visible("a", vis))
@@ -2265,12 +2271,12 @@ test_that("a fully collapsed accordion is not read as one yet to report", {
 
       # Both states read as a NULL input: the accordion yet to report, and the
       # user having collapsed everything.
-      expect_false(gating_active(vis$required))
+      expect_false(gating_active(vis))
 
       report_open_stacks(session)
       session$flushReact()
 
-      expect_setequal(required_now(vis$required), "e")
+      expect_setequal(stack_claim(rv, session), "e")
       expect_setequal(rv$needed(), "e")
     },
     args = list(x = board, plugins = list())
@@ -2299,7 +2305,7 @@ test_that("a board without stacks requires every block", {
       report_open_stacks(session)
       session$flushReact()
 
-      expect_setequal(required_now(vis$required), c("a", "b"))
+      expect_setequal(stack_claim(rv, session), c("a", "b"))
 
       expect_true(evaluated("b"))
       expect_true(rendered("b"))
@@ -2327,7 +2333,7 @@ test_that("the gate_visibility option disables stack gating", {
       report_open_stacks(session, "s1")
       session$flushReact()
 
-      expect_false(gating_active(vis$required))
+      expect_false(gating_active(vis))
       expect_true(rv$needed())
 
       for (id in c("a", "b", "c", "d", "e")) {
@@ -2405,7 +2411,7 @@ test_that("a front-end's own callbacks displace core's stack tracking", {
 
       # The board renders stacks and the option is on, yet core tracks nothing:
       # what gates is whatever the supplied callbacks do.
-      expect_false(gating_active(vis$required))
+      expect_false(gating_active(vis))
       expect_true(rv$needed())
 
       for (id in c("a", "b", "c", "d", "e")) {

--- a/tests/testthat/test-visibility-gating.R
+++ b/tests/testthat/test-visibility-gating.R
@@ -191,11 +191,32 @@ constructed <- function(id) {
   id %in% probe_construct$ids
 }
 
-require_blocks <- function(vis, ...) {
+# The front-end under test: it declares itself the gating owner and states its
+# demand as a `sustain` claim under that label, exactly as any other consumer
+# would. Each helper writes the payload channel once, since a second write
+# before the next flush would clobber the first.
+front_end <- "front-end"
 
-  for (id in c(...)) {
-    vis$required[[id]](TRUE)
-  }
+claim <- function(...) {
+  set_names(list(list(...)), front_end)
+}
+
+gate_blocks <- function(vis, update, ...) {
+
+  vis$gate(front_end)
+  require_blocks(update, ...)
+}
+
+require_blocks <- function(update, ...) {
+
+  update(list(sustain = claim(add = c(...))))
+
+  invisible()
+}
+
+release_blocks <- function(update, ...) {
+
+  update(list(sustain = claim(rm = c(...))))
 
   invisible()
 }
@@ -209,14 +230,26 @@ render_blocks <- function(vis, ...) {
   invisible()
 }
 
-park_blocks <- function(vis, ...) {
+park_blocks <- function(update, vis, ...) {
+
+  release_blocks(update, ...)
 
   for (id in c(...)) {
-    vis$required[[id]](FALSE)
     vis$visible[[id]](FALSE)
   }
 
   invisible()
+}
+
+claimed <- function(rv) {
+  rv$claims()[[front_end]]
+}
+
+# The front-end holds a claim like any other owner, so a test about what
+# consumers hold reads past its entry rather than the whole set.
+consumer_claims <- function(rv) {
+  claims <- rv$claims()
+  claims[setdiff(names(claims), front_end)]
 }
 
 block_conditions <- function(rv, id, severity) {
@@ -278,7 +311,7 @@ test_that("a producer gates evaluation and rendering on visibility", {
     {
       session$flushReact()
 
-      expect_setequal(required_now(vis$required), "b")
+      expect_setequal(claimed(rv), "b")
 
       expect_true(evaluated("b"))
       expect_true(rendered("b"))
@@ -292,7 +325,7 @@ test_that("a producer gates evaluation and rendering on visibility", {
       expect_false(evaluated("d"))
       expect_false(rendered("d"))
 
-      require_blocks(vis, "c", "d")
+      require_blocks(board_update, "c", "d")
       render_blocks(vis, "c", "d")
       session$flushReact()
 
@@ -305,8 +338,8 @@ test_that("a producer gates evaluation and rendering on visibility", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visibility, ...) {
-        require_blocks(visibility, "b")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "b")
         render_blocks(visibility, "b")
       }
     )
@@ -344,8 +377,8 @@ test_that("the gate_visibility option disables gating", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visibility, ...) {
-        require_blocks(visibility, "b")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "b")
         render_blocks(visibility, "b")
       }
     )
@@ -395,8 +428,8 @@ test_that("a link change re-routes the pulled upstream", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visibility, ...) {
-        require_blocks(visibility, "b")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "b")
         render_blocks(visibility, "b")
       }
     )
@@ -408,8 +441,6 @@ test_that("a needed round trip with unchanged inputs does not re-evaluate", {
   reset_probes()
 
   withr::local_options(blockr.background_construction_delay = 0)
-
-  vis_env <- NULL
 
   board <- new_board(
     blocks = c(
@@ -431,13 +462,13 @@ test_that("a needed round trip with unchanged inputs does not re-evaluate", {
 
       # Park the chain, as a view switch whose visibility updates land across
       # several flushes does: b goes un-needed, taking a with it ...
-      vis_env$required[["b"]](FALSE)
+      release_blocks(board_update, "b")
       session$flushReact()
 
       # ... and comes back. Nothing upstream changed, so nothing re-evaluates:
       # the unchanged-inputs guard returns the cached results instead of
       # re-running the block expressions.
-      vis_env$required[["b"]](TRUE)
+      require_blocks(board_update, "b")
       session$flushReact()
 
       expect_false(evaluated("a"))
@@ -446,9 +477,8 @@ test_that("a needed round trip with unchanged inputs does not re-evaluate", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visibility, ...) {
-        vis_env <<- visibility
-        require_blocks(visibility, "b")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "b")
         render_blocks(visibility, "b")
       }
     )
@@ -485,7 +515,7 @@ test_that("a dormant block reports stale when an upstream re-evaluates", {
 
       # Park r off-screen: it drops out of the eval set and goes dormant, while
       # a stays required (its panel is still open).
-      vis$required[["r"]](FALSE)
+      release_blocks(board_update, "r")
       session$flushReact()
 
       expect_identical(rv$eval[["r"]](), "dormant")
@@ -513,8 +543,8 @@ test_that("a dormant block reports stale when an upstream re-evaluates", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visibility, ...) {
-        require_blocks(visibility, "a", "r")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "a", "r")
         render_blocks(visibility, "a", "r")
       }
     )
@@ -549,8 +579,7 @@ test_that("a dormant block whose upstreams are unchanged stays dormant", {
       # Park the whole chain, as a view switch does: r and its upstream a both
       # go dormant. a's last result survives dormancy, so r's cached input still
       # matches and r is not stale.
-      vis$required[["a"]](FALSE)
-      vis$required[["r"]](FALSE)
+      release_blocks(board_update, "a", "r")
       session$flushReact()
 
       expect_identical(rv$eval[["a"]](), "dormant")
@@ -559,8 +588,8 @@ test_that("a dormant block whose upstreams are unchanged stays dormant", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visibility, ...) {
-        require_blocks(visibility, "a", "r")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "a", "r")
         render_blocks(visibility, "a", "r")
       }
     )
@@ -596,8 +625,7 @@ test_that("staleness propagates to the whole dormant downstream cone", {
       expect_identical(rv$eval[["r"]](), "ready")
 
       # Park b and r off-screen; a stays required so it re-evaluates below.
-      vis$required[["b"]](FALSE)
-      vis$required[["r"]](FALSE)
+      release_blocks(board_update, "b", "r")
       session$flushReact()
 
       expect_identical(rv$eval[["b"]](), "dormant")
@@ -622,8 +650,8 @@ test_that("staleness propagates to the whole dormant downstream cone", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visibility, ...) {
-        require_blocks(visibility, "a", "b", "r")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "a", "b", "r")
         render_blocks(visibility, "a", "b", "r")
       }
     )
@@ -653,7 +681,7 @@ test_that("re-routing a dormant block's input marks it stale", {
       expect_identical(rv$eval[["r"]](), "ready")
 
       # Park r; a and b stay required (both ready).
-      vis$required[["r"]](FALSE)
+      release_blocks(board_update, "r")
       session$flushReact()
 
       expect_identical(rv$eval[["r"]](), "dormant")
@@ -675,8 +703,8 @@ test_that("re-routing a dormant block's input marks it stale", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visibility, ...) {
-        require_blocks(visibility, "a", "b", "r")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "a", "b", "r")
         render_blocks(visibility, "a", "b", "r")
       }
     )
@@ -703,7 +731,7 @@ test_that("a stale block that re-evaluates is dormant when parked again", {
     {
       session$flushReact()
 
-      vis$required[["r"]](FALSE)
+      release_blocks(board_update, "r")
       session$flushReact()
 
       board_update(
@@ -719,12 +747,12 @@ test_that("a stale block that re-evaluates is dormant when parked again", {
       # again, so parking it a second time leaves it dormant. Neither b's result
       # nor its status changed in between, so the verdict has to be recomputed
       # off r's own last evaluation.
-      require_blocks(vis, "r")
+      require_blocks(board_update, "r")
       session$flushReact()
 
       expect_identical(rv$eval[["r"]](), "ready")
 
-      vis$required[["r"]](FALSE)
+      release_blocks(board_update, "r")
       session$flushReact()
 
       expect_identical(rv$eval[["r"]](), "dormant")
@@ -732,8 +760,8 @@ test_that("a stale block that re-evaluates is dormant when parked again", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visibility, ...) {
-        require_blocks(visibility, "a", "b", "r")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "a", "b", "r")
         render_blocks(visibility, "a", "b", "r")
       }
     )
@@ -770,7 +798,7 @@ test_that("an evaluation request brings a stale block current", {
 
       # Park the whole a -> r chain off screen, then re-route a to a different
       # dataset: neither re-evaluates, both report the break as stale.
-      park_blocks(vis, "a", "r")
+      park_blocks(board_update, vis, "a", "r")
       session$flushReact()
 
       board_update(
@@ -802,7 +830,7 @@ test_that("an evaluation request brings a stale block current", {
       # The request is spent, and nothing about what is on screen changed.
       expect_length(rv$evaluating(), 0L)
 
-      expect_false(vis$required[["r"]]())
+      expect_false("r" %in% claimed(rv))
       expect_false(vis$visible[["r"]]())
       expect_false(rendered("r"))
     },
@@ -811,7 +839,7 @@ test_that("an evaluation request brings a stale block current", {
       plugins = list(),
       callbacks = function(visibility, update, ...) {
         upd_channel <<- update
-        require_blocks(visibility, "s1", "s2", "a", "r")
+        gate_blocks(visibility, update, "s1", "s2", "a", "r")
         render_blocks(visibility, "s1", "s2", "a", "r")
       }
     )
@@ -848,7 +876,7 @@ test_that("an evaluation request evaluates a block edited while dormant", {
       expect_identical(rv$eval[["r"]](), "ready")
       expect_equal(nrow(block_conditions(rv, "r", "error")), 0L)
 
-      park_blocks(vis, "r")
+      park_blocks(board_update, vis, "r")
       session$flushReact()
 
       expect_identical(rv$eval[["r"]](), "dormant")
@@ -879,8 +907,8 @@ test_that("an evaluation request evaluates a block edited while dormant", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visibility, ...) {
-        require_blocks(visibility, "s", "r")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "s", "r")
         render_blocks(visibility, "s", "r")
       }
     )
@@ -900,7 +928,7 @@ test_that("an edit and a request in one payload evaluate the edit", {
     {
       session$flushReact()
 
-      park_blocks(vis, "r")
+      park_blocks(board_update, vis, "r")
       session$flushReact()
 
       reset_probes()
@@ -923,8 +951,8 @@ test_that("an edit and a request in one payload evaluate the edit", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visibility, ...) {
-        require_blocks(visibility, "s", "r")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "s", "r")
         render_blocks(visibility, "s", "r")
       }
     )
@@ -973,8 +1001,8 @@ test_that("an evaluation request builds the blocks it needs", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visibility, ...) {
-        require_blocks(visibility, "s")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "s")
         render_blocks(visibility, "s")
       }
     )
@@ -1000,7 +1028,7 @@ test_that("a required claim holds a block until it is released", {
     {
       session$flushReact()
 
-      park_blocks(vis, "r")
+      park_blocks(board_update, vis, "r")
       session$flushReact()
 
       expect_identical(rv$eval[["r"]](), "dormant")
@@ -1016,7 +1044,7 @@ test_that("a required claim holds a block until it is released", {
       for (i in 1:3) session$flushReact()
 
       expect_identical(rv$eval[["r"]](), "ready")
-      expect_identical(rv$claims(), list(consumer = "r"))
+      expect_identical(consumer_claims(rv), list(consumer = "r"))
 
       # Releasing it hands the block back to the front-end's gating, which
       # parked it.
@@ -1024,14 +1052,14 @@ test_that("a required claim holds a block until it is released", {
       session$flushReact()
 
       expect_identical(rv$eval[["r"]](), "dormant")
-      expect_length(rv$claims(), 0L)
+      expect_length(consumer_claims(rv), 0L)
       expect_false(rendered("r"))
     },
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visibility, ...) {
-        require_blocks(visibility, "s", "r")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "s", "r")
         render_blocks(visibility, "s", "r")
       }
     )
@@ -1057,7 +1085,7 @@ test_that("one owner's release leaves another owner's claim standing", {
     {
       session$flushReact()
 
-      park_blocks(vis, "r")
+      park_blocks(board_update, vis, "r")
       session$flushReact()
 
       expect_identical(rv$eval[["r"]](), "dormant")
@@ -1068,7 +1096,7 @@ test_that("one owner's release leaves another owner's claim standing", {
       board_update(list(sustain = list(two = list(add = "r"))))
       session$flushReact()
 
-      expect_identical(rv$claims(), list(one = "r", two = "r"))
+      expect_identical(consumer_claims(rv), list(one = "r", two = "r"))
       expect_identical(rv$eval[["r"]](), "ready")
 
       # The block is held by two owners, so the first letting go does not
@@ -1076,7 +1104,7 @@ test_that("one owner's release leaves another owner's claim standing", {
       board_update(list(sustain = list(one = list(set = character()))))
       session$flushReact()
 
-      expect_identical(rv$claims(), list(two = "r"))
+      expect_identical(consumer_claims(rv), list(two = "r"))
       expect_identical(rv$eval[["r"]](), "ready")
 
       # Releasing the last block an owner holds drops the owner, whether it
@@ -1084,15 +1112,100 @@ test_that("one owner's release leaves another owner's claim standing", {
       board_update(list(sustain = list(two = list(rm = "r"))))
       session$flushReact()
 
-      expect_length(rv$claims(), 0L)
+      expect_length(consumer_claims(rv), 0L)
       expect_identical(rv$eval[["r"]](), "dormant")
     },
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visibility, ...) {
-        require_blocks(visibility, "s", "r")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "s", "r")
         render_blocks(visibility, "s", "r")
+      }
+    )
+  )
+})
+
+test_that("a consumer claim does not gate an ungated board", {
+
+  reset_probes()
+
+  withr::local_options(blockr.background_construction_delay = 0)
+
+  board <- new_board(
+    blocks = c(
+      s = with_id(probe_source(), "s"),
+      a = with_id(probe_passthrough(), "a"),
+      b = with_id(probe_passthrough(), "b")
+    ),
+    links = links(
+      sa = new_link("s", "a", "data"),
+      sb = new_link("s", "b", "data")
+    )
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      board_update(list(sustain = list(consumer = list(set = "a"))))
+      session$flushReact()
+
+      # Nothing declared a gate, so a claim is a no-op: it says what one
+      # consumer wants evaluated, never that everything else may be parked.
+      # Inferring the gate from claims instead would leave b -- which nobody
+      # asked for -- dormant and blank on a board that has no front-end.
+      expect_true(rv$needed())
+      expect_identical(rv$eval[["b"]](), "ready")
+      expect_true(rendered("b"))
+    },
+    args = list(x = board, plugins = list())
+  )
+})
+
+test_that("a consumer cannot release what the front-end holds", {
+
+  reset_probes()
+
+  withr::local_options(blockr.background_construction_delay = 0)
+
+  board <- new_board(
+    blocks = c(
+      s = with_id(probe_source(), "s"),
+      r = with_id(probe_passthrough(), "r")
+    ),
+    links = links(sr = new_link("s", "r", "data"))
+  )
+
+  testServer(
+    get_s3_method("board_server", board),
+    {
+      session$flushReact()
+
+      expect_identical(claimed(rv), "r")
+
+      # A consumer holds the block the front-end is showing and then lets go.
+      # Sharing one channel, its write landed on the front-end's own state and
+      # its release took the front-end's demand with it; as one owner among
+      # several it can do neither.
+      board_update(list(sustain = list(consumer = list(set = "r"))))
+      session$flushReact()
+
+      board_update(list(sustain = list(consumer = list(set = character()))))
+      session$flushReact()
+
+      expect_identical(claimed(rv), "r")
+      expect_length(consumer_claims(rv), 0L)
+      expect_setequal(rv$needed(), c("s", "r"))
+      expect_identical(rv$eval[["r"]](), "ready")
+    },
+    args = list(
+      x = board,
+      plugins = list(),
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "r")
+        render_blocks(visibility, "r")
       }
     )
   )
@@ -1132,7 +1245,7 @@ test_that("removing a claimed block prunes it from every owner", {
 
       # An owner left holding nothing is dropped, so a stale claim cannot
       # outlive the block it named.
-      expect_identical(rv$claims(), list(one = "s"))
+      expect_identical(consumer_claims(rv), list(one = "s"))
       expect_setequal(rv$needed(), "s")
 
       # The owner that lost its block still releases cleanly: `rm` names a
@@ -1141,13 +1254,13 @@ test_that("removing a claimed block prunes it from every owner", {
       session$flushReact()
 
       expect_true(rv$last_update$ok)
-      expect_identical(rv$claims(), list(one = "s"))
+      expect_identical(consumer_claims(rv), list(one = "s"))
     },
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visibility, ...) {
-        require_blocks(visibility, "s")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "s")
         render_blocks(visibility, "s")
       }
     )
@@ -1187,8 +1300,8 @@ test_that("a request for a block added in the same payload is honoured", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visibility, ...) {
-        require_blocks(visibility, "s")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "s")
         render_blocks(visibility, "s")
       }
     )
@@ -1233,15 +1346,15 @@ test_that("a construction request builds a block without evaluating it", {
       expect_setequal(rv$needed(), "s")
       expect_identical(probe_construct$ids, c("s", "r"))
 
-      # Nor does the request touch the channel the front-end owns, which is what
-      # keeps it from flipping an ungated board into gated mode.
-      expect_true(is.na(vis$required[["r"]]()))
+      # Nor does the request join the claim the front-end holds, which is what
+      # keeps it from parking what is on screen.
+      expect_identical(claimed(rv), "s")
     },
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visibility, ...) {
-        require_blocks(visibility, "s")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "s")
         render_blocks(visibility, "s")
       }
     )
@@ -1279,7 +1392,7 @@ test_that("overlapping requests union rather than clash", {
       expect_true(rv$last_update$ok)
       expect_true(constructed("r"))
       expect_identical(rv$eval[["r"]](), "ready")
-      expect_identical(rv$claims(), list(one = "r"))
+      expect_identical(consumer_claims(rv), list(one = "r"))
       expect_length(rv$evaluating(), 0L)
 
       # A second consumer cannot know what the first holds, so a one-off over
@@ -1288,13 +1401,13 @@ test_that("overlapping requests union rather than clash", {
       session$flushReact()
 
       expect_true(rv$last_update$ok)
-      expect_identical(rv$claims(), list(one = "r"))
+      expect_identical(consumer_claims(rv), list(one = "r"))
     },
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visibility, ...) {
-        require_blocks(visibility, "s")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "s")
         render_blocks(visibility, "s")
       }
     )
@@ -1334,22 +1447,22 @@ test_that("a request naming an unknown block is rejected", {
       session$flushReact()
 
       expect_false(rv$last_update$ok)
-      expect_length(rv$claims(), 0L)
+      expect_length(consumer_claims(rv), 0L)
 
       # A claim with no owner to release it is refused as well.
       board_update(list(sustain = list(list(set = "a"))))
       session$flushReact()
 
       expect_false(rv$last_update$ok)
-      expect_length(rv$claims(), 0L)
+      expect_length(consumer_claims(rv), 0L)
 
       expect_setequal(rv$needed(), "a")
     },
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visibility, ...) {
-        require_blocks(visibility, "a")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "a")
         render_blocks(visibility, "a")
       }
     )
@@ -1391,8 +1504,7 @@ test_that("a view switch does not re-evaluate shared upstream left needed", {
       # the shared upstream (src, mid) stays needed throughout. Only the newly
       # visible leaf evaluates -- the upstream slots never flip, so nothing
       # pulls the shared pipeline again.
-      vis$required[["t1"]](FALSE)
-      vis$required[["t2"]](TRUE)
+      board_update(list(sustain = claim(add = "t2", rm = "t1")))
       render_blocks(vis, "t2")
       session$flushReact()
 
@@ -1403,8 +1515,8 @@ test_that("a view switch does not re-evaluate shared upstream left needed", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visibility, ...) {
-        require_blocks(visibility, "t1")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "t1")
         render_blocks(visibility, "t1")
       }
     )
@@ -1441,10 +1553,10 @@ test_that("a variadic block skips re-evaluation on unchanged inputs", {
       # pull, but the element objects are the cached upstream results. Park the
       # block across separate flushes and bring it back: the by-reference skip
       # sees the same objects and nothing re-evaluates.
-      vis$required[["v"]](FALSE)
+      release_blocks(board_update, "v")
       session$flushReact()
 
-      vis$required[["v"]](TRUE)
+      require_blocks(board_update, "v")
       session$flushReact()
 
       expect_false(evaluated("a"))
@@ -1454,8 +1566,8 @@ test_that("a variadic block skips re-evaluation on unchanged inputs", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visibility, ...) {
-        require_blocks(visibility, "v")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "v")
         render_blocks(visibility, "v")
       }
     )
@@ -1490,8 +1602,8 @@ test_that("an off-screen data-observing block does not pull its upstream", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visibility, ...) {
-        require_blocks(visibility, "c")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "c")
         render_blocks(visibility, "c")
       }
     )
@@ -1536,8 +1648,8 @@ test_that("an unrelated structural edit does not re-evaluate needed blocks", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visibility, ...) {
-        require_blocks(visibility, "b")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "b")
         render_blocks(visibility, "b")
       }
     )
@@ -1580,8 +1692,8 @@ test_that("adding a block does not re-evaluate existing needed blocks", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visibility, ...) {
-        require_blocks(visibility, "b")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "b")
         render_blocks(visibility, "b")
       }
     )
@@ -1615,8 +1727,8 @@ test_that("a variadic block receives its inputs as values, not reactives", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visibility, ...) {
-        require_blocks(visibility, "c")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "c")
         render_blocks(visibility, "c")
       }
     )
@@ -1653,8 +1765,8 @@ test_that("an off-screen variadic block does not pull its inputs", {
     args = list(
       x = board,
       plugins = list(),
-      callbacks = function(visibility, ...) {
-        require_blocks(visibility, "e")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "e")
         render_blocks(visibility, "e")
       }
     )
@@ -1677,8 +1789,8 @@ ordered_board <- function() {
   )
 }
 
-visible_b <- function(visibility, ...) {
-  require_blocks(visibility, "b")
+visible_b <- function(visibility, update, ...) {
+  gate_blocks(visibility, update, "b")
   render_blocks(visibility, "b")
 }
 
@@ -1704,8 +1816,8 @@ test_that("the priority lane builds the needed set ahead of the backlog", {
     args = list(
       x = ordered_board(),
       plugins = list(),
-      callbacks = function(visibility, ...) {
-        require_blocks(visibility, "c")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "c")
         render_blocks(visibility, "c")
       }
     )
@@ -1727,7 +1839,7 @@ test_that("opening a view pulls its blocks ahead of a gated backlog", {
       expect_false(constructed("c"))
       expect_false(constructed("d"))
 
-      require_blocks(vis, "c")
+      require_blocks(board_update, "c")
       render_blocks(vis, "c")
       session$flushReact()
 
@@ -1737,7 +1849,9 @@ test_that("opening a view pulls its blocks ahead of a gated backlog", {
     args = list(
       x = ordered_board(),
       plugins = list(),
-      callbacks = function(visibility, ...) require_blocks(visibility, "b")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "b")
+      }
     )
   )
 })
@@ -1789,7 +1903,7 @@ test_that("an infinite background delay never fills in the background", {
       expect_false(constructed("c"))
       expect_false(constructed("d"))
 
-      require_blocks(vis, "c")
+      require_blocks(board_update, "c")
       render_blocks(vis, "c")
       session$flushReact()
 
@@ -1834,13 +1948,14 @@ test_that("is_visible is an isTRUE check on the slot value", {
   expect_false(is_visible(NA))
 })
 
-test_that("channel validators enforce the required and visible contracts", {
+test_that("channel validators enforce the gate and visible contracts", {
 
-  expect_true(valid_required(TRUE))
-  expect_true(valid_required(FALSE))
-  expect_true(valid_required(NA))
-  expect_false(valid_required("x"))
-  expect_false(valid_required(NA_character_))
+  expect_true(valid_gate(NULL))
+  expect_true(valid_gate("dock"))
+  expect_false(valid_gate(NA_character_))
+  expect_false(valid_gate(""))
+  expect_false(valid_gate(c("a", "b")))
+  expect_false(valid_gate(TRUE))
 
   expect_true(valid_visible(TRUE))
   expect_true(valid_visible(FALSE))
@@ -1854,71 +1969,64 @@ test_that("validate_vis hard-errors on an off-contract slot", {
 
   isolate({
     vis <- list(
-      required = new.env(parent = emptyenv()),
+      gate = reactiveVal(NULL),
       visible = new.env(parent = emptyenv())
     )
     add_vis_slots(vis, "a")
 
-    vis$required[["a"]](1L)
-    expect_error(validate_vis(vis), class = "invalid_required")
+    vis$gate(1L)
+    expect_error(validate_vis(vis), class = "invalid_gate")
 
-    vis$required[["a"]](TRUE)
+    vis$gate("dock")
     vis$visible[["a"]]("main")
     expect_error(validate_vis(vis), class = "invalid_visible")
   })
 })
 
-test_that("required_now returns the TRUE-required blocks", {
+test_that("gating activates on the declaration, not on a claim", {
 
   isolate({
-    req <- new.env(parent = emptyenv())
-    req$a <- reactiveVal(TRUE)
-    req$b <- reactiveVal(FALSE)
-    req$c <- reactiveVal(NA)
-    req$d <- reactiveVal(TRUE)
+    vis <- list(gate = reactiveVal(NULL))
 
-    expect_setequal(required_now(req), c("a", "d"))
-    expect_length(required_now(new.env(parent = emptyenv())), 0L)
+    expect_false(gating_active(vis))
+
+    vis$gate("dock")
+    expect_true(gating_active(vis))
+
+    withr::local_options(blockr.gate_visibility = FALSE)
+    expect_false(gating_active(vis))
   })
 })
 
-test_that("ever_required and has_required track declared (non-NA) slots", {
-
-  isolate({
-    req <- new.env(parent = emptyenv())
-    req$a <- reactiveVal(TRUE)
-    req$b <- reactiveVal(FALSE)
-    req$c <- reactiveVal(NA)
-
-    expect_setequal(ever_required(req), c("a", "b"))
-    expect_true(has_required(req))
-    expect_false(has_required(new.env(parent = emptyenv())))
-  })
-})
-
-test_that("required_fulfilled holds only when every required block is shown", {
+test_that("gate_fulfilled tracks the gating owner's claim alone", {
 
   isolate({
     vis <- list(
-      required = new.env(parent = emptyenv()),
+      gate = reactiveVal("dock"),
       visible = new.env(parent = emptyenv())
     )
-    add_vis_slots(vis, c("a", "b"))
-    vis$required[["a"]](TRUE)
-    vis$required[["b"]](TRUE)
+    add_vis_slots(vis, c("a", "b", "c"))
+
+    rv <- reactiveValues(
+      claims = reactiveVal(list(dock = c("a", "b"))),
+      gate_claimed = reactiveVal(TRUE)
+    )
     vis$visible[["a"]](TRUE)
     vis$visible[["b"]](TRUE)
 
-    expect_true(required_fulfilled(vis))
+    expect_true(gate_fulfilled(vis, rv))
 
     vis$visible[["b"]](FALSE)
-    expect_false(required_fulfilled(vis))
+    expect_false(gate_fulfilled(vis, rv))
 
-    empty <- list(
-      required = new.env(parent = emptyenv()),
-      visible = new.env(parent = emptyenv())
-    )
-    expect_true(required_fulfilled(empty))
+    # Another owner's claim on an off-screen block never lands on screen, so
+    # holding the backlog for it would stall it for good.
+    vis$visible[["b"]](TRUE)
+    rv$claims(list(dock = c("a", "b"), consumer = "c"))
+    expect_true(gate_fulfilled(vis, rv))
+
+    rv$claims(list())
+    expect_true(gate_fulfilled(vis, rv))
   })
 })
 
@@ -1948,7 +2056,9 @@ test_that("the background waits for the front-end's rendered report", {
     args = list(
       x = ordered_board(),
       plugins = list(),
-      callbacks = function(visibility, ...) require_blocks(visibility, "b")
+      callbacks = function(visibility, update, ...) {
+        gate_blocks(visibility, update, "b")
+      }
     )
   )
 })


### PR DESCRIPTION
## Summary

Evaluation demand was expressed two ways depending on who asked: a front-end wrote the per-block `visibility$required` tri-state, while everyone else went through the `sustain` / `evaluate` / `construct` payload components. This retires the front-end's channel — it now claims under an owner label like any other consumer, so core no longer distinguishes its demand from a code export's and the demand axis cannot silently become multi-writer the way `required` did (the defect behind #320).

The tri-state was doing three jobs. Only evaluation demand folds into the claim set; the other two are separated rather than absorbed:

- **Gating activation** becomes an explicit declaration — a front-end writes its owner label into the new board-wide `visibility$gate` channel. Inferring it from claims instead would mean a consumer asking about one block flips an ungated board into gated mode and parks every other block, which `test-visibility-gating.R` now pins.
- **Construction demand** is the `construct` component from #333.
- **Paint acknowledgement** on `visible` is untouched, so the demand-versus-paint comparison that keeps background construction from competing with first paint stays meaningful. It is now scoped to the gating owner's own claim, since a claim held by anyone else names blocks nobody is putting on screen and would stall the backlog for the session.

The gate declaration is written synchronously as the callback is set up rather than travelling in a payload, and that is forced rather than chosen: a payload applies at `priority = -Inf`, after the first flush has already decided what to construct. Measured on this branch with demand arriving only by payload, flush 1 built every block on the board and left the needed set at `TRUE`. Demand itself has no such constraint, which is why it rides `sustain`.

One consequence worth flagging: a front-end that has declared the gate but whose opening claim is still in flight is indistinguishable from one that claims nothing, so the background pass now waits for that first claim to land (`rv$gate_claimed`). Production previously satisfied this only by accident of the pacing delay; making it explicit is what keeps the priority lane ordered when the claim arrives by payload.

## Migration

| Before | After |
| --- | --- |
| `visibility$required[[id]](TRUE)` | `update(list(sustain = list(<owner> = list(add = id))))` |
| `visibility$required[[id]](FALSE)` | `update(list(sustain = list(<owner> = list(rm = id))))`, plus `update(list(construct = id))` to keep it built |
| `visibility$required[[id]]` non-`NA` activates gating | `visibility$gate("<owner>")`, once, as the callback is set up |
| `visibility$visible[[id]](…)`, `visibility$frozen[[id]](…)` | unchanged |

Breaking for blockr.dock, which drives `required` in `mark_cards_built()` and `show_cards()`; blockr.dock#417 tracks the adoption. The two neighbouring unreleased 0.1.4 NEWS entries (#333, #320) described the change in terms of the `required` channel and were corrected in place.

Fixes #321

