### PR TITLE
Declare roxy.shinylive as a roxygenize-time dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,6 +64,7 @@ Suggests:
     tibble,
     DT
 Config/testthat/edition: 3
+Config/Needs/roxygenize: roxy.shinylive
 VignetteBuilder: quarto
 Collate:
     'arg-spec.R'


### PR DESCRIPTION
## Summary

Prerequisite for BristolMyersSquibb/blockr.ci#48, which switches the shared `lint` and `docs` jobs to resolve hard dependencies only.

The `roxy.shinylive` package sits in `Suggests` here, but `Roxygen: list(markdown = TRUE, packages = c("roxy.shinylive"), ...)` requires it, so the `docs` job would exit 1 with `there is no package called 'roxy.shinylive'` the moment Suggests stops being resolved. Declaring it in `Config/Needs/roxygenize` keeps that job supplied — the job already forwards the field to `setup-r-dependencies` as `needs: roxygenize`.

The field is inert until the blockr.ci change lands, since `Suggests` still covers it today, so this can merge on its own schedule.

Verified against a hard-dependencies-only library: `pak::pkg_deps(dependencies = c("Config/Needs/roxygenize", "hard"))` resolves `roxy.shinylive` while still leaving out `chromote`, `shinytest2` and `testthat`, and `roxygen2::roxygenise()` at the pinned 8.0.0 then exits 0 leaving `man/` and `NAMESPACE` byte-identical.

Refs BristolMyersSquibb/blockr.ci#47
